### PR TITLE
Enable control-click navigation for `Tabs`

### DIFF
--- a/app/src/components/Tabs/Tabs.jsx
+++ b/app/src/components/Tabs/Tabs.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { Link } from 'react-router-dom';
 import './Tabs.scss';
 
 function Tabs({ tabs, selectedIndex, align, urlSelector, specialHighlightIndex }) {
@@ -19,10 +20,10 @@ function Tabs({ tabs, selectedIndex, align, urlSelector, specialHighlightIndex }
         const url = urlSelector && urlSelector(i);
 
         return (
-          <a key={tab} href={url} className={tabClass}>
+          <Link key={tab} to={url} className={tabClass}>
             {tab}
             {i === specialHighlightIndex && <div className="new-dot" />}
-          </a>
+          </Link>
         );
       })}
     </div>

--- a/app/src/components/Tabs/Tabs.jsx
+++ b/app/src/components/Tabs/Tabs.jsx
@@ -1,21 +1,9 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import './Tabs.scss';
 
-function Tabs({ tabs, selectedIndex, onChange, align, specialHighlightIndex }) {
-  const handleSelection = e => {
-    const index = parseInt(e.target.dataset.index, 10);
-
-    if (index === selectedIndex) {
-      return;
-    }
-
-    onChange(index);
-  };
-
-  const onSelect = useCallback(handleSelection, [selectedIndex, onChange]);
-
+function Tabs({ tabs, selectedIndex, align, urlSelector, specialHighlightIndex }) {
   const barClass = classNames({
     'tab-bar': true,
     '-align-left': align === 'left',
@@ -28,12 +16,13 @@ function Tabs({ tabs, selectedIndex, onChange, align, specialHighlightIndex }) {
     <div className={barClass}>
       {tabs.map((tab, i) => {
         const tabClass = classNames({ tab: true, '-highlighted': selectedIndex === i });
+        const url = urlSelector && urlSelector(i);
 
         return (
-          <button key={tab} data-index={i} className={tabClass} type="button" onClick={onSelect}>
+          <a key={tab} href={url} className={tabClass}>
             {tab}
             {i === specialHighlightIndex && <div className="new-dot" />}
-          </button>
+          </a>
         );
       })}
     </div>
@@ -51,8 +40,7 @@ Tabs.propTypes = {
 
   selectedIndex: PropTypes.number.isRequired,
 
-  // Event: fired on tab selected
-  onChange: PropTypes.func.isRequired,
+  urlSelector: PropTypes.func.isRequired,
 
   // The alignment of the tabs (optional), must be one of (right, left, center, space-between)
   align: PropTypes.string,

--- a/app/src/components/Tabs/Tabs.scss
+++ b/app/src/components/Tabs/Tabs.scss
@@ -36,6 +36,8 @@
     min-width: 50px;
     display: flex;
     flex-direction: row;
+    font-size: 0.833em;
+    text-align: center;
 
     &:hover {
       opacity: 0.7;

--- a/app/src/pages/Competition/Competition.jsx
+++ b/app/src/pages/Competition/Competition.jsx
@@ -84,12 +84,12 @@ function Competition() {
     setButtonDisabled(true);
   };
 
-  const handleTabChanged = i => {
+  const getSelectedTabUrl = i => {
     if (i === 1) {
-      router.push(`/competitions/${id}/chart`);
-    } else {
-      router.push(`/competitions/${id}`);
+      return `/competitions/${id}/chart`;
     }
+
+    return `/competitions/${id}`;
   };
 
   const handleDeleteModalClosed = () => {
@@ -106,7 +106,6 @@ function Competition() {
   };
 
   // Memoized callbacks
-  const onTabChanged = useCallback(handleTabChanged, [id, section]);
   const onUpdatePlayer = useCallback(handleUpdatePlayer, [id, dispatch]);
   const onUpdateAllClicked = useCallback(handleUpdateAll, [id, dispatch]);
   const onOptionSelected = useCallback(handleOptionSelected, [router, competition]);
@@ -161,7 +160,7 @@ function Competition() {
           <CompetitionInfo competition={competition} />
         </div>
         <div className="col-md-8">
-          <Tabs tabs={TABS} selectedIndex={selectedSectionIndex} onChange={onTabChanged} />
+          <Tabs tabs={TABS} selectedIndex={selectedSectionIndex} urlSelector={getSelectedTabUrl} />
           {selectedSectionIndex === 0 ? (
             <CompetitionTable
               competition={competition}

--- a/app/src/pages/Group/Group.jsx
+++ b/app/src/pages/Group/Group.jsx
@@ -90,12 +90,12 @@ function Group() {
     }
   };
 
-  const handleTabChanged = i => {
+  const getSelectedTabUrl = i => {
     if (i === 1) {
-      router.push(`/groups/${id}/competitions`);
-    } else {
-      router.push(`/groups/${id}`);
+      return `/groups/${id}/competitions`;
     }
+
+    return `/groups/${id}`;
   };
 
   const handleUpdateAll = () => {
@@ -103,7 +103,6 @@ function Group() {
     setButtonDisabled(true);
   };
 
-  const onTabChanged = useCallback(handleTabChanged, [id]);
   const onOptionSelected = useCallback(handleOptionSelected, [router, group]);
   const onDeleteModalClosed = useCallback(handleDeleteModalClosed, []);
   const onUpdateAllClicked = useCallback(handleUpdateAll, [id, dispatch]);
@@ -154,7 +153,7 @@ function Group() {
           <GroupInfo group={group} />
         </div>
         <div className="col-md-8">
-          <Tabs tabs={TABS} selectedIndex={selectedSectionIndex} onChange={onTabChanged} />
+          <Tabs tabs={TABS} selectedIndex={selectedSectionIndex} urlSelector={getSelectedTabUrl} />
           {selectedSectionIndex === 0 ? (
             <MembersTable members={group.members} isLoading={isLoadingMembers} />
           ) : (

--- a/app/src/pages/Player/Player.jsx
+++ b/app/src/pages/Player/Player.jsx
@@ -203,10 +203,6 @@ function Player() {
     return `/players/${newOptions.id}/${newOptions.section}/${newOptions.metricType}${query}`;
   };
 
-  const handleTabChanged = i => {
-    router.push(getNextUrl({ section: TABS[i].toLowerCase() }));
-  };
-
   const handlePeriodSelected = e => {
     router.push(getNextUrl({ period: e.value }));
   };
@@ -280,7 +276,7 @@ function Player() {
           <Tabs
             tabs={TABS}
             selectedIndex={selectedTabIndex}
-            onChange={handleTabChanged}
+            urlSelector={i => getNextUrl({ section: TABS[i].toLowerCase() })}
             align="space-between"
             specialHighlightIndex={5}
           />


### PR DESCRIPTION
Enable control-click for the `Tabs` component by replacing the button with a `Link` component.
This is for the pages for a given player, competition and group.