### PR TITLE
Bossing kc display

### DIFF
--- a/app/src/components/TextLabel/TextLabel.jsx
+++ b/app/src/components/TextLabel/TextLabel.jsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import './TextLabel.scss';
+
+
+function TextLabel({ value, popupValue }) {
+  const [isPopupVisible, setIsPopupVisible] = useState(false);
+
+  const popupText = popupValue || value;
+  
+  const togglePopup = e => {
+    e.stopPropagation();
+    setIsPopupVisible(!isPopupVisible);
+  };
+
+  const hidePopup = () => setIsPopupVisible(false);
+
+  return (
+    <button className="text-label-btn" type="button" onClick={togglePopup} onBlur={hidePopup}>
+      {isPopupVisible && <div className="text-label-popup">{popupText}</div>}
+      <abbr className="text-label" title={popupText}>
+        <span>{value}</span>
+      </abbr>
+    </button>
+  );
+}
+
+TextLabel.defaultProps = {
+  popupValue: undefined
+};
+
+TextLabel.propTypes = {
+  value: PropTypes.string.isRequired,
+  popupValue: PropTypes.string
+};
+
+export default TextLabel;

--- a/app/src/components/TextLabel/TextLabel.jsx
+++ b/app/src/components/TextLabel/TextLabel.jsx
@@ -2,12 +2,11 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import './TextLabel.scss';
 
-
 function TextLabel({ value, popupValue }) {
   const [isPopupVisible, setIsPopupVisible] = useState(false);
 
   const popupText = popupValue || value;
-  
+
   const togglePopup = e => {
     e.stopPropagation();
     setIsPopupVisible(!isPopupVisible);
@@ -34,4 +33,4 @@ TextLabel.propTypes = {
   popupValue: PropTypes.string
 };
 
-export default TextLabel;
+export default React.memo(TextLabel);

--- a/app/src/components/TextLabel/TextLabel.scss
+++ b/app/src/components/TextLabel/TextLabel.scss
@@ -1,0 +1,27 @@
+@import '../../variables.scss';
+@import '../../styles.scss';
+
+.text-label-btn {
+  position: relative;
+  background: transparent;
+  padding: 0;
+  border: none;
+
+  .text-label-popup {
+    @extend %panel;
+    background: $gray-12;
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    padding: 10px;
+    margin-bottom: 5px;
+    color: white;
+  }
+
+  .text-label {
+    text-decoration: none;
+    color: $gray-60;
+    cursor: default;
+  }
+}

--- a/app/src/components/TextLabel/index.js
+++ b/app/src/components/TextLabel/index.js
@@ -1,0 +1,3 @@
+import TextLabel from './TextLabel';
+
+export default TextLabel;

--- a/app/src/pages/Player/components/PlayerStatsTable/PlayerStatsTable.jsx
+++ b/app/src/pages/Player/components/PlayerStatsTable/PlayerStatsTable.jsx
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types';
 import Table from '../../../../components/Table';
 import TableListPlaceholder from '../../../../components/TableListPlaceholder';
 import NumberLabel from '../../../../components/NumberLabel';
-import { getMetricIcon, getLevel, getMetricName } from '../../../../utils';
+import TextLabel from '../../../../components/TextLabel';
+import { getMetricIcon, getLevel, getMetricName, getMinimumBossKc } from '../../../../utils';
 import { SKILLS, BOSSES, ACTIVITIES } from '../../../../config';
 
 function renderSkillsTable(snapshot, showVirtualLevels) {
@@ -77,12 +78,27 @@ function renderBossesTable(snapshot) {
     },
     {
       key: 'kills',
-      transform: val => <NumberLabel value={val} />
+      transform: (val, row) => {
+        if (val === -1) {
+          return (
+            <TextLabel
+              value={`< ${getMinimumBossKc(row.metric)}`}
+              popupValue={`The Hiscores only start tracking ${getMetricName(row.metric)} kills after ${getMinimumBossKc(row.metric)} kc`}
+            />
+          );
+        }
+        return <NumberLabel value={val} />;
+      }
     },
     {
       key: 'rank',
       className: () => '-break-small',
-      transform: val => <NumberLabel value={val} />
+      transform: val => {
+        if (val === -1) {
+          return <TextLabel value="---" popupValue="Unranked" />;
+        }
+        return <NumberLabel value={val} />;
+      }
     },
     {
       key: 'EHB',

--- a/app/src/pages/Player/components/PlayerStatsTable/PlayerStatsTable.jsx
+++ b/app/src/pages/Player/components/PlayerStatsTable/PlayerStatsTable.jsx
@@ -79,25 +79,28 @@ function renderBossesTable(snapshot) {
     {
       key: 'kills',
       transform: (val, row) => {
-        if (val === -1) {
-          return (
-            <TextLabel
-              value={`< ${getMinimumBossKc(row.metric)}`}
-              popupValue={`The Hiscores only start tracking ${getMetricName(row.metric)} kills after ${getMinimumBossKc(row.metric)} kc`}
-            />
-          );
-        }
-        return <NumberLabel value={val} />;
+        const minKc = getMinimumBossKc(row.metric);
+        const metricName = getMetricName(row.metric);
+
+        return val === -1 ? (
+          <TextLabel
+            value={`< ${minKc}`}
+            popupValue={`The Hiscores only start tracking ${metricName} kills after ${minKc} kc`}
+          />
+        ) : (
+          <NumberLabel value={val} />
+        );
       }
     },
     {
       key: 'rank',
       className: () => '-break-small',
       transform: val => {
-        if (val === -1) {
-          return <TextLabel value="---" popupValue="Unranked" />;
-        }
-        return <NumberLabel value={val} />;
+        return val === -1 ? (
+          <TextLabel value="---" popupValue="Unranked" />
+        ) : (
+          <NumberLabel value={val} />
+        );
       }
     },
     {

--- a/app/src/utils/metrics.js
+++ b/app/src/utils/metrics.js
@@ -29,6 +29,24 @@ export function isBoss(value) {
   return BOSSES.includes(value);
 }
 
+export function getMinimumBossKc(value) {
+  switch (value) {
+    case 'mimic':
+    case 'tzkal_zuk':
+      return 2;
+    case 'bryophyta':
+    case 'chambers_of_xeric_challenge_mode':
+    case 'hespori':
+    case 'obor':
+    case 'skotizo':
+    case 'the_corrupted_gauntlet':
+    case 'tztok_jad':
+      return 10;
+    default:
+      return 50;
+  }
+}
+
 export function getMeasure(value) {
   if (isSkill(value)) {
     return 'experience';


### PR DESCRIPTION
Resolves #171 

- "-1" values for kills now display as "< N" where N is represented by the boss-specific minimum kc that Hiscores will track
- The popup text for the -1 kill value is now a supplementary message describing why it is being displayed as "< N" (ex. "Bryophyta killcounts less than 10 are not tracked by Hiscores")
- "-1" values for ranks now display as "---"
- The popup text for "-1" rank values now displays as "Unranked"


![5etHe7D](https://user-images.githubusercontent.com/10636720/83469512-e9319800-a44d-11ea-916b-1b073976840a.png)

Values are still sort-able by default table sorting rules. Although it might be good in the future to alter the rank sorting to place "---" values after the others.
