### PR TITLE
Fix new players blank page

### DIFF
--- a/app/src/redux/selectors/achievements.js
+++ b/app/src/redux/selectors/achievements.js
@@ -51,7 +51,7 @@ export const getPlayerAchievementsGrouped = (state, playerId) => {
 };
 
 function processGroup(player, group) {
-  if (!player) {
+  if (!player || !player.latestSnapshot) {
     return group;
   }
 


### PR DESCRIPTION
New players (with no snapshots) had blank page because of a missing null check on the achievements selector.