### PR TITLE
Temporarily set rankings cronjob to every minute

### DIFF
--- a/server/src/api/jobs/crons.js
+++ b/server/src/api/jobs/crons.js
@@ -1,6 +1,6 @@
 module.exports = [
   {
     jobName: 'RefreshRankings',
-    cronConfig: '0 */6 * * *' // every 6 hours
+    cronConfig: '* * * * *' // every 6 hours
   }
 ];


### PR DESCRIPTION
Right now it's at 6h, and I don't want to wait 6h to have the initial score values populated.