### PR TITLE
EOL fix for docker-compose on Windows machines

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.js text eol=lf
+*.sh text eol=lf


### PR DESCRIPTION
Forces LF endings in .sh files