### PR TITLE
Snapshot saveAll bugfix

### DIFF
--- a/server/src/api/modules/players/player.service.js
+++ b/server/src/api/modules/players/player.service.js
@@ -224,13 +224,11 @@ async function importCML(username) {
   const importedSnapshots = [];
 
   // If the player hasn't imported in over a year
-  // import the last week, year and decade.
+  // import the last year and decade.
   if (seconds >= YEAR_IN_SECONDS) {
-    const weekSnapshots = await importCMLSince(player.id, player.username, WEEK_IN_SECONDS);
     const yearSnapshots = await importCMLSince(player.id, player.username, YEAR_IN_SECONDS);
     const decadeSnapshots = await importCMLSince(player.id, player.username, DECADE_IN_SECONDS);
 
-    importedSnapshots.push(...weekSnapshots);
     importedSnapshots.push(...yearSnapshots);
     importedSnapshots.push(...decadeSnapshots);
   } else {

--- a/server/src/api/modules/snapshots/snapshot.service.js
+++ b/server/src/api/modules/snapshots/snapshot.service.js
@@ -217,6 +217,10 @@ function average(snapshots) {
  * are from a single player.
  */
 async function saveAll(snapshots) {
+  if (snapshots.length === 0) {
+    return [];
+  }
+
   const { playerId } = snapshots[0];
 
   const existingSnapshots = await Snapshot.findAll({ where: { playerId } });


### PR DESCRIPTION
Adds an early return to the saveAll function in snapshotService to avoid issues with an empty snapshot array

Also removes the "previous week" import statement as it would be filtered out later in the project