### PR TITLE
Fix re-evaluated achievements with null metrics

### DIFF
--- a/server/src/api/modules/achievements/achievement.service.js
+++ b/server/src/api/modules/achievements/achievement.service.js
@@ -245,7 +245,7 @@ async function reevaluateAchievements(playerId) {
   // Attach dates to as many unknown achievements as possible
   const datedUnknownAchievements = await addPastDates(
     playerId,
-    unknown.map(u => ({ type: u.type, createdAt: u.createdAt }))
+    unknown.map(u => u.toJSON())
   );
 
   // Include only achievements with a valid (not unknown) date


### PR DESCRIPTION
Some achievements are first stored with "unknown" dates. The later on when the player's history is imported from CML, a job goes through all those unknown dates and tries to find the achievement date by searching the CML history.

In doing so, any "re-evaluated" achievements were overriding the metric and threshold fields with null.