### PR TITLE
Enable control-click navigation for `Dropdown`

### DIFF
--- a/app/src/components/Dropdown/Dropdown.jsx
+++ b/app/src/components/Dropdown/Dropdown.jsx
@@ -20,10 +20,10 @@ function Dropdown({ options, align, onSelect, children }) {
             return (
               <MenuItem
                 key={option.label}
-                className="dropdown-list__item"
-                onClick={() => onSelect(option)}
+                className={classNames({ 'dropdown-list__item': true, 'dropdown-url': option.url })}
+                onClick={!option.url ? () => onSelect(option) : undefined}
               >
-                {option.label}
+                {option.url ? <a href={option.url}>{option.label}</a> : option.label}
               </MenuItem>
             );
           })}

--- a/app/src/components/Dropdown/Dropdown.scss
+++ b/app/src/components/Dropdown/Dropdown.scss
@@ -60,5 +60,14 @@
         outline: none;
       }
     }
+
+    .dropdown-url {
+      padding: 0;
+
+      a {
+        display: block;
+        padding: 10px;
+      }
+    }
   }
 }

--- a/app/src/pages/Player/Player.jsx
+++ b/app/src/pages/Player/Player.jsx
@@ -150,6 +150,15 @@ function Player() {
   const levelTypeIndex = LEVEL_TYPE_OPTIONS.findIndex(o => o.value === selectedLevelType);
   const deltasPeriodIndex = PERIOD_OPTIONS.findIndex(o => o.value === selectedPeriod);
 
+  useEffect(() => {
+    // Set the player's HiScores URL
+    if (player) {
+      MENU_OPTIONS.find(option => option.value === 'openOsrsHiscores').url = getOfficialHiscoresUrl(
+        player
+      );
+    }
+  }, [player]);
+
   const experienceChartData = useSelector(state =>
     getChartData(state, id, selectedPeriod, selectedMetric, getMeasure(selectedMetric), isReducedChart)
   );
@@ -228,8 +237,6 @@ function Player() {
       await dispatch(assertPlayerTypeAction(player.username, player.id));
     } else if (option.value === 'assertName') {
       await dispatch(assertPlayerNameAction(player.username, player.id));
-    } else if (option.value === 'openOsrsHiscores') {
-      window.location = getOfficialHiscoresUrl(player);
     }
   };
 


### PR DESCRIPTION
Enable control-click navigation for the `Dropdown` component. It makes it possible to open a players HiScores page in a new tab.