### PR TITLE
Fix case sensitive selector search

### DIFF
--- a/app/src/components/Selector/Selector.jsx
+++ b/app/src/components/Selector/Selector.jsx
@@ -84,7 +84,10 @@ function Selector({ options, selectedIndex, onSelect, disabled, search }) {
                 <button
                   key={o.value}
                   type="button"
-                  className={itemClass(i === selectedIndex, o.label.toLowerCase().includes(searchText))}
+                  className={itemClass(
+                    i === selectedIndex,
+                    o.label.toLowerCase().includes(searchText.toLowerCase())
+                  )}
                   onMouseDown={() => onSelection(o)}
                 >
                   {o.icon && <img className="selector-item__icon" src={o.icon} alt="" />}


### PR DESCRIPTION
Fixes #228 

Example:
![image](https://user-images.githubusercontent.com/14054353/84806138-858a9b80-b005-11ea-907f-b9eb145a2962.png)
