### PR TITLE
Add /username endpoints to players API

### DIFF
--- a/server/src/api/modules/players/player.route.js
+++ b/server/src/api/modules/players/player.route.js
@@ -10,13 +10,19 @@ api.post('/assert-type', controller.assertType);
 api.post('/assert-name', controller.assertName);
 
 api.get('/username/:username', controller.details);
+api.get('/username/:username/groups', controller.groups);
+api.get('/username/:username/gained', controller.gained);
+api.get('/username/:username/records', controller.records);
+api.get('/username/:username/snapshots', controller.snapshots);
+api.get('/username/:username/achievements', controller.achievements);
+api.get('/username/:username/competitions', controller.competitions);
 
 api.get('/:id', controller.details);
-api.get('/:id/achievements', controller.achievements);
 api.get('/:id/groups', controller.groups);
-api.get('/:id/competitions', controller.competitions);
 api.get('/:id/gained', controller.gained);
 api.get('/:id/records', controller.records);
 api.get('/:id/snapshots', controller.snapshots);
+api.get('/:id/achievements', controller.achievements);
+api.get('/:id/competitions', controller.competitions);
 
 module.exports = api;

--- a/server/src/api/modules/players/player.service.js
+++ b/server/src/api/modules/players/player.service.js
@@ -503,6 +503,7 @@ exports.sanitize = sanitize;
 exports.isValidUsername = isValidUsername;
 exports.findAllOrCreate = findAllOrCreate;
 exports.findAll = findAll;
+exports.find = find;
 
 // Handlers
 exports.getDetailsById = getDetailsById;


### PR DESCRIPTION
Adds the ability to fetch player data (achievements, gained, records, groups, etc) **by username.**

### New endpoints:

- `/username/:username/groups`
- `/username/:username/gained`
- `/username/:username/records`
- `/username/:username/snapshots`
- `/username/:username/achievements`
- `/username/:username/competitions`
