### PR TITLE
[Re-push] Add Discord Bot events

### DIFF
--- a/.github/contributing/server-guide.md
+++ b/.github/contributing/server-guide.md
@@ -77,7 +77,6 @@ DB_DIALECT=postgres
 
 POSTGRES_PASSWORD=postgres
 POSTGRES_USER=postgres
-POSTGRES_DB=wise-old-man
 
 REDIS_HOST=localhost
 REDIS_PORT=6379

--- a/server/.env.example
+++ b/server/.env.example
@@ -2,7 +2,6 @@ DB_DIALECT=postgres
 
 POSTGRES_PASSWORD=postgres
 POSTGRES_USER=postgres
-POSTGRES_DB=wise-old-man
 
 REDIS_HOST=localhost
 REDIS_PORT=6379

--- a/server/src/api/constants/services.json
+++ b/server/src/api/constants/services.json
@@ -10,6 +10,6 @@
     "HISTORY": "https://crystalmathlabs.com/tracker/api.php?type=datapoints"
   },
   "DISCORD_BOT": {
-    "API": "https://discord-bot.wiseoldman.net"
+    "API": "https://discord-bot.wiseoldman.net/event"
   }
 }

--- a/server/src/api/constants/services.json
+++ b/server/src/api/constants/services.json
@@ -8,5 +8,8 @@
   },
   "CML": {
     "HISTORY": "https://crystalmathlabs.com/tracker/api.php?type=datapoints"
+  },
+  "DISCORD_BOT": {
+    "API": "https://discord-bot.wiseoldman.net"
   }
 }

--- a/server/src/api/events/index.js
+++ b/server/src/api/events/index.js
@@ -2,8 +2,19 @@ const GroupMemberJoined = require('./instances/GroupMemberJoined');
 const GroupMemberLeft = require('./instances/GroupMemberLeft');
 const GroupMemberAchievement = require('./instances/GroupMemberAchievement');
 const GroupCompetitionCreated = require('./instances/GroupCompetitionCreated');
+const GroupCompetitionStarting = require('./instances/GroupCompetitionStarting');
+const GroupCompetitionStarted = require('./instances/GroupCompetitionStarted');
+const GroupCompetitionEnded = require('./instances/GroupCompetitionEnded');
 
-const events = [GroupMemberJoined, GroupMemberLeft, GroupMemberAchievement, GroupCompetitionCreated];
+const events = [
+  GroupMemberJoined,
+  GroupMemberLeft,
+  GroupMemberAchievement,
+  GroupCompetitionCreated,
+  GroupCompetitionStarting,
+  GroupCompetitionStarted,
+  GroupCompetitionEnded
+];
 
 function dispatch(key, payload) {
   const event = events.find(e => e.key === key);

--- a/server/src/api/events/index.js
+++ b/server/src/api/events/index.js
@@ -1,0 +1,16 @@
+const GroupMemberJoined = require('./instances/GroupMemberJoined');
+const GroupMemberLeft = require('./instances/GroupMemberLeft');
+const GroupMemberAchievement = require('./instances/GroupMemberAchievement');
+const GroupCompetitionCreated = require('./instances/GroupCompetitionCreated');
+
+const events = [GroupMemberJoined, GroupMemberLeft, GroupMemberAchievement, GroupCompetitionCreated];
+
+function dispatch(key, payload) {
+  const event = events.find(e => e.key === key);
+
+  if (event) {
+    event.onDispatch(payload);
+  }
+}
+
+exports.dispatch = dispatch;

--- a/server/src/api/events/instances/GroupCompetitionCreated.js
+++ b/server/src/api/events/instances/GroupCompetitionCreated.js
@@ -1,9 +1,14 @@
+const axios = require('axios');
+const services = require('../../constants/services.json');
+
 module.exports = {
   key: 'GroupCompetitionCreated',
   onDispatch({ competition }) {
-    return {
+    const body = {
       type: 'COMPETITION_CREATED',
       data: { groupId: competition.groupId, competition }
     };
+
+    axios.post(services.DISCORD_BOT.API, body);
   }
 };

--- a/server/src/api/events/instances/GroupCompetitionCreated.js
+++ b/server/src/api/events/instances/GroupCompetitionCreated.js
@@ -1,0 +1,9 @@
+module.exports = {
+  key: 'GroupCompetitionCreated',
+  onDispatch({ competition }) {
+    return {
+      type: 'COMPETITION_CREATED',
+      data: { groupId: competition.groupId, competition }
+    };
+  }
+};

--- a/server/src/api/events/instances/GroupCompetitionCreated.js
+++ b/server/src/api/events/instances/GroupCompetitionCreated.js
@@ -6,7 +6,8 @@ module.exports = {
   onDispatch({ competition }) {
     const body = {
       type: 'COMPETITION_CREATED',
-      data: { groupId: competition.groupId, competition }
+      data: { groupId: competition.groupId, competition },
+      api_token: process.env.API_TOKEN
     };
 
     axios.post(services.DISCORD_BOT.API, body);

--- a/server/src/api/events/instances/GroupCompetitionEnded.js
+++ b/server/src/api/events/instances/GroupCompetitionEnded.js
@@ -1,3 +1,6 @@
+const axios = require('axios');
+const services = require('../../constants/services.json');
+
 module.exports = {
   key: 'GroupCompetitionEnded',
   onDispatch({ competition }) {
@@ -7,9 +10,11 @@ module.exports = {
       return { displayName, gained: progress.gained };
     });
 
-    return {
+    const body = {
       type: 'COMPETITION_ENDED',
       data: { groupId, competition, standings }
     };
+
+    axios.post(services.DISCORD_BOT.API, body);
   }
 };

--- a/server/src/api/events/instances/GroupCompetitionEnded.js
+++ b/server/src/api/events/instances/GroupCompetitionEnded.js
@@ -1,0 +1,15 @@
+module.exports = {
+  key: 'GroupCompetitionEnded',
+  onDispatch({ competition }) {
+    const { groupId, participants } = competition;
+
+    const standings = participants.map(({ displayName, progress }) => {
+      return { displayName, gained: progress.gained };
+    });
+
+    return {
+      type: 'COMPETITION_ENDED',
+      data: { groupId, competition, standings }
+    };
+  }
+};

--- a/server/src/api/events/instances/GroupCompetitionEnded.js
+++ b/server/src/api/events/instances/GroupCompetitionEnded.js
@@ -12,7 +12,8 @@ module.exports = {
 
     const body = {
       type: 'COMPETITION_ENDED',
-      data: { groupId, competition, standings }
+      data: { groupId, competition, standings },
+      api_token: process.env.API_TOKEN
     };
 
     axios.post(services.DISCORD_BOT.API, body);

--- a/server/src/api/events/instances/GroupCompetitionEnding.js
+++ b/server/src/api/events/instances/GroupCompetitionEnding.js
@@ -1,0 +1,9 @@
+module.exports = {
+  key: 'GroupCompetitionEnding',
+  onDispatch({ competition, period }) {
+    return {
+      type: 'COMPETITION_ENDING',
+      data: { groupId: competition.groupId, competition, period }
+    };
+  }
+};

--- a/server/src/api/events/instances/GroupCompetitionEnding.js
+++ b/server/src/api/events/instances/GroupCompetitionEnding.js
@@ -1,9 +1,14 @@
+const axios = require('axios');
+const services = require('../../constants/services.json');
+
 module.exports = {
   key: 'GroupCompetitionEnding',
   onDispatch({ competition, period }) {
-    return {
+    const body = {
       type: 'COMPETITION_ENDING',
       data: { groupId: competition.groupId, competition, period }
     };
+
+    axios.post(services.DISCORD_BOT.API, body);
   }
 };

--- a/server/src/api/events/instances/GroupCompetitionEnding.js
+++ b/server/src/api/events/instances/GroupCompetitionEnding.js
@@ -6,7 +6,8 @@ module.exports = {
   onDispatch({ competition, period }) {
     const body = {
       type: 'COMPETITION_ENDING',
-      data: { groupId: competition.groupId, competition, period }
+      data: { groupId: competition.groupId, competition, period },
+      api_token: process.env.API_TOKEN
     };
 
     axios.post(services.DISCORD_BOT.API, body);

--- a/server/src/api/events/instances/GroupCompetitionStarted.js
+++ b/server/src/api/events/instances/GroupCompetitionStarted.js
@@ -6,7 +6,8 @@ module.exports = {
   onDispatch({ competition }) {
     const body = {
       type: 'COMPETITION_STARTED',
-      data: { groupId: competition.groupId, competition }
+      data: { groupId: competition.groupId, competition },
+      api_token: process.env.API_TOKEN
     };
 
     axios.post(services.DISCORD_BOT.API, body);

--- a/server/src/api/events/instances/GroupCompetitionStarted.js
+++ b/server/src/api/events/instances/GroupCompetitionStarted.js
@@ -1,0 +1,9 @@
+module.exports = {
+  key: 'GroupCompetitionStarted',
+  onDispatch({ competition }) {
+    return {
+      type: 'COMPETITION_STARTED',
+      data: { groupId: competition.groupId, competition }
+    };
+  }
+};

--- a/server/src/api/events/instances/GroupCompetitionStarted.js
+++ b/server/src/api/events/instances/GroupCompetitionStarted.js
@@ -1,9 +1,14 @@
+const axios = require('axios');
+const services = require('../../constants/services.json');
+
 module.exports = {
   key: 'GroupCompetitionStarted',
   onDispatch({ competition }) {
-    return {
+    const body = {
       type: 'COMPETITION_STARTED',
       data: { groupId: competition.groupId, competition }
     };
+
+    axios.post(services.DISCORD_BOT.API, body);
   }
 };

--- a/server/src/api/events/instances/GroupCompetitionStarting.js
+++ b/server/src/api/events/instances/GroupCompetitionStarting.js
@@ -1,0 +1,9 @@
+module.exports = {
+  key: 'GroupCompetitionStarting',
+  onDispatch({ competition, period }) {
+    return {
+      type: 'COMPETITION_STARTING',
+      data: { groupId: competition.groupId, competition, period }
+    };
+  }
+};

--- a/server/src/api/events/instances/GroupCompetitionStarting.js
+++ b/server/src/api/events/instances/GroupCompetitionStarting.js
@@ -1,9 +1,14 @@
+const axios = require('axios');
+const services = require('../../constants/services.json');
+
 module.exports = {
   key: 'GroupCompetitionStarting',
   onDispatch({ competition, period }) {
-    return {
+    const body = {
       type: 'COMPETITION_STARTING',
       data: { groupId: competition.groupId, competition, period }
     };
+
+    axios.post(services.DISCORD_BOT.API, body);
   }
 };

--- a/server/src/api/events/instances/GroupCompetitionStarting.js
+++ b/server/src/api/events/instances/GroupCompetitionStarting.js
@@ -6,7 +6,8 @@ module.exports = {
   onDispatch({ competition, period }) {
     const body = {
       type: 'COMPETITION_STARTING',
-      data: { groupId: competition.groupId, competition, period }
+      data: { groupId: competition.groupId, competition, period },
+      api_token: process.env.API_TOKEN
     };
 
     axios.post(services.DISCORD_BOT.API, body);

--- a/server/src/api/events/instances/GroupMemberAchievement.js
+++ b/server/src/api/events/instances/GroupMemberAchievement.js
@@ -6,7 +6,8 @@ module.exports = {
   onDispatch({ groupId, player, achievement }) {
     const body = {
       type: 'MEMBER_ACHIEVEMENT',
-      data: { groupId, player, achievement }
+      data: { groupId, player, achievement },
+      api_token: process.env.API_TOKEN
     };
 
     axios.post(services.DISCORD_BOT.API, body);

--- a/server/src/api/events/instances/GroupMemberAchievement.js
+++ b/server/src/api/events/instances/GroupMemberAchievement.js
@@ -1,9 +1,14 @@
+const axios = require('axios');
+const services = require('../../constants/services.json');
+
 module.exports = {
   key: 'GroupMemberAchievement',
   onDispatch({ groupId, player, achievement }) {
-    return {
+    const body = {
       type: 'MEMBER_ACHIEVEMENT',
       data: { groupId, player, achievement }
     };
+
+    axios.post(services.DISCORD_BOT.API, body);
   }
 };

--- a/server/src/api/events/instances/GroupMemberAchievement.js
+++ b/server/src/api/events/instances/GroupMemberAchievement.js
@@ -1,0 +1,9 @@
+module.exports = {
+  key: 'GroupMemberAchievement',
+  onDispatch({ groupId, player, achievement }) {
+    return {
+      type: 'MEMBER_ACHIEVEMENT',
+      data: { groupId, player, achievement }
+    };
+  }
+};

--- a/server/src/api/events/instances/GroupMemberJoined.js
+++ b/server/src/api/events/instances/GroupMemberJoined.js
@@ -1,9 +1,14 @@
+const axios = require('axios');
+const services = require('../../constants/services.json');
+
 module.exports = {
   key: 'GroupMemberJoined',
   onDispatch({ groupId, playerId, displayName }) {
-    return {
+    const body = {
       type: 'GROUP_MEMBER_JOINED',
       data: { groupId, playerId, displayName }
     };
+
+    axios.post(services.DISCORD_BOT.API, body);
   }
 };

--- a/server/src/api/events/instances/GroupMemberJoined.js
+++ b/server/src/api/events/instances/GroupMemberJoined.js
@@ -1,0 +1,9 @@
+module.exports = {
+  key: 'GroupMemberJoined',
+  onDispatch({ groupId, playerId, displayName }) {
+    return {
+      type: 'GROUP_MEMBER_JOINED',
+      data: { groupId, playerId, displayName }
+    };
+  }
+};

--- a/server/src/api/events/instances/GroupMemberJoined.js
+++ b/server/src/api/events/instances/GroupMemberJoined.js
@@ -6,7 +6,8 @@ module.exports = {
   onDispatch({ groupId, playerId, displayName }) {
     const body = {
       type: 'GROUP_MEMBER_JOINED',
-      data: { groupId, playerId, displayName }
+      data: { groupId, playerId, displayName },
+      api_token: process.env.API_TOKEN
     };
 
     axios.post(services.DISCORD_BOT.API, body);

--- a/server/src/api/events/instances/GroupMemberLeft.js
+++ b/server/src/api/events/instances/GroupMemberLeft.js
@@ -6,7 +6,8 @@ module.exports = {
   onDispatch({ groupId, playerId, displayName }) {
     const body = {
       type: 'GROUP_MEMBER_LEFT',
-      data: { groupId, playerId, displayName }
+      data: { groupId, playerId, displayName },
+      api_token: process.env.API_TOKEN
     };
 
     axios.post(services.DISCORD_BOT.API, body);

--- a/server/src/api/events/instances/GroupMemberLeft.js
+++ b/server/src/api/events/instances/GroupMemberLeft.js
@@ -1,0 +1,9 @@
+module.exports = {
+  key: 'GroupMemberLeft',
+  onDispatch({ groupId, playerId, displayName }) {
+    return {
+      type: 'GROUP_MEMBER_LEFT',
+      data: { groupId, playerId, displayName }
+    };
+  }
+};

--- a/server/src/api/events/instances/GroupMemberLeft.js
+++ b/server/src/api/events/instances/GroupMemberLeft.js
@@ -1,9 +1,14 @@
+const axios = require('axios');
+const services = require('../../constants/services.json');
+
 module.exports = {
   key: 'GroupMemberLeft',
   onDispatch({ groupId, playerId, displayName }) {
-    return {
+    const body = {
       type: 'GROUP_MEMBER_LEFT',
       data: { groupId, playerId, displayName }
     };
+
+    axios.post(services.DISCORD_BOT.API, body);
   }
 };

--- a/server/src/api/hooks.js
+++ b/server/src/api/hooks.js
@@ -74,6 +74,8 @@ function setup() {
     const { groupId } = memberships[0];
     const playerIds = memberships.map(m => m.playerId);
 
+    if (!playerIds || playerIds.length === 0) return;
+
     // Handle jobs
     jobs.add('AddToGroupCompetitions', { groupId, playerIds });
 
@@ -89,6 +91,8 @@ function setup() {
     if (!info || !info.where) return;
 
     const { groupId, playerId } = info.where;
+
+    if (!playerId || playerId.length === 0) return;
 
     // Handle jobs
     jobs.add('RemoveFromGroupCompetitions', { groupId, playerIds: playerId });

--- a/server/src/api/hooks.js
+++ b/server/src/api/hooks.js
@@ -1,9 +1,40 @@
-const { Player, Snapshot, Membership } = require('../database');
+const { Player, Snapshot, Membership, Achievement, Competition } = require('../database');
+const playerService = require('./modules/players/player.service');
+const groupService = require('./modules/groups/group.service');
 const jobs = require('./jobs');
+const events = require('./events');
 
 function setup() {
   Player.afterCreate(({ username }) => {
     jobs.add('AssertPlayerName', { username }, { attempts: 5, backoff: 30000 });
+  });
+
+  Achievement.afterBulkCreate(async achievements => {
+    if (!achievements || achievements.length === 0) return;
+
+    const { playerId } = achievements[0];
+    const now = new Date();
+    const newAchievements = achievements.filter(a => now - a.createdAt < 30000);
+
+    if (newAchievements.length === 0) return;
+
+    const groups = await groupService.getPlayerGroups(playerId);
+
+    if (!groups || groups.length === 0) return;
+
+    const player = await playerService.findById(playerId);
+
+    groups.forEach(g => {
+      newAchievements.forEach(a => {
+        events.dispatch('GroupMemberAchievement', { groupId: g.id, player, achievement: a });
+      });
+    });
+  });
+
+  Competition.afterCreate(competition => {
+    if (!competition || !competition.groupId) return;
+
+    events.dispatch('GroupCompetitionCreated', { competition });
   });
 
   Snapshot.afterCreate(({ playerId }) => {
@@ -15,9 +46,7 @@ function setup() {
   });
 
   Snapshot.afterBulkCreate(snapshots => {
-    if (!snapshots || !snapshots.length) {
-      return;
-    }
+    if (!snapshots || !snapshots.length) return;
 
     const { playerId } = snapshots[0];
 
@@ -25,24 +54,37 @@ function setup() {
     jobs.add('ReevaluatePlayerAchievements', { playerId });
   });
 
-  Membership.afterBulkCreate(memberships => {
-    if (!memberships || !memberships.length) {
-      return;
-    }
+  Membership.afterBulkCreate(async memberships => {
+    if (!memberships || !memberships.length) return;
 
     const { groupId } = memberships[0];
     const playerIds = memberships.map(m => m.playerId);
 
+    // Handle jobs
     jobs.add('AddToGroupCompetitions', { groupId, playerIds });
+
+    // Handle events
+    const players = await playerService.findAllByIds(playerIds);
+
+    players.forEach(({ id, displayName }) => {
+      events.dispatch('GroupMemberJoined', { groupId, playerId: id, displayName });
+    });
   });
 
-  Membership.afterBulkDestroy(info => {
-    if (!info || !info.where) {
-      return;
-    }
+  Membership.afterBulkDestroy(async info => {
+    if (!info || !info.where) return;
 
     const { groupId, playerId } = info.where;
+
+    // Handle jobs
     jobs.add('RemoveFromGroupCompetitions', { groupId, playerIds: playerId });
+
+    // Handle events
+    const players = await playerService.findAllByIds(playerId);
+
+    players.forEach(({ id, displayName }) => {
+      events.dispatch('GroupMemberLeft', { groupId, playerId: id, displayName });
+    });
   });
 }
 

--- a/server/src/api/jobs/instances/CompetitionEnded.js
+++ b/server/src/api/jobs/instances/CompetitionEnded.js
@@ -1,0 +1,25 @@
+const events = require('../../events');
+const competitionService = require('../../modules/competitions/competition.service');
+
+module.exports = {
+  name: 'CompetitionEnded',
+  async handle({ data }) {
+    const { competitionId } = data;
+    const competition = await competitionService.getDetails(competitionId);
+
+    if (!competition) return;
+
+    // Double check the competition just ended, since the
+    // competition start date can be changed between the
+    // scheduling and execution of this job
+    if (Math.abs(new Date() - competition.endsAt) > 10000) {
+      return;
+    }
+
+    // Add all onCompetitionEnded actions below
+
+    if (competition.groupId) {
+      events.dispatch('GroupCompetitionEnded', { competition });
+    }
+  }
+};

--- a/server/src/api/jobs/instances/CompetitionEnding.js
+++ b/server/src/api/jobs/instances/CompetitionEnding.js
@@ -1,0 +1,26 @@
+const events = require('../../events');
+const competitionService = require('../../modules/competitions/competition.service');
+
+module.exports = {
+  name: 'CompetitionEnding',
+  async handle({ data }) {
+    const { competitionId, minutes } = data;
+    const competition = await competitionService.getDetails(competitionId);
+
+    if (!competition) return;
+
+    // Double check the competition is ending, since the
+    // competition start date can be changed between the
+    // scheduling and execution of this job
+    if (Math.abs(new Date() - (competition.endsAt - minutes * 60 * 1000)) > 10000) {
+      return;
+    }
+
+    // Add all onCompetitionEnding actions below
+
+    if (competition.groupId) {
+      const period = minutes <= 60 ? { minutes } : { hours: minutes / 60 };
+      events.dispatch('GroupCompetitionEnding', { competition, period });
+    }
+  }
+};

--- a/server/src/api/jobs/instances/CompetitionStarted.js
+++ b/server/src/api/jobs/instances/CompetitionStarted.js
@@ -1,0 +1,25 @@
+const events = require('../../events');
+const competitionService = require('../../modules/competitions/competition.service');
+
+module.exports = {
+  name: 'CompetitionStarted',
+  async handle({ data }) {
+    const { competitionId } = data;
+    const competition = await competitionService.getDetails(competitionId);
+
+    if (!competition) return;
+
+    // Double check the competition just started, since the
+    // competition start date can be changed between the
+    // scheduling and execution of this job
+    if (Math.abs(new Date() - competition.startsAt) > 10000) {
+      return;
+    }
+
+    // Add all onCompetitionStarted actions below
+
+    if (competition.groupId) {
+      events.dispatch('GroupCompetitionStarted', { competition });
+    }
+  }
+};

--- a/server/src/api/jobs/instances/CompetitionStarting.js
+++ b/server/src/api/jobs/instances/CompetitionStarting.js
@@ -1,0 +1,26 @@
+const events = require('../../events');
+const competitionService = require('../../modules/competitions/competition.service');
+
+module.exports = {
+  name: 'CompetitionStarting',
+  async handle({ data }) {
+    const { competitionId, minutes } = data;
+    const competition = await competitionService.getDetails(competitionId);
+
+    if (!competition) return;
+
+    // Double check the competition is starting, since the
+    // competition start date can be changed between the
+    // scheduling and execution of this job
+    if (Math.abs(new Date() - (competition.startsAt - minutes * 60 * 1000)) > 10000) {
+      return;
+    }
+
+    // Add all onCompetitionStarting actions below
+
+    if (competition.groupId) {
+      const period = minutes <= 60 ? { minutes } : { hours: minutes / 60 };
+      events.dispatch('GroupCompetitionStarting', { competition, period });
+    }
+  }
+};

--- a/server/src/api/jobs/instances/index.js
+++ b/server/src/api/jobs/instances/index.js
@@ -8,6 +8,10 @@ const ReevaluatePlayerAchievements = require('./ReevaluatePlayerAchievements');
 const SyncPlayerInitialValues = require('./SyncPlayerInitialValues');
 const AssertPlayerName = require('./AssertPlayerName');
 const RefreshRankings = require('./RefreshRankings');
+const CompetitionStarted = require('./CompetitionStarted');
+const CompetitionStarting = require('./CompetitionStarting');
+const CompetitionEnding = require('./CompetitionEnding');
+const CompetitionEnded = require('./CompetitionEnded');
 
 module.exports = {
   ImportPlayer,
@@ -19,5 +23,9 @@ module.exports = {
   ReevaluatePlayerAchievements,
   SyncPlayerInitialValues,
   AssertPlayerName,
-  RefreshRankings
+  RefreshRankings,
+  CompetitionStarted,
+  CompetitionStarting,
+  CompetitionEnding,
+  CompetitionEnded
 };

--- a/server/src/api/modules/groups/group.service.js
+++ b/server/src/api/modules/groups/group.service.js
@@ -608,24 +608,68 @@ async function setMembers(group, members) {
     throw new BadRequestError(`Invalid group.`);
   }
 
-  const uniqueNames = _.uniqBy(
-    members.map(m => m.username),
-    m => m.toLowerCase()
-  );
+  // Ignore any duplicate names
+  const uniqueNames = _.uniq(members.map(m => m.username.toLowerCase()));
 
+  // Fetch (or create) player from the unique usernames
   const players = await playerService.findAllOrCreate(uniqueNames);
 
-  const newMemberships = players.map((p, i) => ({
-    playerId: p.id,
+  // Define membership models for each player
+  const memberships = players.map((player, i) => ({
+    playerId: player.id,
     groupId: group.id,
     role: members[i].role || 'member'
+    // TODO: this can be problematic in the future and should be fixed ASAP:
+    // If we supply a list of 4 usernames, 2 of them being repeated,
+    // array size of members will be different than uniqueNames and therefore players
+    // so by doing members[i] we might be accessing the wrong index.
   }));
 
-  // Remove all existing memberships
-  await Membership.destroy({ where: { groupId: group.id } });
+  // Fetch all previous (existing) memberships
+  const previousMemberships = await Membership.findAll({
+    attributes: ['groupId', 'playerId', 'role'],
+    where: { groupId: group.id }
+  });
 
-  // Add all the new memberships
-  await Membership.bulkCreate(newMemberships, { ignoreDuplicates: true });
+  // Find all "to remove" memberships (were previously members, and should now be removed)
+  const removeMemberships = previousMemberships.filter(
+    pm => !memberships.find(m => m.playerId === pm.playerId)
+  );
+
+  // Find all memberships that should be stay members (opposite of removeMemberships)
+  const keptMemberships = previousMemberships.filter(pm =>
+    memberships.find(m => m.playerId === pm.playerId)
+  );
+
+  // Find all new memberships (were not previously members, but should be added)
+  const newMemberships = memberships.filter(
+    m => !previousMemberships.map(pm => pm.playerId).includes(m.playerId)
+  );
+
+  // Delete all memberships for "removed members", if any exist
+  if (removeMemberships.length > 0) {
+    const toRemoveIds = removeMemberships.map(rm => rm.playerId);
+    await Membership.destroy({ where: { groupId: group.id, playerId: toRemoveIds } });
+  }
+
+  // Add all the new memberships, if any exist
+  if (memberships.length > 0) {
+    await Membership.bulkCreate(newMemberships, { ignoreDuplicates: true });
+  }
+
+  // Check if any kept member's role should be changed
+  if (keptMemberships.length > 0) {
+    await Promise.all(
+      keptMemberships.map(async k => {
+        const membership = memberships.find(m => m.playerId === k.playerId);
+
+        // Role has changed and should be updated
+        if (membership && membership.role !== k.role) {
+          await k.update({ role: membership.role });
+        }
+      })
+    );
+  }
 
   const allMembers = await group.getMembers();
 

--- a/server/src/api/modules/players/player.service.js
+++ b/server/src/api/modules/players/player.service.js
@@ -429,6 +429,22 @@ async function findAll(usernames) {
   return promises;
 }
 
+async function findById(playerId) {
+  const players = await Player.findOne({
+    where: { id: playerId }
+  });
+
+  return players;
+}
+
+async function findAllByIds(playerIds) {
+  const players = await Player.findAll({
+    where: { id: playerIds }
+  });
+
+  return players;
+}
+
 /**
  * Fetches the player history from the CML API.
  */
@@ -505,6 +521,8 @@ exports.isValidUsername = isValidUsername;
 exports.findAllOrCreate = findAllOrCreate;
 exports.findAll = findAll;
 exports.find = find;
+exports.findAllByIds = findAllByIds;
+exports.findById = findById;
 
 // Handlers
 exports.getDetailsById = getDetailsById;

--- a/server/src/database/config.js
+++ b/server/src/database/config.js
@@ -4,7 +4,7 @@ module.exports = {
   host: process.env.DB_HOST,
   username: process.env.POSTGRES_USER,
   password: process.env.POSTGRES_PASSWORD,
-  database: process.env.POSTGRES_DB,
+  database: 'wise-old-man',
   dialect: process.env.DB_DIALECT,
   storage: process.env.DB_STORAGE,
   logging: false,

--- a/server/src/database/index.js
+++ b/server/src/database/index.js
@@ -1,7 +1,9 @@
 const { Sequelize } = require('sequelize');
-const CONFIG = require('./config');
+const databaseConfig = require('./config');
 
-const sequelize = new Sequelize(CONFIG.database, CONFIG.username, CONFIG.password, CONFIG);
+const sequelize = new Sequelize({
+  ...databaseConfig
+});
 
 // Import and define all models
 const models = {


### PR DESCRIPTION
This was previously pushed but had to be reverted as it had a critical bug.

- Adds support for time-based competition events (Ex: onCompetitionStarted, onCompetitionEnding, etc)
- Adds event dispatching to the discord bot API (placeholder for now)
- Removes variable database name from .env (it is now hardcoded for this project, and also the discord-bot project)
- Rewrites the group setMembers function to be smarter