### PR TITLE
Create local postgres database on docker-complse build

### DIFF
--- a/server/src/api/modules/players/player.service.ts
+++ b/server/src/api/modules/players/player.service.ts
@@ -190,7 +190,7 @@ async function update(username) {
   } catch (e) {
     // If the player was just registered and it failed to fetch hiscores,
     // set updatedAt to null to allow for re-attempts without the 60s waiting period
-    if (created) {
+    if (created && player.type !== 'unknown') {
       // Doing this with the model method (Player.update) because the
       // instance method (instance.update) doesn't seem to work.
       await Player.update({ updatedAt: null }, { where: { id: player.id }, silent: true });


### PR DESCRIPTION
The [server/API documentation](https://github.com/wise-old-man/wise-old-man/blob/master/.github/contributing/server-guide.md) does not mention that we have to create the database manually. This PR will create that database in the `postgres` container automatically during the `docker-compose`. Contributors can then simply build and get to work. Prior to this PR, an uninitiated database would result in errors such as:

```
 $ docker-compose up --build
[...]
db_1       | 2020-08-01 16:46:16.528 UTC [35] FATAL:  database "wise-old-man" does not exist
db_1       | 2020-08-01 16:46:16.800 UTC [36] FATAL:  database "wise-old-man" does not exist
db_1       | 2020-08-01 16:46:17.267 UTC [37] FATAL:  database "wise-old-man" does not exist
db_1       | 2020-08-01 16:46:18.124 UTC [38] FATAL:  database "wise-old-man" does not exist
db_1       | 2020-08-01 16:46:19.796 UTC [39] FATAL:  database "wise-old-man" does not exist
db_1       | 2020-08-01 16:46:23.299 UTC [40] FATAL:  database "wise-old-man" does not exist
db_1       | 2020-08-01 16:46:31.210 UTC [41] FATAL:  database "wise-old-man" does not exist
db_1       | 2020-08-01 16:46:50.606 UTC [42] FATAL:  database "wise-old-man" does not exist
server_1   |
server_1   | ERROR: database "wise-old-man" does not exist
server_1   |
server_1   | npm ERR! code ELIFECYCLE
server_1   | npm ERR! errno 1
server_1   | npm ERR! wise-old-man-server@1.0.0 predev: `npm run build && sequelize db:migrate`
server_1   | npm ERR! Exit status 1
server_1   | npm ERR!
server_1   | npm ERR! Failed at the wise-old-man-server@1.0.0 predev script.
```