### PR TITLE
Add player builds (f2p, lvl3, 1def)

### DIFF
--- a/app/src/components/PageBadge/PageBadge.jsx
+++ b/app/src/components/PageBadge/PageBadge.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import './PageBadge.scss';
+
+function PageBadge({ text, hoverText }) {
+  return (
+    <abbr className="page-badge" title={hoverText}>
+      <span>{text}</span>
+    </abbr>
+  );
+}
+
+PageBadge.propTypes = {
+  text: PropTypes.string.isRequired,
+  hoverText: PropTypes.string.isRequired
+};
+
+export default PageBadge;

--- a/app/src/components/PageBadge/PageBadge.scss
+++ b/app/src/components/PageBadge/PageBadge.scss
@@ -1,0 +1,11 @@
+@import '../../variables.scss';
+
+.page-badge {
+  display: inline-block;
+  text-decoration: none;
+  color: $brand-color-bright;
+  border: 1px solid $brand-color-bright;
+  border-radius: 5px;
+  font-size: 0.7em;
+  padding: 3px 5px;
+}

--- a/app/src/components/PageBadge/index.js
+++ b/app/src/components/PageBadge/index.js
@@ -1,0 +1,3 @@
+import PageBadge from './PageBadge';
+
+export default PageBadge;

--- a/app/src/components/PageHeader/PageHeader.jsx
+++ b/app/src/components/PageHeader/PageHeader.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import VerifiedBadge from '../VerifiedBadge';
+import PageBadge from '../PageBadge';
 import './PageHeader.scss';
 
-function PageHeader({ title, icon, iconTooltip, children, verified }) {
+function PageHeader({ title, icon, iconTooltip, children, badges }) {
   return (
     <div className="page-header">
       {icon && (
@@ -12,7 +12,10 @@ function PageHeader({ title, icon, iconTooltip, children, verified }) {
         </abbr>
       )}
       <h1 className="page-header__title">{title}</h1>
-      {verified && <VerifiedBadge version="full" />}
+      {badges &&
+        badges.map(badge => (
+          <PageBadge key={badge.text} text={badge.text} hoverText={badge.hoverText} />
+        ))}
       <div className="page-header__actions">{children}</div>
     </div>
   );
@@ -21,7 +24,7 @@ function PageHeader({ title, icon, iconTooltip, children, verified }) {
 PageHeader.defaultProps = {
   icon: undefined,
   iconTooltip: undefined,
-  verified: false
+  badges: []
 };
 
 PageHeader.propTypes = {
@@ -35,7 +38,10 @@ PageHeader.propTypes = {
   iconTooltip: PropTypes.string,
 
   // If enabled, a verified badge will be displayed next to the title
-  verified: PropTypes.bool
+  badges: PropTypes.arrayOf({
+    text: PropTypes.string.isRequired,
+    hoverText: PropTypes.string.isRequired
+  })
 };
 
 export default React.memo(PageHeader);

--- a/app/src/components/VerifiedBadge/VerifiedBadge.jsx
+++ b/app/src/components/VerifiedBadge/VerifiedBadge.jsx
@@ -1,26 +1,15 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import classNames from 'classnames';
 import './VerifiedBadge.scss';
 
-function VerifiedBadge({ version }) {
+function VerifiedBadge() {
   return (
     <abbr
-      className={classNames('verified-badge', `-${version}`)}
+      className="verified-badge"
       title="Verified group: This group's leader is verified on our Discord server."
     >
-      {version === 'full' && <span>Verified</span>}
-      {version === 'icon' && <img src="/img/icons/verified.svg" alt="" />}
+      <img src="/img/icons/verified.svg" alt="" />
     </abbr>
   );
 }
-
-VerifiedBadge.defaultProps = {
-  version: 'icon'
-};
-
-VerifiedBadge.propTypes = {
-  version: PropTypes.string // (icon/full)
-};
 
 export default VerifiedBadge;

--- a/app/src/components/VerifiedBadge/VerifiedBadge.scss
+++ b/app/src/components/VerifiedBadge/VerifiedBadge.scss
@@ -3,22 +3,11 @@
 .verified-badge {
   display: inline-block;
   text-decoration: none;
+  width: 15px;
+  height: 15px;
 
-  &.-full {
-    color: $brand-color-bright;
-    border: 1px solid $brand-color-bright;
-    border-radius: 5px;
-    font-size: 0.7em;
-    padding: 3px 5px;
-  }
-
-  &.-icon {
-    width: 15px;
-    height: 15px;
-
-    img {
-      width: 100%;
-      height: 100%;
-    }
+  img {
+    width: 100%;
+    height: 100%;
   }
 }

--- a/app/src/config/player.js
+++ b/app/src/config/player.js
@@ -1,1 +1,2 @@
 export const PLAYER_TYPES = ['regular', 'ironman', 'ultimate', 'hardcore'];
+export const PLAYER_BUILDS = ['lvl3', 'f2p', '1def', 'main'];

--- a/app/src/config/routing.js
+++ b/app/src/config/routing.js
@@ -27,7 +27,7 @@ export const ROUTES = [
     component: TopPage
   },
   {
-    path: '/records/:metric?/:playerType?',
+    path: '/records/:metric?',
     component: RecordsPage
   },
   {

--- a/app/src/config/routing.js
+++ b/app/src/config/routing.js
@@ -23,7 +23,7 @@ export const ROUTES = [
     component: HomePage
   },
   {
-    path: '/top/:metric?/:playerType?',
+    path: '/top/:metric?',
     component: TopPage
   },
   {

--- a/app/src/pages/Group/Group.jsx
+++ b/app/src/pages/Group/Group.jsx
@@ -52,6 +52,11 @@ const PERIOD_OPTIONS = [
   { label: 'Year', value: 'year' }
 ];
 
+const VERIFIED_BADGE = {
+  text: 'Verified',
+  hoverText: "Verified group: This group's leader is verified on our Discord server."
+};
+
 const TABS = ['Members', 'Competitions', 'Hiscores', 'Gained', 'Records', 'Achievements', 'Statistics'];
 
 const MENU_OPTIONS = [
@@ -193,7 +198,7 @@ function Group() {
       </Helmet>
       <div className="group__header row">
         <div className="col">
-          <PageHeader title={group.name} verified={group.verified}>
+          <PageHeader title={group.name} badges={[VERIFIED_BADGE]}>
             <Button text="Update all" onClick={onUpdateAllClicked} disabled={isButtonDisabled} />
             <Dropdown options={MENU_OPTIONS} onSelect={onOptionSelected}>
               <button className="header__options-btn" type="button">

--- a/app/src/pages/Player/Player.jsx
+++ b/app/src/pages/Player/Player.jsx
@@ -67,6 +67,19 @@ const MENU_OPTIONS = [
   { label: '[NEW] Change name', value: 'changeName' }
 ];
 
+function getPlayerBadges(build) {
+  switch (build) {
+    case 'lvl3':
+      return [{ text: 'Level 3', hoverText: '' }];
+    case 'f2p':
+      return [{ text: 'F2P', hoverText: '' }];
+    case '1def':
+      return [{ text: '1 Def Pure', hoverText: '' }];
+    default:
+      return [];
+  }
+}
+
 function getSelectedTabIndex(section) {
   const index = TABS.findIndex(t => t.toLowerCase() === section);
   return Math.max(0, index);
@@ -285,6 +298,7 @@ function Player() {
             title={player.displayName}
             icon={getPlayerIcon(player.type)}
             iconTooltip={getPlayerTooltip(player.type, player.flagged)}
+            badges={getPlayerBadges(player.build)}
           >
             <Button text="Update" onClick={onUpdateButtonClicked} loading={isTracking} />
             <Dropdown options={MENU_OPTIONS} onSelect={onOptionSelected}>

--- a/app/src/pages/Records/Records.jsx
+++ b/app/src/pages/Records/Records.jsx
@@ -209,11 +209,13 @@ function Records() {
           />
         </div>
         <div className="col-lg-3 col-md-5">
-          <Selector
-            options={playerBuildOptions}
-            selectedIndex={playerBuildIndex}
-            onSelect={handleBuildSelected}
-          />
+          {new Date() > new Date('2020-08-20') && (
+            <Selector
+              options={playerBuildOptions}
+              selectedIndex={playerBuildIndex}
+              onSelect={handleBuildSelected}
+            />
+          )}
         </div>
         <div className="col-md-2">
           {isLoading && <img className="loading-icon" src="/img/icons/loading.png" alt="" />}

--- a/app/src/pages/Records/Records.jsx
+++ b/app/src/pages/Records/Records.jsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useCallback, useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Link, useHistory, useParams } from 'react-router-dom';
+import { Link, useHistory, useParams, useLocation } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 import PageTitle from '../../components/PageTitle';
 import Selector from '../../components/Selector';
@@ -8,7 +8,7 @@ import PlayerTag from '../../components/PlayerTag';
 import Table from '../../components/Table';
 import NumberLabel from '../../components/NumberLabel';
 import TablePlaceholder from '../../components/TablePlaceholder';
-import { PLAYER_TYPES, ALL_METRICS } from '../../config';
+import { PLAYER_TYPES, PLAYER_BUILDS, ALL_METRICS } from '../../config';
 import {
   formatDate,
   getPlayerIcon,
@@ -19,12 +19,17 @@ import {
   isBoss
 } from '../../utils';
 import fetchLeaderboard from '../../redux/modules/records/actions/fetchLeaderboard';
-import { getLeaderboard, isFetchingLeaderboard } from '../../redux/selectors/records';
+import {
+  getLeaderboards,
+  isFetchingDay,
+  isFetchingWeek,
+  isFetchingMonth
+} from '../../redux/selectors/records';
 import './Records.scss';
 
 function getTableConfig(metric) {
   return {
-    uniqueKey: row => row.username,
+    uniqueKey: row => row.player.username,
     columns: [
       {
         key: 'rank',
@@ -33,10 +38,11 @@ function getTableConfig(metric) {
       },
       {
         key: 'displayName',
+        get: row => row.player.displayName,
         className: () => '-primary',
         transform: (value, row) => (
-          <Link to={getPlayerURL(row.playerId, metric)}>
-            <PlayerTag name={value} type={row.type} flagged={row.flagged} />
+          <Link to={getPlayerURL(row.player.Id, metric)}>
+            <PlayerTag name={value} type={row.player.type} flagged={row.player.flagged} />
           </Link>
         )
       },
@@ -58,14 +64,22 @@ function getTableConfig(metric) {
 }
 
 function getPlayerTypeOptions() {
-  return [
-    { label: 'All players', value: null },
-    ...PLAYER_TYPES.map(type => ({
-      label: capitalize(type),
-      icon: getPlayerIcon(type),
-      value: type
-    }))
-  ];
+  const options = PLAYER_TYPES.map(type => ({
+    label: capitalize(type),
+    icon: getPlayerIcon(type),
+    value: type
+  }));
+
+  return [{ label: 'All player types', value: null }, ...options];
+}
+
+function getPlayerBuildOptions() {
+  const options = PLAYER_BUILDS.map(type => ({
+    label: capitalize(type),
+    value: type
+  }));
+
+  return [{ label: 'All player builds', value: null }, ...options];
 }
 
 function getMetricOptions() {
@@ -76,60 +90,96 @@ function getMetricOptions() {
   }));
 }
 
+function useQuery(keys) {
+  const urlQuery = new URLSearchParams(useLocation().search);
+  const result = {};
+
+  keys.forEach(k => {
+    result[k] = urlQuery.get(k);
+  });
+
+  return result;
+}
+
 function getPlayerURL(playerId, metric) {
+  let section = '';
+
   if (isSkill(metric)) {
-    return `/players/${playerId}/records/skilling`;
+    section = 'skilling';
+  } else if (isBoss(metric)) {
+    section = 'bossing';
+  } else {
+    section = 'activities';
   }
 
-  if (isBoss(metric)) {
-    return `/players/${playerId}/records/bossing`;
+  return `/players/${playerId}/records/${section}`;
+}
+
+function getNextUrl(nextMetric, nextType, nextBuild) {
+  const baseUrl = `/records/${nextMetric}?`;
+  const queries = [];
+
+  if (nextType !== null) {
+    queries.push(`type=${nextType}`);
   }
 
-  return `/players/${playerId}/records/activities`;
+  if (nextBuild !== null) {
+    queries.push(`build=${nextBuild}`);
+  }
+
+  return `${baseUrl}${queries.join('&')}`;
 }
 
 function Records() {
-  const { metric, playerType } = useParams();
   const router = useHistory();
   const dispatch = useDispatch();
 
+  const { metric } = useParams();
+  const { type, build } = useQuery(['type', 'build']);
+
   const selectedMetric = metric || 'overall';
-  const selectedPlayerType = playerType || null;
+  const selectedPlayerType = type || null;
+  const selectedPlayerBuild = build || null;
 
   const metricOptions = useMemo(() => getMetricOptions(), []);
   const playerTypeOptions = useMemo(() => getPlayerTypeOptions(), []);
+  const playerBuildOptions = useMemo(() => getPlayerBuildOptions(), []);
 
   const metricIndex = metricOptions.findIndex(o => o.value === selectedMetric);
   const playerTypeIndex = playerTypeOptions.findIndex(o => o.value === selectedPlayerType);
+  const playerBuildIndex = playerBuildOptions.findIndex(o => o.value === selectedPlayerBuild);
 
   // Memoized redux variables
-  const leaderboard = useSelector(state => getLeaderboard(state));
-  const isLoading = useSelector(state => isFetchingLeaderboard(state));
+  const leaderboards = useSelector(getLeaderboards);
+  const isLoadingDay = useSelector(isFetchingDay);
+  const isLoadingWeek = useSelector(isFetchingWeek);
+  const isLoadingMonth = useSelector(isFetchingMonth);
+  const isLoading = isLoadingDay || isLoadingWeek || isLoadingMonth;
 
   const reloadList = () => {
-    dispatch(fetchLeaderboard({ metric: selectedMetric, playerType: selectedPlayerType }));
+    const periods = ['day', 'week', 'month'];
+
+    periods.forEach(p => {
+      dispatch(fetchLeaderboard(selectedMetric, p, selectedPlayerType, selectedPlayerBuild));
+    });
   };
 
   const handleMetricSelected = e => {
-    if (e && e.value) {
-      router.push(`/records/${e.value}/${selectedPlayerType || ''}`);
-    }
+    if (!e || !e.value) return;
+    router.push(getNextUrl(e.value, selectedPlayerType, selectedPlayerBuild));
   };
 
   const handleTypeSelected = e => {
-    if (e && e.value) {
-      router.push(`/records/${selectedMetric}/${e.value}`);
-    } else {
-      router.push(`/records/${selectedMetric}`);
-    }
+    router.push(getNextUrl(selectedMetric, e.value, selectedPlayerBuild));
   };
 
-  const onMetricSelected = useCallback(handleMetricSelected, [selectedMetric, selectedPlayerType]);
-  const onTypeSelected = useCallback(handleTypeSelected, [selectedMetric, selectedPlayerType]);
+  const handleBuildSelected = e => {
+    router.push(getNextUrl(selectedMetric, selectedPlayerType, e.value));
+  };
 
   const tableConfig = useMemo(() => getTableConfig(selectedMetric), [selectedMetric]);
 
-  useEffect(reloadList, [selectedMetric, selectedPlayerType]);
+  useEffect(reloadList, [selectedMetric, selectedPlayerType, selectedPlayerBuild]);
 
   return (
     <div className="records__container container">
@@ -146,7 +196,7 @@ function Records() {
           <Selector
             options={metricOptions}
             selectedIndex={metricIndex}
-            onSelect={onMetricSelected}
+            onSelect={handleMetricSelected}
             search
           />
         </div>
@@ -154,7 +204,14 @@ function Records() {
           <Selector
             options={playerTypeOptions}
             selectedIndex={playerTypeIndex}
-            onSelect={onTypeSelected}
+            onSelect={handleTypeSelected}
+          />
+        </div>
+        <div className="col-lg-3 col-md-5">
+          <Selector
+            options={playerBuildOptions}
+            selectedIndex={playerBuildIndex}
+            onSelect={handleBuildSelected}
           />
         </div>
         <div className="col-md-2">
@@ -164,39 +221,39 @@ function Records() {
       <div className="records__list row">
         <div className="col-lg-4 col-md-6">
           <h3 className="period-label">Day</h3>
-          {!leaderboard || !leaderboard.day ? (
+          {!leaderboards || !leaderboards.day ? (
             <TablePlaceholder size={20} />
           ) : (
             <Table
               uniqueKeySelector={tableConfig.uniqueKey}
               columns={tableConfig.columns}
-              rows={leaderboard.day}
+              rows={leaderboards.day}
               listStyle
             />
           )}
         </div>
         <div className="col-lg-4 col-md-6">
           <h3 className="period-label">Week</h3>
-          {!leaderboard || !leaderboard.week ? (
+          {!leaderboards || !leaderboards.week ? (
             <TablePlaceholder size={20} />
           ) : (
             <Table
               uniqueKeySelector={tableConfig.uniqueKey}
               columns={tableConfig.columns}
-              rows={leaderboard.week}
+              rows={leaderboards.week}
               listStyle
             />
           )}
         </div>
         <div className="col-lg-4 col-md-6">
           <h3 className="period-label">Month</h3>
-          {!leaderboard || !leaderboard.month ? (
+          {!leaderboards || !leaderboards.month ? (
             <TablePlaceholder size={20} />
           ) : (
             <Table
               uniqueKeySelector={tableConfig.uniqueKey}
               columns={tableConfig.columns}
-              rows={leaderboard.month}
+              rows={leaderboards.month}
               listStyle
             />
           )}

--- a/app/src/pages/Records/Records.jsx
+++ b/app/src/pages/Records/Records.jsx
@@ -12,6 +12,7 @@ import { PLAYER_TYPES, PLAYER_BUILDS, ALL_METRICS } from '../../config';
 import {
   formatDate,
   getPlayerIcon,
+  getPlayerBuild,
   getMetricIcon,
   capitalize,
   getMetricName,
@@ -75,7 +76,7 @@ function getPlayerTypeOptions() {
 
 function getPlayerBuildOptions() {
   const options = PLAYER_BUILDS.map(type => ({
-    label: capitalize(type),
+    label: getPlayerBuild(type),
     value: type
   }));
 

--- a/app/src/pages/Top/Top.jsx
+++ b/app/src/pages/Top/Top.jsx
@@ -201,11 +201,13 @@ function Top() {
           />
         </div>
         <div className="col-lg-3 col-md-5">
-          <Selector
-            options={playerBuildOptions}
-            selectedIndex={playerBuildIndex}
-            onSelect={handleBuildSelected}
-          />
+          {new Date() > new Date('2020-08-20') && (
+            <Selector
+              options={playerBuildOptions}
+              selectedIndex={playerBuildIndex}
+              onSelect={handleBuildSelected}
+            />
+          )}
         </div>
         <div className="col-md-2">
           {isLoading && <img className="loading-icon" src="/img/icons/loading.png" alt="" />}

--- a/app/src/pages/Top/Top.jsx
+++ b/app/src/pages/Top/Top.jsx
@@ -21,7 +21,7 @@ import './Top.scss';
 
 function getTableConfig(metric, period) {
   return {
-    uniqueKey: row => row.username,
+    uniqueKey: row => row.player.username,
     columns: [
       {
         key: 'rank',

--- a/app/src/pages/Top/Top.jsx
+++ b/app/src/pages/Top/Top.jsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useCallback, useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Link, useHistory, useParams } from 'react-router-dom';
+import { Link, useHistory, useParams, useLocation } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 import PageTitle from '../../components/PageTitle';
 import PlayerTag from '../../components/PlayerTag';
@@ -8,10 +8,15 @@ import Selector from '../../components/Selector';
 import Table from '../../components/Table';
 import NumberLabel from '../../components/NumberLabel';
 import TablePlaceholder from '../../components/TablePlaceholder';
-import { PLAYER_TYPES, ALL_METRICS } from '../../config';
+import { PLAYER_TYPES, PLAYER_BUILDS, ALL_METRICS } from '../../config';
 import { capitalize, getPlayerIcon, getMetricIcon, getMetricName, isSkill, isBoss } from '../../utils';
 import fetchLeaderboard from '../../redux/modules/deltas/actions/fetchLeaderboard';
-import { getLeaderboard, isFetchingLeaderboard } from '../../redux/selectors/deltas';
+import {
+  getLeaderboards,
+  isFetchingDay,
+  isFetchingWeek,
+  isFetchingMonth
+} from '../../redux/selectors/deltas';
 import './Top.scss';
 
 function getTableConfig(metric, period) {
@@ -25,10 +30,11 @@ function getTableConfig(metric, period) {
       },
       {
         key: 'displayName',
+        get: row => row.player.displayName,
         className: () => '-primary',
         transform: (value, row) => (
-          <Link to={getPlayerURL(row.playerId, metric, period)}>
-            <PlayerTag name={value} type={row.type} flagged={row.flagged} />
+          <Link to={getPlayerURL(row.player.id, metric, period)}>
+            <PlayerTag name={value} type={row.player.type} flagged={row.player.flagged} />
           </Link>
         )
       },
@@ -42,14 +48,22 @@ function getTableConfig(metric, period) {
 }
 
 function getPlayerTypeOptions() {
-  return [
-    { label: 'All players', value: null },
-    ...PLAYER_TYPES.map(type => ({
-      label: capitalize(type),
-      icon: getPlayerIcon(type),
-      value: type
-    }))
-  ];
+  const options = PLAYER_TYPES.map(type => ({
+    label: capitalize(type),
+    icon: getPlayerIcon(type),
+    value: type
+  }));
+
+  return [{ label: 'All player types', value: null }, ...options];
+}
+
+function getPlayerBuildOptions() {
+  const options = PLAYER_BUILDS.map(type => ({
+    label: capitalize(type),
+    value: type
+  }));
+
+  return [{ label: 'All player builds', value: null }, ...options];
 }
 
 function getMetricOptions() {
@@ -60,62 +74,97 @@ function getMetricOptions() {
   }));
 }
 
+function useQuery(keys) {
+  const urlQuery = new URLSearchParams(useLocation().search);
+  const result = {};
+
+  keys.forEach(k => {
+    result[k] = urlQuery.get(k);
+  });
+
+  return result;
+}
+
 function getPlayerURL(playerId, metric, period) {
+  let section = '';
+
   if (isSkill(metric)) {
-    return `/players/${playerId}/gained/skilling/?metric=${metric}&period=${period}`;
+    section = 'skilling';
+  } else if (isBoss(metric)) {
+    section = 'bossing';
+  } else {
+    section = 'activities';
   }
 
-  if (isBoss(metric)) {
-    return `/players/${playerId}/gained/bossing/?metric=${metric}&period=${period}`;
+  return `/players/${playerId}/gained/${section}/?metric=${metric}&period=${period}`;
+}
+
+function getNextUrl(nextMetric, nextType, nextBuild) {
+  const baseUrl = `/top/${nextMetric}?`;
+  const queries = [];
+
+  if (nextType !== null) {
+    queries.push(`type=${nextType}`);
   }
 
-  return `/players/${playerId}/gained/activities/?metric=${metric}&period=${period}`;
+  if (nextBuild !== null) {
+    queries.push(`build=${nextBuild}`);
+  }
+
+  return `${baseUrl}${queries.join('&')}`;
 }
 
 function Top() {
-  const { metric, playerType } = useParams();
   const router = useHistory();
   const dispatch = useDispatch();
+  const { metric } = useParams();
+  const { type, build } = useQuery(['type', 'build']);
 
   const selectedMetric = metric || 'overall';
-  const selectedPlayerType = playerType || null;
+  const selectedPlayerType = type || null;
+  const selectedPlayerBuild = build || null;
 
   const metricOptions = useMemo(() => getMetricOptions(), []);
   const playerTypeOptions = useMemo(() => getPlayerTypeOptions(), []);
+  const playerBuildOptions = useMemo(() => getPlayerBuildOptions(), []);
 
   const metricIndex = metricOptions.findIndex(o => o.value === selectedMetric);
   const playerTypeIndex = playerTypeOptions.findIndex(o => o.value === selectedPlayerType);
+  const playerBuildIndex = playerBuildOptions.findIndex(o => o.value === selectedPlayerBuild);
 
   // Memoized redux variables
-  const leaderboard = useSelector(state => getLeaderboard(state));
-  const isLoading = useSelector(state => isFetchingLeaderboard(state));
+  const leaderboards = useSelector(getLeaderboards);
+  const isLoadingDay = useSelector(isFetchingDay);
+  const isLoadingWeek = useSelector(isFetchingWeek);
+  const isLoadingMonth = useSelector(isFetchingMonth);
+  const isLoading = isLoadingDay || isLoadingWeek || isLoadingMonth;
 
   const reloadList = () => {
-    dispatch(fetchLeaderboard({ metric: selectedMetric, playerType: selectedPlayerType }));
+    const periods = ['day', 'week', 'month'];
+
+    periods.forEach(p => {
+      dispatch(fetchLeaderboard(selectedMetric, p, selectedPlayerType, selectedPlayerBuild));
+    });
   };
 
   const handleMetricSelected = e => {
-    if (e && e.value) {
-      router.push(`/top/${e.value}/${selectedPlayerType || ''}`);
-    }
+    if (!e || !e.value) return;
+    router.push(getNextUrl(e.value, selectedPlayerType, selectedPlayerBuild));
   };
 
   const handleTypeSelected = e => {
-    if (e && e.value) {
-      router.push(`/top/${selectedMetric}/${e.value}`);
-    } else {
-      router.push(`/top/${selectedMetric}`);
-    }
+    router.push(getNextUrl(selectedMetric, e.value, selectedPlayerBuild));
   };
 
-  const onMetricSelected = useCallback(handleMetricSelected, [selectedMetric, selectedPlayerType]);
-  const onTypeSelected = useCallback(handleTypeSelected, [selectedMetric, selectedPlayerType]);
+  const handleBuildSelected = e => {
+    router.push(getNextUrl(selectedMetric, selectedPlayerType, e.value));
+  };
 
   const dayTableConfig = useMemo(() => getTableConfig(selectedMetric, 'day'), [selectedMetric]);
   const weekTableConfig = useMemo(() => getTableConfig(selectedMetric, 'week'), [selectedMetric]);
   const monthTableConfig = useMemo(() => getTableConfig(selectedMetric, 'month'), [selectedMetric]);
 
-  useEffect(reloadList, [selectedMetric, selectedPlayerType]);
+  useEffect(reloadList, [selectedMetric, selectedPlayerType, selectedPlayerBuild]);
 
   return (
     <div className="top__container container">
@@ -132,7 +181,7 @@ function Top() {
           <Selector
             options={metricOptions}
             selectedIndex={metricIndex}
-            onSelect={onMetricSelected}
+            onSelect={handleMetricSelected}
             search
           />
         </div>
@@ -140,7 +189,14 @@ function Top() {
           <Selector
             options={playerTypeOptions}
             selectedIndex={playerTypeIndex}
-            onSelect={onTypeSelected}
+            onSelect={handleTypeSelected}
+          />
+        </div>
+        <div className="col-lg-3 col-md-5">
+          <Selector
+            options={playerBuildOptions}
+            selectedIndex={playerBuildIndex}
+            onSelect={handleBuildSelected}
           />
         </div>
         <div className="col-md-2">
@@ -150,39 +206,39 @@ function Top() {
       <div className="top__list row">
         <div className="col-lg-4 col-md-6">
           <h3 className="period-label">Day</h3>
-          {!leaderboard || !leaderboard.day ? (
+          {!leaderboards || !leaderboards.day ? (
             <TablePlaceholder size={20} />
           ) : (
             <Table
               uniqueKeySelector={dayTableConfig.uniqueKey}
               columns={dayTableConfig.columns}
-              rows={leaderboard.day}
+              rows={leaderboards.day}
               listStyle
             />
           )}
         </div>
         <div className="col-lg-4 col-md-6">
           <h3 className="period-label">Week</h3>
-          {!leaderboard || !leaderboard.week ? (
+          {!leaderboards || !leaderboards.week ? (
             <TablePlaceholder size={20} />
           ) : (
             <Table
               uniqueKeySelector={weekTableConfig.uniqueKey}
               columns={weekTableConfig.columns}
-              rows={leaderboard.week}
+              rows={leaderboards.week}
               listStyle
             />
           )}
         </div>
         <div className="col-lg-4 col-md-6">
           <h3 className="period-label">Month</h3>
-          {!leaderboard || !leaderboard.month ? (
+          {!leaderboards || !leaderboards.month ? (
             <TablePlaceholder size={20} />
           ) : (
             <Table
               uniqueKeySelector={monthTableConfig.uniqueKey}
               columns={monthTableConfig.columns}
-              rows={leaderboard.month}
+              rows={leaderboards.month}
               listStyle
             />
           )}

--- a/app/src/pages/Top/Top.jsx
+++ b/app/src/pages/Top/Top.jsx
@@ -9,7 +9,15 @@ import Table from '../../components/Table';
 import NumberLabel from '../../components/NumberLabel';
 import TablePlaceholder from '../../components/TablePlaceholder';
 import { PLAYER_TYPES, PLAYER_BUILDS, ALL_METRICS } from '../../config';
-import { capitalize, getPlayerIcon, getMetricIcon, getMetricName, isSkill, isBoss } from '../../utils';
+import {
+  capitalize,
+  getPlayerBuild,
+  getPlayerIcon,
+  getMetricIcon,
+  getMetricName,
+  isSkill,
+  isBoss
+} from '../../utils';
 import fetchLeaderboard from '../../redux/modules/deltas/actions/fetchLeaderboard';
 import {
   getLeaderboards,
@@ -59,7 +67,7 @@ function getPlayerTypeOptions() {
 
 function getPlayerBuildOptions() {
   const options = PLAYER_BUILDS.map(type => ({
-    label: capitalize(type),
+    label: getPlayerBuild(type),
     value: type
   }));
 

--- a/app/src/redux/modules/deltas/actions/fetchLeaderboard.js
+++ b/app/src/redux/modules/deltas/actions/fetchLeaderboard.js
@@ -3,39 +3,31 @@ import { BASE_API_URL } from '../../../../config';
 import {
   FETCH_LEADERBOARD_REQUEST,
   FETCH_LEADERBOARD_SUCCESS,
-  FETCH_LEADERBOARD_FAILURE,
+  FETCH_LEADERBOARD_FAILURE
 } from '../reducer';
 
-function fetchLeaderboardRequest() {
-  return {
-    type: FETCH_LEADERBOARD_REQUEST,
-  };
+function fetchLeaderboardRequest(period) {
+  return { type: FETCH_LEADERBOARD_REQUEST, period };
 }
 
-function fetchLeaderboardSuccess(data) {
-  return {
-    type: FETCH_LEADERBOARD_SUCCESS,
-    leaderboard: data,
-  };
+function fetchLeaderboardSuccess(period, data) {
+  return { type: FETCH_LEADERBOARD_SUCCESS, period, leaderboard: data };
 }
 
-function fetchLeaderboardFailure(error) {
-  return {
-    type: FETCH_LEADERBOARD_FAILURE,
-    error,
-  };
+function fetchLeaderboardFailure(period, error) {
+  return { type: FETCH_LEADERBOARD_FAILURE, period, error };
 }
 
-export default function fetchLeaderboard({ metric, playerType }) {
+export default function fetchLeaderboard(metric, period, playerType, playerBuild) {
   return dispatch => {
-    dispatch(fetchLeaderboardRequest());
+    dispatch(fetchLeaderboardRequest(period));
 
     const url = `${BASE_API_URL}/deltas/leaderboard/`;
-    const params = { metric, playerType };
+    const params = { metric, period, playerType, playerBuild };
 
     return axios
       .get(url, { params })
-      .then(result => dispatch(fetchLeaderboardSuccess(result.data)))
-      .catch(error => dispatch(fetchLeaderboardFailure(error)));
+      .then(result => dispatch(fetchLeaderboardSuccess(period, result.data)))
+      .catch(error => dispatch(fetchLeaderboardFailure(period, error)));
   };
 }

--- a/app/src/redux/modules/deltas/reducer.js
+++ b/app/src/redux/modules/deltas/reducer.js
@@ -11,24 +11,41 @@ export const FETCH_GROUP_DELTAS_SUCCESS = 'deltas/FETCH_GROUP_DELTAS_SUCCESS';
 export const FETCH_GROUP_DELTAS_FAILURE = 'deltas/FETCH_GROUP_DELTAS_FAILURE';
 
 const initialState = {
-  isFetchingLeaderboard: false,
+  isFetching: {
+    day: false,
+    week: false,
+    month: false
+  },
+  leaderboards: {
+    day: null,
+    week: null,
+    month: null
+  },
   isFetchingPlayerDeltas: false,
   isFetchingGroupDeltas: false,
   playerDeltas: {},
-  groupDeltas: {},
-  leaderboard: {}
+  groupDeltas: {}
 };
 
 export default function deltasReducer(state = initialState, action) {
   switch (action.type) {
     case FETCH_LEADERBOARD_REQUEST:
-      return { ...state, isFetchingLeaderboard: true };
+      return { ...state, isFetching: { ...state.isFetching, [action.period]: true } };
 
-    case FETCH_LEADERBOARD_SUCCESS:
-      return { ...state, isFetchingLeaderboard: false, leaderboard: action.leaderboard };
+    case FETCH_LEADERBOARD_SUCCESS: {
+      return {
+        ...state,
+        isFetching: { ...state.isFetching, [action.period]: false },
+        leaderboards: { ...state.leaderboards, [action.period]: action.leaderboard }
+      };
+    }
 
     case FETCH_LEADERBOARD_FAILURE:
-      return { ...state, isFetchingLeaderboard: false, error: action.error };
+      return {
+        ...state,
+        isFetching: { ...state.isFetching, [action.period]: false },
+        error: action.error
+      };
 
     case FETCH_PLAYER_DELTAS_REQUEST:
       return { ...state, isFetchingPlayerDeltas: true };

--- a/app/src/redux/modules/records/actions/fetchLeaderboard.js
+++ b/app/src/redux/modules/records/actions/fetchLeaderboard.js
@@ -1,37 +1,33 @@
 import axios from 'axios';
 import { BASE_API_URL } from '../../../../config';
-import { FETCH_LEADERBOARD_REQUEST, FETCH_LEADERBOARD_SUCCESS, FETCH_LEADERBOARD_FAILURE } from '../reducer';
+import {
+  FETCH_LEADERBOARD_REQUEST,
+  FETCH_LEADERBOARD_SUCCESS,
+  FETCH_LEADERBOARD_FAILURE
+} from '../reducer';
 
-function fetchLeaderboardRequest() {
-  return {
-    type: FETCH_LEADERBOARD_REQUEST
-  };
+function fetchLeaderboardRequest(period) {
+  return { type: FETCH_LEADERBOARD_REQUEST, period };
 }
 
-function fetchLeaderboardSuccess(data) {
-  return {
-    type: FETCH_LEADERBOARD_SUCCESS,
-    leaderboard: data
-  };
+function fetchLeaderboardSuccess(period, data) {
+  return { type: FETCH_LEADERBOARD_SUCCESS, period, leaderboard: data };
 }
 
-function fetchLeaderboardFailure(error) {
-  return {
-    type: FETCH_LEADERBOARD_FAILURE,
-    error
-  };
+function fetchLeaderboardFailure(period, error) {
+  return { type: FETCH_LEADERBOARD_FAILURE, period, error };
 }
 
-export default function fetchLeaderboard({ metric, playerType }) {
+export default function fetchLeaderboard(metric, period, playerType, playerBuild) {
   return dispatch => {
-    dispatch(fetchLeaderboardRequest());
+    dispatch(fetchLeaderboardRequest(period));
 
     const url = `${BASE_API_URL}/records/leaderboard/`;
-    const params = { metric, playerType };
+    const params = { metric, period, playerType, playerBuild };
 
     return axios
       .get(url, { params })
-      .then(result => dispatch(fetchLeaderboardSuccess(result.data)))
-      .catch(error => dispatch(fetchLeaderboardFailure(error)));
+      .then(result => dispatch(fetchLeaderboardSuccess(period, result.data)))
+      .catch(error => dispatch(fetchLeaderboardFailure(period, error)));
   };
 }

--- a/app/src/redux/modules/records/reducer.js
+++ b/app/src/redux/modules/records/reducer.js
@@ -11,24 +11,41 @@ export const FETCH_GROUP_RECORDS_SUCCESS = 'records/FETCH_GROUP_RECORDS_SUCCESS'
 export const FETCH_GROUP_RECORDS_FAILURE = 'records/FETCH_GROUP_RECORDS_FAILURE';
 
 const initialState = {
-  isFetchingLeaderboard: false,
+  isFetching: {
+    day: false,
+    week: false,
+    month: false
+  },
+  leaderboards: {
+    day: null,
+    week: null,
+    month: null
+  },
   isFetchingPlayerRecords: false,
   isFetchingGroupRecords: false,
   playerRecords: {},
-  groupRecords: {},
-  leaderboard: {}
+  groupRecords: {}
 };
 
 export default function recordsReducer(state = initialState, action) {
   switch (action.type) {
     case FETCH_LEADERBOARD_REQUEST:
-      return { ...state, isFetchingLeaderboard: true };
+      return { ...state, isFetching: { ...state.isFetching, [action.period]: true } };
 
-    case FETCH_LEADERBOARD_SUCCESS:
-      return { ...state, isFetchingLeaderboard: false, leaderboard: action.leaderboard };
+    case FETCH_LEADERBOARD_SUCCESS: {
+      return {
+        ...state,
+        isFetching: { ...state.isFetching, [action.period]: false },
+        leaderboards: { ...state.leaderboards, [action.period]: action.leaderboard }
+      };
+    }
 
     case FETCH_LEADERBOARD_FAILURE:
-      return { ...state, isFetchingLeaderboard: false, error: action.error };
+      return {
+        ...state,
+        isFetching: { ...state.isFetching, [action.period]: false },
+        error: action.error
+      };
 
     case FETCH_PLAYER_RECORDS_REQUEST:
       return { ...state, isFetchingPlayerRecords: true };

--- a/app/src/redux/selectors/deltas.js
+++ b/app/src/redux/selectors/deltas.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import { createSelector } from 'reselect';
 
 const rootSelector = state => state.deltas;
-const leaderboardSelector = state => state.deltas.leaderboard;
+const leaderboardsSelector = state => state.deltas.leaderboards;
 const playerDeltasSelector = state => state.deltas.playerDeltas;
 const groupDeltasSelector = state => state.deltas.groupDeltas;
 
@@ -17,10 +17,13 @@ const getGroupDeltasMap = createSelector(groupDeltasSelector, map => {
   );
 });
 
-export const isFetchingLeaderboard = createSelector(rootSelector, root => root.isFetchingLeaderboard);
+export const isFetchingDay = createSelector(rootSelector, root => root.isFetching.day);
+export const isFetchingWeek = createSelector(rootSelector, root => root.isFetching.week);
+export const isFetchingMonth = createSelector(rootSelector, root => root.isFetching.month);
+
 export const isFetchingGroupDeltas = createSelector(rootSelector, root => root.isFetchingGroupDeltas);
 
-export const getLeaderboard = createSelector(leaderboardSelector, map => {
+export const getLeaderboards = createSelector(leaderboardsSelector, map => {
   // Add a "rank" field to each delta of each period
   return _.mapValues(map, deltas => deltas.map((d, i) => ({ ...d, rank: i + 1 })));
 });

--- a/app/src/redux/selectors/deltas.js
+++ b/app/src/redux/selectors/deltas.js
@@ -25,7 +25,7 @@ export const isFetchingGroupDeltas = createSelector(rootSelector, root => root.i
 
 export const getLeaderboards = createSelector(leaderboardsSelector, map => {
   // Add a "rank" field to each delta of each period
-  return _.mapValues(map, deltas => deltas.map((d, i) => ({ ...d, rank: i + 1 })));
+  return _.mapValues(map, deltas => deltas && deltas.map((d, i) => ({ ...d, rank: i + 1 })));
 });
 
 export const getPlayerDeltas = (state, playerId) => getPlayerDeltasMap(state)[playerId];

--- a/app/src/redux/selectors/records.js
+++ b/app/src/redux/selectors/records.js
@@ -4,7 +4,7 @@ import { createSelector } from 'reselect';
 const rootSelector = state => state.records;
 const playerRecordsSelector = state => state.records.playerRecords;
 const groupRecordsSelector = state => state.records.groupRecords;
-const leaderboardSelector = state => state.records.leaderboard;
+const leaderboardsSelector = state => state.records.leaderboards;
 
 const getPlayerRecordsMap = createSelector(playerRecordsSelector, map => map);
 
@@ -13,12 +13,15 @@ const getGroupRecordsMap = createSelector(groupRecordsSelector, map => {
   return _.mapValues(map, hiscores => hiscores.map((d, i) => ({ ...d, rank: i + 1 })));
 });
 
-export const isFetchingLeaderboard = createSelector(rootSelector, root => root.isFetchingLeaderboard);
+export const isFetchingDay = createSelector(rootSelector, root => root.isFetching.day);
+export const isFetchingWeek = createSelector(rootSelector, root => root.isFetching.week);
+export const isFetchingMonth = createSelector(rootSelector, root => root.isFetching.month);
+
 export const isFetchingGroupRecords = createSelector(rootSelector, root => root.isFetchingGroupRecords);
 
-export const getLeaderboard = createSelector(leaderboardSelector, map => {
+export const getLeaderboards = createSelector(leaderboardsSelector, map => {
   // Add a "rank" field to each record of each period
-  return _.mapValues(map, records => records.map((r, i) => ({ ...r, rank: i + 1 })));
+  return _.mapValues(map, records => records && records.map((r, i) => ({ ...r, rank: i + 1 })));
 });
 
 export const getPlayerRecords = (state, playerId) => getPlayerRecordsMap(state)[playerId];

--- a/app/src/utils/player.js
+++ b/app/src/utils/player.js
@@ -2,6 +2,19 @@ export function getPlayerIcon(type, flagged) {
   return `/img/runescape/icons_small/${flagged ? 'flagged' : type}.png`;
 }
 
+export function getPlayerBuild(build) {
+  switch (build) {
+    case '1def':
+      return '1 Def Pure';
+    case 'lvl3':
+      return 'Level 3';
+    case 'f2p':
+      return 'F2P';
+    default:
+      return 'Main';
+  }
+}
+
 export function getOfficialHiscoresUrl(player) {
   const username = encodeURI(player.username);
   let suffix;

--- a/server/src/api/constants.ts
+++ b/server/src/api/constants.ts
@@ -109,6 +109,19 @@ export const BOSSES_MAP = [
   { key: 'zulrah', name: 'Zulrah' }
 ];
 
+export const MEMBER_SKILLS = [
+  'agility',
+  'construction',
+  'farming',
+  'fletching',
+  'herblore',
+  'hunter',
+  'thieving',
+  'slayer'
+];
+
+export const COMBAT_SKILLS = ['attack', 'strength', 'defence', 'hitpoints', 'ranged', 'prayer', 'magic'];
+
 export const SKILLS = SKILLS_MAP.map(s => s.key);
 export const ACTIVITIES = ACTIVITIES_MAP.map(s => s.key);
 export const BOSSES = BOSSES_MAP.map(s => s.key);

--- a/server/src/api/constants.ts
+++ b/server/src/api/constants.ts
@@ -120,6 +120,8 @@ export const MEMBER_SKILLS = [
   'slayer'
 ];
 
+export const F2P_BOSSES = ['obor', 'bryophyta'];
+
 export const COMBAT_SKILLS = ['attack', 'strength', 'defence', 'hitpoints', 'ranged', 'prayer', 'magic'];
 
 export const SKILLS = SKILLS_MAP.map(s => s.key);

--- a/server/src/api/constants.ts
+++ b/server/src/api/constants.ts
@@ -7,6 +7,8 @@ export const PLAYER_TYPES = ['unknown', 'regular', 'ironman', 'hardcore', 'ultim
 
 export const GROUP_ROLES = ['member', 'leader'];
 
+export const PLAYER_BUILDS = ['f2p', 'lvl3', '1def', 'main'];
+
 export const COMPETITION_STATUSES = ['upcoming', 'ongoing', 'finished'];
 
 export const OSRS_HISCORES = {

--- a/server/src/api/controllers/delta.controller.ts
+++ b/server/src/api/controllers/delta.controller.ts
@@ -3,11 +3,9 @@ import * as service from '../services/internal/delta.service';
 // GET /deltas/leaderboard
 async function leaderboard(req, res, next) {
   try {
-    const { metric, period, playerType } = req.query;
+    const { metric, period, playerType, playerBuild } = req.query;
 
-    const results = period
-      ? await service.getPeriodLeaderboard(metric, period, playerType)
-      : await service.getLeaderboard(metric, playerType);
+    const results = await service.getLeaderboard(metric, period, playerType, playerBuild);
 
     res.json(results);
   } catch (e) {

--- a/server/src/api/controllers/player.controller.ts
+++ b/server/src/api/controllers/player.controller.ts
@@ -40,7 +40,7 @@ async function assertType(req, res, next) {
     const { username } = req.body;
 
     // (Forcefully) Assert the player's account type
-    const type = await playerService.assertType(username, true);
+    const type = await playerService.assertType(username);
 
     res.json({ type });
   } catch (e) {

--- a/server/src/api/controllers/record.controller.ts
+++ b/server/src/api/controllers/record.controller.ts
@@ -3,11 +3,9 @@ import * as service from '../services/internal/record.service';
 // GET /records/leaderboard
 async function leaderboard(req, res, next) {
   try {
-    const { metric, period, playerType } = req.query;
+    const { metric, period, playerType, playerBuild } = req.query;
 
-    const result = period
-      ? await service.getPeriodLeaderboard(metric, period, playerType)
-      : await service.getLeaderboard(metric, playerType);
+    const result = await service.getLeaderboard(metric, period, playerType, playerBuild);
 
     res.json(result);
   } catch (e) {

--- a/server/src/api/jobs/instances/AssertPlayerType.ts
+++ b/server/src/api/jobs/instances/AssertPlayerType.ts
@@ -10,7 +10,7 @@ class AssertPlayerType implements Job {
 
   async handle(data: any): Promise<void> {
     const { username } = data;
-    await playerService.assertType(username, true);
+    await playerService.assertType(username);
   }
 }
 

--- a/server/src/api/services/internal/player.service.ts
+++ b/server/src/api/services/internal/player.service.ts
@@ -18,10 +18,7 @@ const DECADE_IN_SECONDS = 315569260;
  * "Hello_world  " -> "hello world"
  */
 function standardize(username: string): string {
-  return username
-    .replace(/[-_\s]/g, ' ')
-    .trim()
-    .toLowerCase();
+  return sanitize(username).toLowerCase();
 }
 
 function sanitize(username: string): string {
@@ -29,26 +26,18 @@ function sanitize(username: string): string {
 }
 
 function isValidUsername(username: string): boolean {
-  if (typeof username !== 'string') {
-    return false;
-  }
+  if (typeof username !== 'string') return false;
 
   const standardized = standardize(username);
 
   // If doesn't meet the size requirements
-  if (standardized.length < 1 || standardized.length > 12) {
-    return false;
-  }
+  if (standardized.length < 1 || standardized.length > 12) return false;
 
   // If starts or ends with a space
-  if (standardized.startsWith(' ') || standardized.endsWith(' ')) {
-    return false;
-  }
+  if (standardized.startsWith(' ') || standardized.endsWith(' ')) return false;
 
   // If has any special characters
-  if (!new RegExp(/^[a-zA-Z0-9 ]{1,12}$/).test(standardized)) {
-    return false;
-  }
+  if (!new RegExp(/^[a-zA-Z0-9 ]{1,12}$/).test(standardized)) return false;
 
   return true;
 }
@@ -61,8 +50,7 @@ function shouldUpdate(player: Player): [boolean, number] {
     return [true, DECADE_IN_SECONDS];
   }
 
-  const diff = Date.now() - player.updatedAt.getTime();
-  const seconds = Math.floor(diff / 1000);
+  const seconds = Math.floor((Date.now() - player.updatedAt.getTime()) / 1000);
 
   return [seconds >= 60, seconds];
 }
@@ -77,8 +65,7 @@ function shouldImport(player: Player): [boolean, number] {
     return [true, DECADE_IN_SECONDS];
   }
 
-  const diff = Date.now() - player.lastImportedAt.getTime();
-  const seconds = Math.floor(diff / 1000);
+  const seconds = Math.floor(Date.now() - player.lastImportedAt.getTime() / 1000);
 
   return [seconds / 60 / 60 >= 24, seconds];
 }
@@ -168,7 +155,7 @@ async function update(username: string): Promise<[Player, boolean]> {
     // If the player is new or has an unknown player type,
     // determine it before tracking (to get the correct ranks)
     if (player.type === 'unknown') {
-      player.type = await assertType(player.username);
+      player.type = await getType(player);
     }
 
     // Get the latest snapshot from the DB
@@ -263,9 +250,9 @@ async function importCMLSince(player: Player, time: number): Promise<Snapshot[]>
   return savedSnapshots;
 }
 
-async function fetchStats(player: Player): Promise<Snapshot> {
+async function fetchStats(player: Player, type?: string): Promise<Snapshot> {
   // Load data from OSRS hiscores
-  const hiscoresCSV = await jagexService.getHiscoresData(player.username, player.type);
+  const hiscoresCSV = await jagexService.getHiscoresData(player.username, type || player.type);
 
   // Convert the csv data to a Snapshot instance (saved in the DB)
   const newSnapshot = await snapshotService.fromRS(player.id, hiscoresCSV);
@@ -274,104 +261,52 @@ async function fetchStats(player: Player): Promise<Snapshot> {
 }
 
 /**
- * Gets a player's overall experience in a specific
- * player type hiscores endpoint.
- *
- * Note: This is an auxilary function for the assertType function
- * and should not be used for any other situation.
+ * Gets a player's overall exp in a specific hiscores endpoint.
+ * Note: This is an auxilary function for the getType function.
  */
-async function getOverallExperience(username: string, type: string): Promise<number> {
+async function getOverallExperience(player: Player, type: string): Promise<number> {
   try {
-    const data = await jagexService.getHiscoresData(username, type);
-
-    if (!data || data.length === 0) {
-      throw new ServerError('Failed to fetch hiscores data.');
-    }
-
-    const rows = data.split('\n');
-
-    if (!rows || rows.length === 0) {
-      throw new ServerError('Failed to fetch hiscores data.');
-    }
-
-    const values = rows[0].split(',');
-
-    if (values.length < 3) {
-      throw new ServerError('Failed to fetch hiscores data.');
-    }
-
-    return parseInt(values[2], 10);
+    return (await fetchStats(player, type)).overallExperience;
   } catch (e) {
     if (e instanceof ServerError) throw e;
     return -1;
   }
 }
 
-/**
- * Query the multiple hiscore endpoints to try and determine
- * the player's account type.
- *
- * If force is true, this will reassign the type, even if the current
- * value is not unknown.
- *
- * Note: If an hardcore acc dies at 1m overall exp, it stays that way in the
- * hardcore hiscores, even if the regular ironman hiscores continue to progress.
- * So to check if the player is no longer hardcore, we have to check if the
- * ironman exp is higher than the hardcore exp (meaning it progressed further as an ironman)
- */
-async function assertType(username, force = false) {
-  async function submitType(player, type) {
-    if (player.type === type) {
-      throw new BadRequestError(`Failed to reassign player type: ${username}'s is already ${type}.`);
-    }
+async function getType(player: Player): Promise<string> {
+  const regularExp = await getOverallExperience(player, 'regular');
 
+  // This username is not on the hiscores
+  if (regularExp === -1) {
+    throw new BadRequestError(`Failed to load hiscores for ${player.displayName}.`);
+  }
+
+  const ironmanExp = await getOverallExperience(player, 'ironman');
+  if (ironmanExp < regularExp) return 'regular';
+
+  const hardcoreExp = await getOverallExperience(player, 'hardcore');
+  if (hardcoreExp >= ironmanExp) return 'hardcore';
+
+  const ultimateExp = await getOverallExperience(player, 'ultimate');
+  if (ultimateExp >= ironmanExp) return 'ultimate';
+
+  return 'ironman';
+}
+
+async function assertType(username: string) {
+  if (!username) throw new BadRequestError('Invalid username.');
+
+  const player = await find(username);
+
+  if (!player) throw new NotFoundError('Player not found.');
+
+  const type = await getType(player);
+
+  if (player.type !== type) {
     await player.update({ type });
   }
 
-  if (!username) {
-    throw new BadRequestError('Invalid username.');
-  }
-
-  const formattedUsername = standardize(username);
-  const player = await find(formattedUsername);
-
-  if (!player) {
-    throw new BadRequestError(`Invalid player: ${username} is not being tracked yet.`);
-  }
-
-  if (!force && player.type !== 'unknown') {
-    return player.type;
-  }
-
-  const regularExp = await getOverallExperience(formattedUsername, 'regular');
-
-  if (regularExp === -1) {
-    throw new BadRequestError(`Failed to load hiscores for ${username}.`);
-  }
-
-  const ironmanExp = await getOverallExperience(formattedUsername, 'ironman');
-
-  if (ironmanExp < regularExp) {
-    await submitType(player, 'regular');
-    return 'regular';
-  }
-
-  const hardcoreExp = await getOverallExperience(formattedUsername, 'hardcore');
-
-  if (hardcoreExp >= ironmanExp) {
-    await submitType(player, 'hardcore');
-    return 'hardcore';
-  }
-
-  const ultimateExp = await getOverallExperience(formattedUsername, 'ultimate');
-
-  if (ultimateExp >= ironmanExp) {
-    await submitType(player, 'ultimate');
-    return 'ultimate';
-  }
-
-  await submitType(player, 'ironman');
-  return 'ironman';
+  return type;
 }
 
 /**

--- a/server/src/api/util/level.ts
+++ b/server/src/api/util/level.ts
@@ -3,6 +3,7 @@ import { Snapshot } from '../../database/models';
 import {
   BOSSES,
   COMBAT_SKILLS,
+  F2P_BOSSES,
   MAX_LEVEL,
   MAX_VIRTUAL_LEVEL,
   MEMBER_SKILLS,
@@ -12,7 +13,7 @@ import { getValueKey } from './metrics';
 
 function getLevel(exp: number, virtual = false): number {
   // Unranked
-  if (exp === -1) return 0;
+  if (exp === -1) return 1;
 
   const maxlevel = virtual ? MAX_VIRTUAL_LEVEL : MAX_LEVEL;
 
@@ -77,7 +78,7 @@ function get200msCount(snapshot: any) {
 
 function isF2p(snapshot: Snapshot) {
   const hasMemberStats = MEMBER_SKILLS.some(s => getLevel(snapshot[getValueKey(s)]) > 1);
-  const hasBossKc = BOSSES.some(b => snapshot[getValueKey(b)] > 0);
+  const hasBossKc = BOSSES.filter(b => !F2P_BOSSES.includes(b)).some(b => snapshot[getValueKey(b)] > 0);
 
   return !hasMemberStats && !hasBossKc;
 }
@@ -87,7 +88,7 @@ function isLvl3(snapshot: Snapshot) {
 }
 
 function is1Def(snapshot: Snapshot) {
-  return getLevel(snapshot.defenceExperience) <= 1;
+  return getLevel(snapshot.defenceExperience) === 1;
 }
 
 export { getLevel, getCombatLevel, getTotalLevel, get200msCount, is1Def, isF2p, isLvl3 };

--- a/server/src/api/util/level.ts
+++ b/server/src/api/util/level.ts
@@ -1,12 +1,18 @@
 import { pick, transform } from 'lodash';
-import { MAX_LEVEL, MAX_VIRTUAL_LEVEL, SKILLS } from '../constants';
+import { Snapshot } from '../../database/models';
+import {
+  BOSSES,
+  COMBAT_SKILLS,
+  MAX_LEVEL,
+  MAX_VIRTUAL_LEVEL,
+  MEMBER_SKILLS,
+  SKILLS
+} from '../constants';
 import { getValueKey } from './metrics';
 
-function getLevel(experience, virtual = false) {
+function getLevel(exp: number, virtual = false): number {
   // Unranked
-  if (experience === -1) {
-    return 0;
-  }
+  if (exp === -1) return 0;
 
   const maxlevel = virtual ? MAX_VIRTUAL_LEVEL : MAX_LEVEL;
 
@@ -15,7 +21,7 @@ function getLevel(experience, virtual = false) {
   for (let level = 1; level < maxlevel; level++) {
     const required = getXpDifferenceTo(level + 1);
 
-    if (experience >= accumulated && experience < accumulated + required) {
+    if (exp >= accumulated && exp < accumulated + required) {
       return level;
     }
 
@@ -25,17 +31,15 @@ function getLevel(experience, virtual = false) {
   return maxlevel;
 }
 
-function getXpDifferenceTo(level) {
+function getXpDifferenceTo(level: number): number {
   if (level < 2) return 0;
   return Math.floor(level - 1 + 300 * 2 ** ((level - 1) / 7)) / 4;
 }
 
 function getCombatLevel(snapshot: any) {
-  const combatSkills = ['attack', 'strength', 'defence', 'hitpoints', 'ranged', 'prayer', 'magic'];
-
   const combatExperiences = pick(
     snapshot,
-    combatSkills.map(s => `${s}Experience`)
+    COMBAT_SKILLS.map(s => getValueKey(s))
   );
 
   const levels: any = transform(combatExperiences, (r, v, k) => {
@@ -45,16 +49,16 @@ function getCombatLevel(snapshot: any) {
 
   // If the player has at least one of the stats as level 0 the calculation becomes incorrect
   // This is due to the player not being on the Hiscores
-  if (Object.values(levels).some(level => level === 0)) {
-    return 0;
-  }
+  if (Object.values(levels).some(level => level === 0)) return 0;
+
+  const { defence, hitpoints, prayer, attack, strength, ranged, magic } = levels;
 
   // Formula from https://oldschool.runescape.wiki/w/Combat_level
   // Calculate the combat level
-  const baseCombat = 0.25 * (levels.defence + levels.hitpoints + Math.floor(levels.prayer / 2));
-  const meleeCombat = 0.325 * (levels.attack + levels.strength);
-  const rangeCombat = 0.325 * Math.floor((3 * levels.ranged) / 2);
-  const mageCombat = 0.325 * Math.floor((3 * levels.magic) / 2);
+  const baseCombat = 0.25 * (defence + hitpoints + Math.floor(prayer / 2));
+  const meleeCombat = 0.325 * (attack + strength);
+  const rangeCombat = 0.325 * Math.floor((3 * ranged) / 2);
+  const mageCombat = 0.325 * Math.floor((3 * magic) / 2);
   const combatLevel = Math.floor(baseCombat + Math.max(meleeCombat, rangeCombat, mageCombat));
 
   return combatLevel;
@@ -71,4 +75,19 @@ function get200msCount(snapshot: any) {
   return validSkills.filter(skill => snapshot[getValueKey(skill)] === 200000000).length;
 }
 
-export { getLevel, getCombatLevel, getTotalLevel, get200msCount };
+function isF2p(snapshot: Snapshot) {
+  const hasMemberStats = MEMBER_SKILLS.some(s => getLevel(snapshot[getValueKey(s)]) > 1);
+  const hasBossKc = BOSSES.some(b => snapshot[getValueKey(b)] > 0);
+
+  return !hasMemberStats && !hasBossKc;
+}
+
+function isLvl3(snapshot: Snapshot) {
+  return getCombatLevel(snapshot) <= 3;
+}
+
+function is1Def(snapshot: Snapshot) {
+  return getLevel(snapshot.defenceExperience) <= 1;
+}
+
+export { getLevel, getCombatLevel, getTotalLevel, get200msCount, is1Def, isF2p, isLvl3 };

--- a/server/src/database/migrations/20200815180358-add-build-column.ts
+++ b/server/src/database/migrations/20200815180358-add-build-column.ts
@@ -1,0 +1,15 @@
+import { QueryInterface } from 'sequelize/types';
+
+function up(queryInterface: QueryInterface, dataTypes: any): Promise<void> {
+  return queryInterface.addColumn('players', 'build', {
+    type: dataTypes.STRING,
+    allowNull: false,
+    defaultValue: 'main'
+  });
+}
+
+function down(queryInterface: QueryInterface): Promise<void> {
+  return queryInterface.removeColumn('players', 'build');
+}
+
+export { up, down };

--- a/server/src/database/models/player.model.ts
+++ b/server/src/database/models/player.model.ts
@@ -10,7 +10,7 @@ import {
   Table,
   UpdatedAt
 } from 'sequelize-typescript';
-import { PLAYER_TYPES } from '../../api/constants';
+import { PLAYER_BUILDS, PLAYER_TYPES } from '../../api/constants';
 import {
   Achievement,
   Competition,
@@ -106,9 +106,7 @@ function validateType(this: Player) {
 }
 
 function validateBuild(this: Player) {
-  const builds = ['f2p', 'lvl3', '1def', 'main'];
-
-  if (!builds.includes(this.build)) {
+  if (!PLAYER_BUILDS.includes(this.build)) {
     throw new Error('Invalid player build.');
   }
 }

--- a/server/src/database/models/player.model.ts
+++ b/server/src/database/models/player.model.ts
@@ -30,7 +30,8 @@ const options = {
   validate: {
     validateUsername,
     validateDisplayName,
-    validateType
+    validateType,
+    validateBuild
   },
   indexes: [
     {
@@ -58,6 +59,9 @@ export default class Player extends Model<Player> {
   @Default(PLAYER_TYPES[0]) // unknown
   @Column({ type: DataType.ENUM(...PLAYER_TYPES), allowNull: false })
   type: string;
+
+  @Column({ type: DataType.STRING, allowNull: false, defaultValue: 'main' })
+  build: string;
 
   @Column({ type: DataType.BOOLEAN, defaultValue: false })
   flagged: boolean;
@@ -98,6 +102,14 @@ export default class Player extends Model<Player> {
 function validateType(this: Player) {
   if (!PLAYER_TYPES.includes(this.type)) {
     throw new Error('Invalid player type.');
+  }
+}
+
+function validateBuild(this: Player) {
+  const builds = ['f2p', 'lvl3', '1def', 'main'];
+
+  if (!builds.includes(this.build)) {
+    throw new Error('Invalid player build.');
   }
 }
 

--- a/server/src/database/queries.ts
+++ b/server/src/database/queries.ts
@@ -12,13 +12,10 @@ const GET_PLAYER_DELTA = `
 
 // Since sequelize's param escaping doesn't work too well with strings,
 // we should just inject some variables into the query directly
-const GET_PERIOD_LEADERBOARD = (metricKey, typeCondition) => `
+const GET_PERIOD_LEADERBOARD = (metricKey, typeCondition, buildCondition) => `
     SELECT
         player.id as "playerId",
-        player.username,
-        player."displayName",
-        player.type,
-        player.flagged,
+        player.*,
         c."minDate" AS "startDate",
         c."maxDate" AS "endDate",
         c."endValue",
@@ -40,7 +37,7 @@ const GET_PERIOD_LEADERBOARD = (metricKey, typeCondition) => `
         FROM "initialValues"
         GROUP BY "pId"
     ) i ON player.id = i."pId"
-    WHERE ${typeCondition}
+    WHERE ${typeCondition} ${buildCondition}
     ORDER BY gained DESC
     LIMIT 20`;
 


### PR DESCRIPTION
- Add `build` column to player model
- Add build check on player update
- Some cleanups and refactors in the player service
- Add build badges on player profiles (image below)
- Add player build filters to delta and record leaderboard endpoints
- Add lazy loading to `/top` and `/records` pages
- Add player build filters to `/top` and `/records` pages (**These will not be visible until 20th of August, to allow for some time to pass, so that more players can be updated, preventing empty leaderboards**)

![](https://i.gyazo.com/ad1bff0af3dc592301d5172c0e8c535f.png)
