### PR TITLE
feat: Add 10 HP as an account build

### DIFF
--- a/app/src/config/player.js
+++ b/app/src/config/player.js
@@ -1,2 +1,2 @@
 export const PLAYER_TYPES = ['regular', 'ironman', 'ultimate', 'hardcore'];
-export const PLAYER_BUILDS = ['lvl3', 'f2p', '1def', 'main'];
+export const PLAYER_BUILDS = ['lvl3', 'f2p', '1def', '10hp', 'main'];

--- a/app/src/pages/Player/Player.jsx
+++ b/app/src/pages/Player/Player.jsx
@@ -76,7 +76,7 @@ function getPlayerBadges(build) {
     case '1def':
       return [{ text: '1 Def Pure', hoverText: '' }];
     case '10hp':
-      return [{ text: '10 Hitpoints Pure', hoverText: '' }]
+      return [{ text: '10 HP Pure', hoverText: '' }]
     default:
       return [];
   }

--- a/app/src/pages/Player/Player.jsx
+++ b/app/src/pages/Player/Player.jsx
@@ -75,6 +75,8 @@ function getPlayerBadges(build) {
       return [{ text: 'F2P', hoverText: '' }];
     case '1def':
       return [{ text: '1 Def Pure', hoverText: '' }];
+    case '10hp':
+      return [{ text: '10 Hitpoints Pure', hoverText: '' }]
     default:
       return [];
   }

--- a/app/src/utils/player.js
+++ b/app/src/utils/player.js
@@ -10,6 +10,8 @@ export function getPlayerBuild(build) {
       return 'Level 3';
     case 'f2p':
       return 'F2P';
+    case '10hp':
+      return '10 Hitpoints Pure';
     default:
       return 'Main';
   }

--- a/docs/src/configs/docs/players/entities.js
+++ b/docs/src/configs/docs/players/entities.js
@@ -58,6 +58,6 @@ export default [
   {
     name: 'Player Builds',
     description: 'All the possible values for the "build" field of the player model.',
-    values: ['main', '1def', 'lvl3', 'f2p']
+    values: ['main', '1def', 'lvl3', '10hp', 'f2p']
   }
 ];

--- a/server/src/api/constants.ts
+++ b/server/src/api/constants.ts
@@ -7,7 +7,7 @@ export const PLAYER_TYPES = ['unknown', 'regular', 'ironman', 'hardcore', 'ultim
 
 export const GROUP_ROLES = ['member', 'leader'];
 
-export const PLAYER_BUILDS = ['f2p', 'lvl3', '1def', 'main'];
+export const PLAYER_BUILDS = ['f2p', 'lvl3', '1def', '10hp', 'main'];
 
 export const COMPETITION_STATUSES = ['upcoming', 'ongoing', 'finished'];
 

--- a/server/src/api/services/internal/player.service.ts
+++ b/server/src/api/services/internal/player.service.ts
@@ -2,7 +2,7 @@ import { Op } from 'sequelize';
 import { Player, Snapshot } from '../../../database/models';
 import { BadRequestError, NotFoundError, RateLimitError, ServerError } from '../../errors';
 import { isValidDate } from '../../util/dates';
-import { getCombatLevel, is1Def, isF2p, isLvl3 } from '../../util/level';
+import { getCombatLevel, is1Def, isF2p, isLvl3, is10HP } from '../../util/level';
 import * as cmlService from '../external/cml.service';
 import * as jagexService from '../external/jagex.service';
 import * as snapshotService from './snapshot.service';
@@ -355,6 +355,11 @@ function getBuild(snapshot: Snapshot) {
 
   if (isLvl3(snapshot)) {
     return 'lvl3';
+  }
+
+  // This must be above 1def because 10 HP accounts can also have 1 def
+  if (is10HP(snapshot)) {
+    return '10hp';
   }
 
   if (is1Def(snapshot)) {

--- a/server/src/api/util/level.ts
+++ b/server/src/api/util/level.ts
@@ -91,4 +91,8 @@ function is1Def(snapshot: Snapshot) {
   return getLevel(snapshot.defenceExperience) === 1;
 }
 
-export { getLevel, getCombatLevel, getTotalLevel, get200msCount, is1Def, isF2p, isLvl3 };
+function is10HP(snapshot: Snapshot) {
+  return getCombatLevel(snapshot) > 3 && getLevel(snapshot.hitpointsExperience) <= 10;
+}
+
+export { getLevel, getCombatLevel, getTotalLevel, get200msCount, is1Def, isF2p, isLvl3, is10HP };

--- a/server/src/api/util/level.ts
+++ b/server/src/api/util/level.ts
@@ -92,7 +92,7 @@ function is1Def(snapshot: Snapshot) {
 }
 
 function is10HP(snapshot: Snapshot) {
-  return getCombatLevel(snapshot) > 3 && getLevel(snapshot.hitpointsExperience) <= 10;
+  return getCombatLevel(snapshot) > 3 && getLevel(snapshot.hitpointsExperience) === 10;
 }
 
 export { getLevel, getCombatLevel, getTotalLevel, get200msCount, is1Def, isF2p, isLvl3, is10HP };


### PR DESCRIPTION
Add support for showing '10 Hitpoints Pure' for an account that has 10 HP and is higher than 3 CB (so not a skiller)