### PR TITLE
Use displayName instead of username for label

### DIFF
--- a/app/src/redux/selectors/competitions.js
+++ b/app/src/redux/selectors/competitions.js
@@ -66,7 +66,7 @@ export const getChartData = (state, id) => {
     datasets.push({
       borderColor: COLORS[i],
       pointBorderWidth: 1,
-      label: participant.username,
+      label: participant.displayName,
       data: filteredPoints,
       fill: false
     });


### PR DESCRIPTION
Fixes name not being capitalized on top progress charts of competitions. This fixes #400 

![image](https://user-images.githubusercontent.com/35583098/94865307-5a3c8880-040b-11eb-99d7-c27095631f93.png)
