### PR TITLE
Show pointer on legend label hover

### DIFF
--- a/app/src/components/LineChart/LineChart.jsx
+++ b/app/src/components/LineChart/LineChart.jsx
@@ -20,8 +20,10 @@ function getConfig(datasets, invertYAxis) {
           usePointStyle: true,
           boxWidth: 6,
           fontColor: 'white',
-          padding: 30
-        }
+          padding: 30,
+        },
+        onHover: (e) => { e.target.style.cursor = 'pointer' },
+        onLeave: (e) => { e.target.style.cursor = 'default' }
       },
       hover: {
         mode: 'point'


### PR DESCRIPTION
Hovering over chart.js line chart legend items did not show a pointer as expected. Adding `onHover` and `onLeave` to change the elements cursor fixes this. This fixes #405 