### PR TITLE
Fix group records updatedAt date

### DIFF
--- a/app/src/pages/Group/components/GroupRecords/GroupRecords.jsx
+++ b/app/src/pages/Group/components/GroupRecords/GroupRecords.jsx
@@ -31,7 +31,7 @@ const TABLE_CONFIG = {
       key: 'updatedAt',
       label: 'Date',
       className: () => '-break-small',
-      transform: (value, row) => formatDate(row.player.updatedAt, 'DD MMM, YYYY')
+      transform: (value, row) => formatDate(row.updatedAt, 'DD MMM, YYYY')
     }
   ]
 };


### PR DESCRIPTION
The table was showing the player last update date, instead of the record's.