### PR TITLE
Fix/leaderboards ui

### DIFF
--- a/app/src/pages/EhbRates/EhbRates.jsx
+++ b/app/src/pages/EhbRates/EhbRates.jsx
@@ -33,8 +33,7 @@ const RATES_TABLE_CONFIG = {
 function getTypeOptions() {
   return [
     { label: 'Main', value: 'main' },
-    { label: 'Ironman', value: 'ironman' },
-    { label: 'F2P', value: 'f2p' }
+    { label: 'Ironman', value: 'ironman' }
   ];
 }
 

--- a/app/src/pages/Leaderboards/Leaderboards.jsx
+++ b/app/src/pages/Leaderboards/Leaderboards.jsx
@@ -84,13 +84,11 @@ function useQuery(keys) {
 }
 
 function getPlayerTypeOptions() {
-  const options = PLAYER_TYPES.map(type => ({
+  return PLAYER_TYPES.map(type => ({
     label: capitalize(type),
     icon: getPlayerIcon(type),
     value: type
   }));
-
-  return [{ label: 'All player types', value: null }, ...options];
 }
 
 function getPlayerBuildOptions() {
@@ -119,7 +117,7 @@ function Leaderboards() {
   const [pageIndex, setPageIndex] = useState(0);
 
   const selectedMetric = metric || 'ehp';
-  const selectedPlayerType = type || null;
+  const selectedPlayerType = type || 'regular';
   const selectedPlayerBuild = build || null;
 
   const tableConfig = useMemo(() => getTableConfig(selectedMetric), [selectedMetric]);


### PR DESCRIPTION
- Removes the "All Player Types" option from the Leaderboard pages, as each player's ehp/ehb is dependant on their player type/build, so comparing every type of player would not be correct.

- Removes F2P EHB from the EHB Rates page.