### PR TITLE
Fix/trailblazer flagging

### DIFF
--- a/server/src/api/services/internal/snapshot.service.ts
+++ b/server/src/api/services/internal/snapshot.service.ts
@@ -71,7 +71,9 @@ function hasExcessiveGains(before: Snapshot, after: Snapshot): boolean {
   const ehpDiff = efficiencyService.calculateEHPDiff(before, after);
   const ehbDiff = efficiencyService.calculateEHBDiff(before, after);
 
-  return ehpDiff + ehbDiff > hoursDiff;
+  const leagueExpModifier = 20;
+
+  return ehpDiff * leagueExpModifier + ehbDiff > hoursDiff;
 }
 
 /**

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,5 +1,5 @@
-import env from './env';
 import api from './api';
+import env from './env';
 
 const port = env.PORT || 6000;
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,5 +1,5 @@
-import api from './api';
 import env from './env';
+import api from './api';
 
 const port = env.PORT || 6000;
 


### PR DESCRIPTION
Since the league has increased exp rates, people were getting "too much exp in a short amount of time" and would then get flagged as having had their names changed. 

This adds a x20 modifier which should fix this for now.

This will require some more work in the future to properly fix.