### PR TITLE
Wrap league jobs with tb prefix

### DIFF
--- a/server/src/api/jobs/index.ts
+++ b/server/src/api/jobs/index.ts
@@ -18,13 +18,17 @@ enum JobPriority {
   Low = 3
 }
 
+function wrapJobName(name) {
+  return `tb_${name}`;
+}
+
 class JobHandler {
   private queues;
 
   constructor() {
     this.queues = jobs.map((job: Job) => ({
-      bull: new Queue(job.name, redisConfig),
-      name: job.name,
+      bull: new Queue(wrapJobName(job.name), redisConfig),
+      name: wrapJobName(job.name),
       handle: job.handle,
       onFailure: job.onFailure,
       onSuccess: job.onSuccess
@@ -39,7 +43,7 @@ class JobHandler {
       return;
     }
 
-    const queue = this.queues.find(q => q.name === name);
+    const queue = this.queues.find(q => q.name === wrapJobName(name));
 
     if (!queue) {
       throw new Error(`No job found for name ${name}`);


### PR DESCRIPTION
Cron jobs aren't working on the main website (and probably leagues too).

My suspicion is since both the league and main jobs have the same names, redis might be routing them incorrectly, so I'm not adding a prefix to league jobs.

We'll see if it works or not.