### PR TITLE
Fix league tiers calculating off overall rank

### DIFF
--- a/server/src/api/constants.ts
+++ b/server/src/api/constants.ts
@@ -21,7 +21,7 @@ export const OSRS_HISCORES = {
   ultimate: 'https://services.runescape.com/m=hiscore_oldschool_ultimate/index_lite.ws',
   seasonal: 'https://services.runescape.com/m=hiscore_oldschool_seasonal/index_lite.ws',
   nameCheck: 'https://secure.runescape.com/m=hiscore_oldschool/overall?table=0',
-  leagueRankCheck: 'https://secure.runescape.com/m=hiscore_oldschool_seasonal/overall?table=0' // &page=6699
+  leagueRank: 'https://secure.runescape.com/m=hiscore_oldschool_seasonal/overall?category_type=1&table=0' // &page=6699
 };
 
 export const CML = {

--- a/server/src/api/services/external/jagex.service.ts
+++ b/server/src/api/services/external/jagex.service.ts
@@ -71,7 +71,7 @@ function getHiscoresTableColumns(data: string, columnIndex: number): string[] {
 
 async function getLeagueTableRanks(pageIndex: number): Promise<string[]> {
   const proxy = proxiesService.getNextProxy();
-  const URL = `${OSRS_HISCORES.leagueRankCheck}&page=${pageIndex}`;
+  const URL = `${OSRS_HISCORES.leagueRank}&page=${pageIndex}`;
 
   try {
     // Fetch the data through the API Url

--- a/server/src/api/services/internal/league.service.ts
+++ b/server/src/api/services/internal/league.service.ts
@@ -10,11 +10,11 @@ const TIERS = [
   { name: 'dragon', threshold: 1 }
 ];
 
-async function getPlayerTier(overallRank: number) {
-  if (!overallRank) return TIERS[0].name;
+async function getPlayerTier(leaguePointsRank: number) {
+  if (!leaguePointsRank) return TIERS[0].name;
 
   const tierThresholds = await getTierRankThresholds();
-  const playerTier = tierThresholds.reverse().find(tier => tier.threshold > overallRank);
+  const playerTier = tierThresholds.reverse().find(tier => tier.threshold > leaguePointsRank);
 
   return playerTier.name || TIERS[0].name;
 }

--- a/server/src/api/services/internal/player.service.ts
+++ b/server/src/api/services/internal/player.service.ts
@@ -149,7 +149,7 @@ async function update(username: string): Promise<[PlayerDetails, boolean]> {
     player.flagged = false;
 
     const virtuals = await efficiencyService.calcPlayerVirtuals(player, currentStats);
-    const leagueTier = await leagueService.getPlayerTier(currentStats.overallRank);
+    const leagueTier = await leagueService.getPlayerTier(currentStats.league_pointsRank);
 
     // Set the player's global virtual data
     player.exp = currentStats.overallExperience;


### PR DESCRIPTION
The current tiers are being calculated from the overall rank and this is incorrect. 

The minimum threshold for bronze tier is 100 points, and luckily that is the minimum points that a ranked (hiscores) player can have. This makes it easy to change the tier calcs.