### PR TITLE
Tweak name change auto approval to be more forgiving

### DIFF
--- a/server/src/api/jobs/config/crons.ts
+++ b/server/src/api/jobs/config/crons.ts
@@ -5,6 +5,6 @@ export default [
   },
   {
     jobName: 'RefreshNameChanges',
-    cronConfig: '0 */6 * * *' // every 6 hours
+    cronConfig: '0 */3 * * *' // every 3 hours
   }
 ];

--- a/server/src/api/services/internal/name.service.ts
+++ b/server/src/api/services/internal/name.service.ts
@@ -234,8 +234,8 @@ async function autoReview(id: number): Promise<void> {
     return;
   }
 
-  // If the transition period is over 2 weeks
-  if (hoursDiff > 336) {
+  // If the transition period is over 3 weeks
+  if (hoursDiff > 504) {
     return;
   }
 
@@ -249,7 +249,7 @@ async function autoReview(id: number): Promise<void> {
     .reduce((acc, cur) => acc + cur);
 
   // If is high level enough (high level swaps are harder to fake)
-  if (totalLevel < 1000) {
+  if (totalLevel < 700) {
     return;
   }
 


### PR DESCRIPTION
- The maximum transition gap is now 3 weeks (previously 2)
- The minimum total level is now 700 (previously 1000)
- The auto approval process will be ran every 3 hours (previously 6)