### PR TITLE
feature: Auto-deny negative gain name changes

### DIFF
--- a/server/src/api/services/internal/name.service.ts
+++ b/server/src/api/services/internal/name.service.ts
@@ -229,8 +229,9 @@ async function autoReview(id: number): Promise<void> {
     return;
   }
 
-  // If has lost exp/kills/scores
+  // If has lost exp/kills/scores, deny request
   if (hasNegativeGains) {
+    await deny(id, env.ADMIN_PASSWORD);
     return;
   }
 


### PR DESCRIPTION
Automatically denies any name changes with negative gains between old and new usernames.

This should reduce the amount of manual reviews I have to do.