### PR TITLE
Feat/player last changed

### DIFF
--- a/app/src/pages/Player/components/PlayerInfo/PlayerInfo.jsx
+++ b/app/src/pages/Player/components/PlayerInfo/PlayerInfo.jsx
@@ -4,7 +4,7 @@ import InfoPanel from '../../../../components/InfoPanel';
 import { capitalize, formatDate } from '../../../../utils';
 
 function formatData(player) {
-  const { id, type, build, registeredAt, updatedAt } = player;
+  const { id, type, build, registeredAt, updatedAt, lastChangedAt } = player;
 
   return [
     {
@@ -20,12 +20,16 @@ function formatData(player) {
       value: capitalize(build)
     },
     {
-      key: 'Registered at',
-      value: formatDate(registeredAt, 'DD MMM YYYY, HH:mm')
-    },
-    {
       key: 'Last updated at',
       value: formatDate(updatedAt, 'DD MMM YYYY, HH:mm')
+    },
+    {
+      key: 'Last changed at',
+      value: lastChangedAt ? formatDate(lastChangedAt, 'DD MMM YYYY, HH:mm') : 'Unknown'
+    },
+    {
+      key: 'Registered at',
+      value: formatDate(registeredAt, 'DD MMM YYYY, HH:mm')
     }
   ];
 }

--- a/docs/src/configs/docs/competitions/endpoints.js
+++ b/docs/src/configs/docs/competitions/endpoints.js
@@ -204,6 +204,7 @@ export default [
               build: 'main',
               flagged: false,
               lastImportedAt: '2020-03-27T21:56:50.000Z',
+              lastChangedAt: '2020-11-26T06:30:14.825Z',
               registeredAt: '2020-03-13T23:29:57.000Z',
               updatedAt: '2020-03-27T21:56:50.000Z'
             },
@@ -215,6 +216,7 @@ export default [
               build: 'main',
               flagged: false,
               lastImportedAt: '2020-03-15T02:21:49.000Z',
+              lastChangedAt: '2020-11-26T06:30:14.825Z',
               registeredAt: '2020-03-15T02:21:46.000Z',
               updatedAt: '2020-03-15T02:21:49.000Z'
             }
@@ -309,6 +311,7 @@ export default [
               build: 'main',
               flagged: false,
               lastImportedAt: '2020-04-04T22:33:53.450Z',
+              lastChangedAt: '2020-11-26T06:30:14.825Z',
               registeredAt: '2020-04-03T21:43:17.574Z',
               updatedAt: '2020-04-04T22:35:31.530Z'
             },
@@ -320,6 +323,7 @@ export default [
               build: 'main',
               flagged: false,
               lastImportedAt: null,
+              lastChangedAt: '2020-11-26T06:30:14.825Z',
               registeredAt: '2020-04-03T23:48:03.561Z',
               updatedAt: '2020-04-04T16:43:30.787Z'
             },
@@ -331,6 +335,7 @@ export default [
               build: 'main',
               flagged: false,
               lastImportedAt: null,
+              lastChangedAt: '2020-11-26T06:30:14.825Z',
               registeredAt: '2020-04-04T23:44:53.755Z',
               updatedAt: '2020-04-04T23:44:53.755Z'
             }
@@ -461,7 +466,8 @@ export default [
               flagged: false,
               updatedAt: '2020-04-04T23:59:58.661Z',
               registeredAt: '2020-04-04T23:59:58.661Z',
-              lastImportedAt: null
+              lastImportedAt: null,
+              lastChangedAt: '2020-11-26T06:30:14.825Z'
             }
           ]
         }

--- a/docs/src/configs/docs/deltas/endpoints.js
+++ b/docs/src/configs/docs/deltas/endpoints.js
@@ -42,6 +42,7 @@ export default [
               build: 'main',
               flagged: false,
               lastImportedAt: '2020-08-30T01:41:49.077Z',
+              lastChangedAt: '2020-11-26T06:30:14.825Z',
               registeredAt: '2020-05-14T14:33:32.249Z',
               updatedAt: '2020-08-30T01:41:49.077Z'
             }
@@ -58,6 +59,7 @@ export default [
               build: 'main',
               flagged: false,
               lastImportedAt: '2020-08-30T23:48:35.941Z',
+              lastChangedAt: '2020-11-26T06:30:14.825Z',
               registeredAt: '2020-04-15T13:21:12.033Z',
               updatedAt: '2020-09-03T03:49:14.300Z'
             }
@@ -74,6 +76,7 @@ export default [
               build: 'main',
               flagged: false,
               lastImportedAt: '2020-08-30T01:26:24.762Z',
+              lastChangedAt: '2020-11-26T06:30:14.825Z',
               registeredAt: '2020-05-14T14:33:32.392Z',
               updatedAt: '2020-08-30T01:26:24.762Z'
             }

--- a/docs/src/configs/docs/groups/endpoints.js
+++ b/docs/src/configs/docs/groups/endpoints.js
@@ -1064,7 +1064,6 @@ export default [
               flagged: false,
               lastImportedAt: '2020-04-18T02:23:59.945Z',
               lastChangedAt: '2020-11-26T06:30:14.825Z',
-              lastChangedAt: '2020-11-26T06:30:14.825Z',
               registeredAt: '2020-04-10T18:11:52.333Z',
               updatedAt: '2020-04-18T03:22:36.419Z',
               role: 'leader'

--- a/docs/src/configs/docs/groups/endpoints.js
+++ b/docs/src/configs/docs/groups/endpoints.js
@@ -124,6 +124,7 @@ export default [
             build: 'main',
             flagged: false,
             lastImportedAt: null,
+            lastChangedAt: '2020-11-26T06:30:14.825Z',
             registeredAt: '2020-05-02T20:35:05.251Z',
             updatedAt: '2020-05-03T01:08:18.827Z',
             role: 'leader',
@@ -137,6 +138,7 @@ export default [
             flagged: false,
             type: 'regular',
             lastImportedAt: '2020-05-03T01:27:05.764Z',
+            lastChangedAt: '2020-11-26T06:30:14.825Z',
             registeredAt: '2020-05-02T20:35:06.302Z',
             updatedAt: '2020-05-03T01:49:14.712Z',
             role: 'member',
@@ -300,6 +302,7 @@ export default [
                 build: 'main',
                 flagged: false,
                 lastImportedAt: '2020-08-24T16:29:13.227Z',
+                lastChangedAt: '2020-11-26T06:30:14.825Z',
                 registeredAt: '2020-04-28T18:46:19.553Z',
                 updatedAt: '2020-08-26T22:07:37.104Z'
               }
@@ -316,6 +319,7 @@ export default [
                 build: 'main',
                 flagged: false,
                 lastImportedAt: '2020-08-22T20:20:32.956Z',
+                lastChangedAt: '2020-11-26T06:30:14.825Z',
                 registeredAt: '2020-04-28T19:25:58.626Z',
                 updatedAt: '2020-08-26T22:07:39.384Z'
               }
@@ -332,6 +336,7 @@ export default [
                 build: 'main',
                 flagged: false,
                 lastImportedAt: '2020-08-22T23:41:14.792Z',
+                lastChangedAt: '2020-11-26T06:30:14.825Z',
                 registeredAt: '2020-04-27T20:46:08.951Z',
                 updatedAt: '2020-08-26T22:02:42.961Z'
               }
@@ -411,6 +416,7 @@ export default [
             build: 'main',
             flagged: false,
             lastImportedAt: '2020-05-14T00:21:28.251Z',
+            lastChangedAt: '2020-11-26T06:30:14.825Z',
             registeredAt: '2020-04-15T13:03:28.396Z',
             updatedAt: '2020-06-02T23:37:26.348Z',
             rank: 171,
@@ -425,6 +431,7 @@ export default [
             build: 'main',
             flagged: false,
             lastImportedAt: '2020-05-13T23:14:52.828Z',
+            lastChangedAt: '2020-11-26T06:30:14.825Z',
             registeredAt: '2020-04-28T17:56:45.960Z',
             updatedAt: '2020-06-02T23:41:18.937Z',
             rank: 888,
@@ -439,6 +446,7 @@ export default [
             build: 'main',
             flagged: false,
             lastImportedAt: null,
+            lastChangedAt: '2020-11-26T06:30:14.825Z',
             registeredAt: '2020-04-28T22:00:09.281Z',
             updatedAt: '2020-06-03T00:58:50.838Z',
             rank: 1141,
@@ -794,6 +802,7 @@ export default [
               build: 'main',
               flagged: false,
               lastImportedAt: '2020-04-19T17:21:12.258Z',
+              lastChangedAt: '2020-11-26T06:30:14.825Z',
               registeredAt: '2020-04-10T18:11:02.544Z',
               updatedAt: '2020-04-20T23:55:14.540Z',
               role: 'leader'
@@ -806,6 +815,7 @@ export default [
               build: 'main',
               flagged: false,
               lastImportedAt: '2020-04-18T02:23:59.945Z',
+              lastChangedAt: '2020-11-26T06:30:14.825Z',
               registeredAt: '2020-04-10T18:11:52.333Z',
               updatedAt: '2020-04-20T23:55:19.286Z',
               role: 'member'
@@ -818,6 +828,7 @@ export default [
               build: 'main',
               flagged: false,
               lastImportedAt: '2020-04-11T01:02:25.132Z',
+              lastChangedAt: '2020-11-26T06:30:14.825Z',
               registeredAt: '2020-04-11T01:02:06.424Z',
               updatedAt: '2020-04-20T23:55:24.007Z',
               role: 'leader'
@@ -830,6 +841,7 @@ export default [
               build: 'main',
               flagged: false,
               lastImportedAt: null,
+              lastChangedAt: '2020-11-26T06:30:14.825Z',
               registeredAt: '2020-04-23T01:53:26.156Z',
               updatedAt: '2020-04-23T01:53:26.156Z',
               role: 'member'
@@ -908,6 +920,7 @@ export default [
               build: 'main',
               flagged: false,
               lastImportedAt: '2020-04-18T02:22:49.364Z',
+              lastChangedAt: '2020-11-26T06:30:14.825Z',
               registeredAt: '2020-04-10T18:11:02.544Z',
               updatedAt: '2020-04-18T04:02:42.235Z',
               role: 'member'
@@ -920,6 +933,7 @@ export default [
               build: 'main',
               flagged: false,
               lastImportedAt: '2020-04-11T01:02:25.132Z',
+              lastChangedAt: '2020-11-26T06:30:14.825Z',
               registeredAt: '2020-04-11T01:02:06.424Z',
               updatedAt: '2020-04-18T03:40:17.940Z',
               role: 'member'
@@ -1049,6 +1063,8 @@ export default [
               build: 'main',
               flagged: false,
               lastImportedAt: '2020-04-18T02:23:59.945Z',
+              lastChangedAt: '2020-11-26T06:30:14.825Z',
+              lastChangedAt: '2020-11-26T06:30:14.825Z',
               registeredAt: '2020-04-10T18:11:52.333Z',
               updatedAt: '2020-04-18T03:22:36.419Z',
               role: 'leader'
@@ -1061,6 +1077,7 @@ export default [
               build: 'main',
               flagged: false,
               lastImportedAt: '2020-04-18T02:23:59.945Z',
+              lastChangedAt: '2020-11-26T06:30:14.825Z',
               registeredAt: '2020-04-10T18:11:52.333Z',
               updatedAt: '2020-04-18T03:22:36.419Z',
               role: 'member'
@@ -1194,6 +1211,7 @@ export default [
             build: 'main',
             flagged: false,
             lastImportedAt: '2020-04-18T02:22:49.364Z',
+            lastChangedAt: '2020-11-26T06:30:14.825Z',
             registeredAt: '2020-04-10T18:11:02.544Z',
             updatedAt: '2020-04-18T04:02:42.235Z',
             role: 'leader'

--- a/docs/src/configs/docs/players/endpoints.js
+++ b/docs/src/configs/docs/players/endpoints.js
@@ -28,6 +28,7 @@ export default [
             build: 'main',
             flagged: false,
             lastImportedAt: '2020-08-09T09:08:42.573Z',
+            lastChangedAt: '2020-11-26T06:30:14.825Z',
             registeredAt: '2020-07-31T09:41:00.833Z',
             updatedAt: '2020-08-09T21:16:42.420Z'
           },
@@ -39,6 +40,7 @@ export default [
             build: 'main',
             flagged: false,
             lastImportedAt: null,
+            lastChangedAt: '2020-11-26T06:30:14.825Z',
             registeredAt: '2020-07-31T22:33:17.388Z',
             updatedAt: '2020-07-31T22:33:17.388Z'
           },
@@ -50,6 +52,7 @@ export default [
             build: 'main',
             flagged: false,
             lastImportedAt: '2020-09-06T03:50:33.069Z',
+            lastChangedAt: '2020-11-26T06:30:14.825Z',
             registeredAt: '2020-08-01T03:11:47.081Z',
             updatedAt: '2020-09-06T13:44:34.779Z'
           },
@@ -61,6 +64,7 @@ export default [
             build: 'main',
             flagged: false,
             lastImportedAt: '2020-09-06T19:24:26.611Z',
+            lastChangedAt: '2020-11-26T06:30:14.825Z',
             registeredAt: '2020-08-01T09:43:11.461Z',
             updatedAt: '2020-09-06T19:24:26.611Z'
           }
@@ -102,6 +106,7 @@ export default [
           build: 'main',
           flagged: false,
           lastImportedAt: '2020-09-13T23:46:06.779Z',
+          lastChangedAt: '2020-11-26T06:30:14.825Z',
           registeredAt: '2020-09-13T23:42:53.316Z',
           updatedAt: '2020-09-13T23:46:06.779Z',
           combatLevel: 125,
@@ -302,6 +307,7 @@ export default [
           build: 'main',
           flagged: false,
           lastImportedAt: '2020-09-13T23:46:06.779Z',
+          lastChangedAt: '2020-11-26T06:30:14.825Z',
           registeredAt: '2020-09-13T23:42:53.316Z',
           updatedAt: '2020-09-13T23:46:06.779Z',
           combatLevel: 125,

--- a/docs/src/configs/docs/players/entities.js
+++ b/docs/src/configs/docs/players/entities.js
@@ -39,6 +39,11 @@ export default [
         description: "The last time this player's history was imported from CML."
       },
       {
+        field: 'lastChangedAt',
+        type: 'date',
+        description: 'The last time this player gained exp/kc/scores.'
+      },
+      {
         field: 'registeredAt',
         type: 'date',
         description: "The player's registration date."

--- a/server/src/api/services/internal/player.service.ts
+++ b/server/src/api/services/internal/player.service.ts
@@ -164,6 +164,11 @@ async function update(username: string): Promise<[PlayerDetails, boolean]> {
       throw new ServerError('Failed to update: Unregistered name change.');
     }
 
+    // The player has gained exp/kc/scores since the last update
+    if (snapshotService.hasChanged(previousStats, currentStats)) {
+      player.lastChangedAt = new Date();
+    }
+
     // Refresh the player's build
     player.build = getBuild(currentStats);
     player.flagged = false;

--- a/server/src/api/services/internal/snapshot.service.ts
+++ b/server/src/api/services/internal/snapshot.service.ts
@@ -78,6 +78,9 @@ function hasExcessiveGains(before: Snapshot, after: Snapshot): boolean {
  * Checks whether there has been gains between two snapshots
  */
 function hasChanged(before: Snapshot, after: Snapshot): boolean {
+  if (!before) return true;
+  if (!after) return false;
+
   // EHP and EHB can fluctuate without the player's envolvement
   const keysToIgnore = ['ehpValue', 'ehbValue'];
 

--- a/server/src/api/services/internal/snapshot.service.ts
+++ b/server/src/api/services/internal/snapshot.service.ts
@@ -75,6 +75,19 @@ function hasExcessiveGains(before: Snapshot, after: Snapshot): boolean {
 }
 
 /**
+ * Checks whether there has been gains between two snapshots
+ */
+function hasChanged(before: Snapshot, after: Snapshot): boolean {
+  // EHP and EHB can fluctuate without the player's envolvement
+  const keysToIgnore = ['ehpValue', 'ehbValue'];
+
+  const isValidKey = key => !keysToIgnore.includes(key);
+  const keys = ALL_METRICS.map(m => getValueKey(m));
+
+  return keys.some(k => isValidKey(k) && after[k] > -1 && after[k] > before[k]);
+}
+
+/**
  * Checks whether two snapshots have negative gains in between.
  */
 function hasNegativeGains(before: Snapshot, after: Snapshot): boolean {
@@ -305,6 +318,7 @@ async function fromRS(playerId: number, csvData: string): Promise<Snapshot> {
 export {
   format,
   withinRange,
+  hasChanged,
   hasExcessiveGains,
   hasNegativeGains,
   findAll,

--- a/server/src/database/migrations/20201126061730-add-player-col-lastchanged.ts
+++ b/server/src/database/migrations/20201126061730-add-player-col-lastchanged.ts
@@ -1,0 +1,13 @@
+import { QueryInterface } from 'sequelize/types';
+
+function up(queryInterface: QueryInterface, dataTypes: any): Promise<void> {
+  return queryInterface.addColumn('players', 'lastChangedAt', {
+    type: dataTypes.DATE
+  });
+}
+
+function down(queryInterface: QueryInterface): Promise<void> {
+  return queryInterface.removeColumn('players', 'lastChangedAt');
+}
+
+export { up, down };

--- a/server/src/database/models/player.model.ts
+++ b/server/src/database/models/player.model.ts
@@ -84,6 +84,9 @@ export default class Player extends Model<Player> {
   @Column({ type: DataType.DATE })
   lastImportedAt: Date;
 
+  @Column({ type: DataType.DATE })
+  lastChangedAt: Date;
+
   @CreatedAt
   registeredAt: Date;
 


### PR DESCRIPTION
Adds a new date property to the player model: `lastChangedAt`.
Also added to the player page's info panel on the left.

This property is updated whenever new gains are detected. Useful for clan leaders who want to know who's active.