### PR TITLE
Update all participants on competition started

### DIFF
--- a/server/src/api/controllers/competition.controller.ts
+++ b/server/src/api/controllers/competition.controller.ts
@@ -161,7 +161,7 @@ async function updateAllParticipants(req: Request, res: Response, next: NextFunc
     const id = extractNumber(req.params, { key: 'id', required: true });
 
     const competition = await service.resolve(id);
-    const participants = await service.updateAllParticipants(competition, player => {
+    const participants = await service.updateAll(competition, false, player => {
       // Attempt this 3 times per player, waiting 65 seconds in between
       jobs.add('UpdatePlayer', { username: player.username }, { attempts: 3, backoff: 65000 });
     });

--- a/server/src/api/services/internal/competition.service.ts
+++ b/server/src/api/services/internal/competition.service.ts
@@ -634,15 +634,17 @@ async function removeFromGroupCompetitions(groupId, playerIds) {
  * within the service (circular dependency).
  * I'd rather call them from the controller.
  */
-async function updateAllParticipants(competition: Competition, updateAction: (player: Player) => void) {
-  const participants = await getOutdatedParticipants(competition.id);
+async function updateAll(competition: Competition, force: boolean, updateFn: (player: Player) => void) {
+  const participants = force
+    ? await getParticipants(competition.id)
+    : await getOutdatedParticipants(competition.id);
 
   if (!participants || participants.length === 0) {
     throw new BadRequestError('This competition has no outdated participants.');
   }
 
   // Execute the update action for every participant
-  participants.forEach(player => updateAction(player));
+  participants.forEach(player => updateFn(player));
 
   return participants;
 }
@@ -824,7 +826,7 @@ export {
   removeParticipants,
   addToGroupCompetitions,
   removeFromGroupCompetitions,
-  updateAllParticipants,
+  updateAll,
   refreshScores,
   syncParticipations
 };


### PR DESCRIPTION
Resolves #126 

Automatically attempts to update every competition participant (up to 3 tries each) whenever the competition starts, bypassing the usual 1h cooldown.