### PR TITLE
Feature: 6 hour Gains/Records

### DIFF
--- a/app/src/pages/Group/Group.jsx
+++ b/app/src/pages/Group/Group.jsx
@@ -32,6 +32,7 @@ import { getMetricName, getMetricIcon } from '../../utils';
 import './Group.scss';
 
 const PERIOD_OPTIONS = [
+  { label: '6 Hours', value: '6h' },
   { label: 'Day', value: 'day' },
   { label: 'Week', value: 'week' },
   { label: 'Month', value: 'month' },
@@ -79,7 +80,7 @@ function Group() {
   const selectedSectionIndex = getSelectedTabIndex(section);
 
   const [selectedMetric, setSelectedMetric] = useState(ALL_METRICS[0]);
-  const [selectedPeriod, setSelectedPeriod] = useState(PERIOD_OPTIONS[1].value);
+  const [selectedPeriod, setSelectedPeriod] = useState(PERIOD_OPTIONS[2].value);
   const [showingDeleteModal, setShowingDeleteModal] = useState(false);
   const [isButtonDisabled, setButtonDisabled] = useState(false);
 

--- a/app/src/pages/Player/Player.jsx
+++ b/app/src/pages/Player/Player.jsx
@@ -42,6 +42,7 @@ import './Player.scss';
 const TABS = ['Overview', 'Gained', 'Competitions', 'Groups', 'Records', 'Achievements', 'Names'];
 
 const PERIOD_OPTIONS = [
+  { label: '6 Hours', value: '6h' },
   { label: 'Day', value: 'day' },
   { label: 'Week', value: 'week' },
   { label: 'Month', value: 'month' },
@@ -96,7 +97,7 @@ function getSelectedPeriod(location) {
   const queryPeriod = params.period;
 
   const index = PERIOD_OPTIONS.findIndex(t => t.value.toLowerCase() === queryPeriod);
-  return PERIOD_OPTIONS[index === -1 ? 1 : index].value;
+  return PERIOD_OPTIONS[index === -1 ? 2 : index].value;
 }
 
 function getSelectedMetric(metricType, location) {

--- a/app/src/pages/Player/components/PlayerDeltasInfo/PlayerDeltasInfo.jsx
+++ b/app/src/pages/Player/components/PlayerDeltasInfo/PlayerDeltasInfo.jsx
@@ -5,6 +5,8 @@ import './PlayerDeltasInfo.scss';
 
 function getSeconds(period) {
   switch (period) {
+    case '6h':
+      return 3600 * 6;
     case 'day':
       return 3600 * 24;
     case 'week':

--- a/app/src/pages/Player/components/PlayerRecords/PlayerRecords.jsx
+++ b/app/src/pages/Player/components/PlayerRecords/PlayerRecords.jsx
@@ -55,7 +55,7 @@ function PlayerRecord({ metricRecords, metric }) {
     return null;
   }
 
-  const PERIOD_ORDER = ['day', 'week', 'month', 'year'];
+  const PERIOD_ORDER = ['6h', 'day', 'week', 'month', 'year'];
 
   const filteredRecords = metricRecords.sort(
     (a, b) => PERIOD_ORDER.indexOf(a.period) - PERIOD_ORDER.indexOf(b.period)

--- a/app/src/pages/Records/Records.jsx
+++ b/app/src/pages/Records/Records.jsx
@@ -146,12 +146,13 @@ function Records() {
 
   // Memoized redux variables
   const leaderboards = useSelector(recordSelectors.getLeaderboards);
+  const isLoading6h = useSelector(recordSelectors.isFetching6h);
   const isLoadingDay = useSelector(recordSelectors.isFetchingDay);
   const isLoadingWeek = useSelector(recordSelectors.isFetchingWeek);
   const isLoadingMonth = useSelector(recordSelectors.isFetchingMonth);
 
   const reloadList = () => {
-    const periods = ['day', 'week', 'month'];
+    const periods = ['6h', 'day', 'week', 'month'];
 
     periods.forEach(p => {
       dispatch(
@@ -252,6 +253,20 @@ function Records() {
               uniqueKeySelector={tableConfig.uniqueKey}
               columns={tableConfig.columns}
               rows={leaderboards.month}
+              listStyle
+            />
+          )}
+        </div>
+        <div className="col-lg-4 col-md-6">
+          <h3 className="period-label">6 hours</h3>
+          {isLoading6h && <img className="loading-icon" src="/img/icons/loading.png" alt="" />}
+          {!leaderboards || !leaderboards['6h'] ? (
+            <TablePlaceholder size={20} />
+          ) : (
+            <Table
+              uniqueKeySelector={tableConfig.uniqueKey}
+              columns={tableConfig.columns}
+              rows={leaderboards['6h']}
               listStyle
             />
           )}

--- a/app/src/pages/Records/Records.jsx
+++ b/app/src/pages/Records/Records.jsx
@@ -150,9 +150,10 @@ function Records() {
   const isLoadingDay = useSelector(recordSelectors.isFetchingDay);
   const isLoadingWeek = useSelector(recordSelectors.isFetchingWeek);
   const isLoadingMonth = useSelector(recordSelectors.isFetchingMonth);
+  const isLoadingYear = useSelector(recordSelectors.isFetchingYear);
 
   const reloadList = () => {
-    const periods = ['6h', 'day', 'week', 'month'];
+    const periods = ['6h', 'day', 'week', 'month', 'year'];
 
     periods.forEach(p => {
       dispatch(
@@ -267,6 +268,20 @@ function Records() {
               uniqueKeySelector={tableConfig.uniqueKey}
               columns={tableConfig.columns}
               rows={leaderboards['6h']}
+              listStyle
+            />
+          )}
+        </div>
+        <div className="col-lg-4 col-md-6">
+          <h3 className="period-label">Year</h3>
+          {isLoadingYear && <img className="loading-icon" src="/img/icons/loading.png" alt="" />}
+          {!leaderboards || !leaderboards.year ? (
+            <TablePlaceholder size={20} />
+          ) : (
+            <Table
+              uniqueKeySelector={tableConfig.uniqueKey}
+              columns={tableConfig.columns}
+              rows={leaderboards.year}
               listStyle
             />
           )}

--- a/app/src/pages/Top/Top.jsx
+++ b/app/src/pages/Top/Top.jsx
@@ -140,9 +140,10 @@ function Top() {
   const isLoadingDay = useSelector(deltasSelectors.isFetchingDay);
   const isLoadingWeek = useSelector(deltasSelectors.isFetchingWeek);
   const isLoadingMonth = useSelector(deltasSelectors.isFetchingMonth);
+  const isLoadingYear = useSelector(deltasSelectors.isFetchingYear);
 
   const reloadList = () => {
-    const periods = ['6h', 'day', 'week', 'month'];
+    const periods = ['6h', 'day', 'week', 'month', 'year'];
 
     periods.forEach(p => {
       dispatch(
@@ -168,6 +169,7 @@ function Top() {
   const dayTableConfig = useMemo(() => getTableConfig(selectedMetric, 'day'), [selectedMetric]);
   const weekTableConfig = useMemo(() => getTableConfig(selectedMetric, 'week'), [selectedMetric]);
   const monthTableConfig = useMemo(() => getTableConfig(selectedMetric, 'month'), [selectedMetric]);
+  const yearTableConfig = useMemo(() => getTableConfig(selectedMetric, 'year'), [selectedMetric]);
 
   useEffect(reloadList, [selectedMetric, selectedPlayerType, selectedPlayerBuild]);
 
@@ -260,6 +262,20 @@ function Top() {
               uniqueKeySelector={sixHoursTableConfig.uniqueKey}
               columns={sixHoursTableConfig.columns}
               rows={leaderboards['6h']}
+              listStyle
+            />
+          )}
+        </div>
+        <div className="col-lg-4 col-md-6">
+          <h3 className="period-label">Year</h3>
+          {isLoadingYear && <img className="loading-icon" src="/img/icons/loading.png" alt="" />}
+          {!leaderboards || !leaderboards.year ? (
+            <TablePlaceholder size={20} />
+          ) : (
+            <Table
+              uniqueKeySelector={yearTableConfig.uniqueKey}
+              columns={yearTableConfig.columns}
+              rows={leaderboards.year}
               listStyle
             />
           )}

--- a/app/src/pages/Top/Top.jsx
+++ b/app/src/pages/Top/Top.jsx
@@ -136,12 +136,13 @@ function Top() {
 
   // Memoized redux variables
   const leaderboards = useSelector(deltasSelectors.getLeaderboards);
+  const isLoading6h = useSelector(deltasSelectors.isFetching6h);
   const isLoadingDay = useSelector(deltasSelectors.isFetchingDay);
   const isLoadingWeek = useSelector(deltasSelectors.isFetchingWeek);
   const isLoadingMonth = useSelector(deltasSelectors.isFetchingMonth);
 
   const reloadList = () => {
-    const periods = ['day', 'week', 'month'];
+    const periods = ['6h', 'day', 'week', 'month'];
 
     periods.forEach(p => {
       dispatch(
@@ -163,6 +164,7 @@ function Top() {
     router.push(getNextUrl(selectedMetric, selectedPlayerType, e.value));
   };
 
+  const sixHoursTableConfig = useMemo(() => getTableConfig(selectedMetric, '6h'), [selectedMetric]);
   const dayTableConfig = useMemo(() => getTableConfig(selectedMetric, 'day'), [selectedMetric]);
   const weekTableConfig = useMemo(() => getTableConfig(selectedMetric, 'week'), [selectedMetric]);
   const monthTableConfig = useMemo(() => getTableConfig(selectedMetric, 'month'), [selectedMetric]);
@@ -244,6 +246,20 @@ function Top() {
               uniqueKeySelector={monthTableConfig.uniqueKey}
               columns={monthTableConfig.columns}
               rows={leaderboards.month}
+              listStyle
+            />
+          )}
+        </div>
+        <div className="col-lg-4 col-md-6">
+          <h3 className="period-label">6 Hours</h3>
+          {isLoading6h && <img className="loading-icon" src="/img/icons/loading.png" alt="" />}
+          {!leaderboards || !leaderboards['6h'] ? (
+            <TablePlaceholder size={20} />
+          ) : (
+            <Table
+              uniqueKeySelector={sixHoursTableConfig.uniqueKey}
+              columns={sixHoursTableConfig.columns}
+              rows={leaderboards['6h']}
               listStyle
             />
           )}

--- a/app/src/redux/deltas/reducer.js
+++ b/app/src/redux/deltas/reducer.js
@@ -7,13 +7,15 @@ const initialState = {
     '6h': false,
     day: false,
     week: false,
-    month: false
+    month: false,
+    year: false
   },
   leaderboards: {
     '6h': null,
     day: null,
     week: null,
-    month: null
+    month: null,
+    year: null
   },
   playerDeltas: {},
   groupDeltas: {},

--- a/app/src/redux/deltas/reducer.js
+++ b/app/src/redux/deltas/reducer.js
@@ -4,11 +4,13 @@ const initialState = {
   isFetchingPlayerDeltas: false,
   isFetchingGroupDeltas: false,
   isFetchingLeaderboards: {
+    '6h': false,
     day: false,
     week: false,
     month: false
   },
   leaderboards: {
+    '6h': null,
     day: null,
     week: null,
     month: null

--- a/app/src/redux/deltas/selectors.js
+++ b/app/src/redux/deltas/selectors.js
@@ -13,6 +13,7 @@ const getGroupDeltasMap = createSelector(groupDeltasSelector, map => {
   return mapValues(map, hiscores => hiscores.map((d, i) => ({ ...d, rank: i + 1 })));
 });
 
+export const isFetching6h = createSelector(rootSelector, root => root.isFetchingLeaderboards['6h']);
 export const isFetchingDay = createSelector(rootSelector, root => root.isFetchingLeaderboards.day);
 export const isFetchingWeek = createSelector(rootSelector, root => root.isFetchingLeaderboards.week);
 export const isFetchingMonth = createSelector(rootSelector, root => root.isFetchingLeaderboards.month);

--- a/app/src/redux/deltas/selectors.js
+++ b/app/src/redux/deltas/selectors.js
@@ -17,6 +17,7 @@ export const isFetching6h = createSelector(rootSelector, root => root.isFetching
 export const isFetchingDay = createSelector(rootSelector, root => root.isFetchingLeaderboards.day);
 export const isFetchingWeek = createSelector(rootSelector, root => root.isFetchingLeaderboards.week);
 export const isFetchingMonth = createSelector(rootSelector, root => root.isFetchingLeaderboards.month);
+export const isFetchingYear = createSelector(rootSelector, root => root.isFetchingLeaderboards.year);
 
 export const isFetchingGroupDeltas = createSelector(rootSelector, root => root.isFetchingGroupDeltas);
 

--- a/app/src/redux/records/reducer.js
+++ b/app/src/redux/records/reducer.js
@@ -7,13 +7,15 @@ const initialState = {
     '6h': false,
     day: false,
     week: false,
-    month: false
+    month: false,
+    year: false
   },
   leaderboards: {
     '6h': null,
     day: null,
     week: null,
-    month: null
+    month: null,
+    year: null
   },
   playerRecords: {},
   groupRecords: {},

--- a/app/src/redux/records/reducer.js
+++ b/app/src/redux/records/reducer.js
@@ -4,11 +4,13 @@ const initialState = {
   isFetchingPlayerRecords: false,
   isFetchingGroupRecords: false,
   isFetchingLeaderboards: {
+    '6h': false,
     day: false,
     week: false,
     month: false
   },
   leaderboards: {
+    '6h': null,
     day: null,
     week: null,
     month: null

--- a/app/src/redux/records/selectors.js
+++ b/app/src/redux/records/selectors.js
@@ -13,6 +13,7 @@ const getGroupRecordsMap = createSelector(groupRecordsSelector, map => {
   return mapValues(map, hiscores => hiscores.map((d, i) => ({ ...d, rank: i + 1 })));
 });
 
+export const isFetching6h = createSelector(rootSelector, root => root.isFetchingLeaderboards['6h']);
 export const isFetchingDay = createSelector(rootSelector, root => root.isFetchingLeaderboards.day);
 export const isFetchingWeek = createSelector(rootSelector, root => root.isFetchingLeaderboards.week);
 export const isFetchingMonth = createSelector(rootSelector, root => root.isFetchingLeaderboards.month);

--- a/app/src/redux/records/selectors.js
+++ b/app/src/redux/records/selectors.js
@@ -17,6 +17,7 @@ export const isFetching6h = createSelector(rootSelector, root => root.isFetching
 export const isFetchingDay = createSelector(rootSelector, root => root.isFetchingLeaderboards.day);
 export const isFetchingWeek = createSelector(rootSelector, root => root.isFetchingLeaderboards.week);
 export const isFetchingMonth = createSelector(rootSelector, root => root.isFetchingLeaderboards.month);
+export const isFetchingYear = createSelector(rootSelector, root => root.isFetchingLeaderboards.year);
 
 export const isFetchingGroupRecords = createSelector(rootSelector, root => root.isFetchingGroupRecords);
 

--- a/docs/src/configs/docs/deltas/entities.js
+++ b/docs/src/configs/docs/deltas/entities.js
@@ -440,7 +440,7 @@ export default [
     name: 'Periods',
     description:
       'All the possible values for the "period" field of the delta model. (Note: a month is 31 days)',
-    values: ['day', 'week', 'month', 'year']
+    values: ['6h', 'day', 'week', 'month', 'year']
   },
   {
     name: 'Metrics',

--- a/docs/src/configs/docs/groups/entities.js
+++ b/docs/src/configs/docs/groups/entities.js
@@ -76,7 +76,7 @@ export default [
     name: 'Periods',
     description:
       'All the possible values for the "period" field of the group leaderboard endpoint. (Note: a month is 31 days)',
-    values: ['day', 'week', 'month', 'year']
+    values: ['6h', 'day', 'week', 'month', 'year']
   },
   {
     name: 'Metrics',

--- a/docs/src/configs/docs/records/entities.js
+++ b/docs/src/configs/docs/records/entities.js
@@ -40,7 +40,7 @@ export default [
     name: 'Periods',
     description:
       'All the possible values for the "period" field of the record model. (Note: a month is 31 days)',
-    values: ['day', 'week', 'month', 'year']
+    values: ['6h', 'day', 'week', 'month', 'year']
   },
   {
     name: 'Metrics',

--- a/docs/src/configs/docs/snapshots/entities.js
+++ b/docs/src/configs/docs/snapshots/entities.js
@@ -799,6 +799,6 @@ export default [
     name: 'Periods',
     description:
       'All the possible values for the "period" field (used for filtering in the endpoint below).',
-    values: ['day', 'week', 'month', 'year']
+    values: ['6h', 'day', 'week', 'month', 'year']
   }
 ];

--- a/server/src/api/constants.ts
+++ b/server/src/api/constants.ts
@@ -5,7 +5,7 @@ export const MAX_LEVEL = 99;
 export const MAX_VIRTUAL_LEVEL = 126;
 export const CAPPED_MAX_TOTAL_XP = 299791913;
 
-export const PERIODS = ['day', 'week', 'month', 'year'];
+export const PERIODS = ['6h', 'day', 'week', 'month', 'year'];
 
 export const PLAYER_TYPES = ['unknown', 'regular', 'ironman', 'hardcore', 'ultimate'];
 

--- a/server/src/api/services/internal/delta.service.ts
+++ b/server/src/api/services/internal/delta.service.ts
@@ -5,6 +5,7 @@ import { Delta, InitialValues, Player, Snapshot } from '../../../database/models
 import { Pagination } from '../../../types';
 import { ALL_METRICS, PERIODS, PLAYER_BUILDS, PLAYER_TYPES } from '../../constants';
 import { BadRequestError } from '../../errors';
+import { getSeconds } from '../../util/dates';
 import { getMeasure, getRankKey, getValueKey, isBoss, isSkill, isVirtual } from '../../util/metrics';
 import { round } from '../../util/numbers';
 import { buildQuery } from '../../util/query';
@@ -23,26 +24,6 @@ interface GroupDeltasFilter {
   playerIds: number[];
   period?: string;
   metric?: string;
-}
-
-export const DAY_IN_SECONDS = 86400;
-export const WEEK_IN_SECONDS = 604800;
-export const MONTH_IN_SECONDS = 2678400; // month = 31 days (like CML)
-export const YEAR_IN_SECONDS = 31556926;
-
-function getSeconds(period: string) {
-  switch (period) {
-    case 'day':
-      return DAY_IN_SECONDS;
-    case 'week':
-      return WEEK_IN_SECONDS;
-    case 'month':
-      return MONTH_IN_SECONDS;
-    case 'year':
-      return YEAR_IN_SECONDS;
-    default:
-      return -1;
-  }
 }
 
 function parseNum(key: string, val: string) {

--- a/server/src/api/services/internal/snapshot.service.ts
+++ b/server/src/api/services/internal/snapshot.service.ts
@@ -4,6 +4,7 @@ import { Op } from 'sequelize';
 import { Snapshot } from '../../../database/models';
 import { ACTIVITIES, ALL_METRICS, BOSSES, PERIODS, SKILLS } from '../../constants';
 import { BadRequestError, ServerError } from '../../errors';
+import { getSeconds } from '../../util/dates';
 import { getMeasure, getRankKey, getValueKey, isBoss, isSkill } from '../../util/metrics';
 import * as efficiencyService from './efficiency.service';
 
@@ -111,12 +112,12 @@ async function getSnapshots(playerId: number, period: string) {
     throw new BadRequestError(`Invalid period: ${period}.`);
   }
 
-  const before = moment().subtract(1, period as any);
+  const before = moment().subtract(getSeconds(period), 'seconds').toDate();
 
   const result = await Snapshot.findAll({
     where: {
       playerId,
-      createdAt: { [Op.gte]: before.toDate() }
+      createdAt: { [Op.gte]: before }
     },
     order: [['createdAt', 'DESC']]
   });

--- a/server/src/api/util/dates.ts
+++ b/server/src/api/util/dates.ts
@@ -65,4 +65,21 @@ function durationBetween(startDate, endDate) {
   return str;
 }
 
-export { isValidDate, isPast, durationBetween };
+function getSeconds(period: string) {
+  switch (period) {
+    case '6h':
+      return 3600 * 6;
+    case 'day':
+      return 3600 * 24;
+    case 'week':
+      return 3600 * 24 * 7;
+    case 'month':
+      return 3600 * 24 * 31;
+    case 'year':
+      return 31556926;
+    default:
+      return -1;
+  }
+}
+
+export { isValidDate, isPast, durationBetween, getSeconds };


### PR DESCRIPTION
- Adds 6h gains/records to players and groups (accessible through the API too)
- Adds a 6h table to the global gains/records leaderboards
- Adds a year table to the global gains/records leaderboards


**Still need to test/check the discord bot to make sure it will also work there.**