### PR TITLE
break-all -> break-word

### DIFF
--- a/app/src/components/InfoPanel/InfoPanel.scss
+++ b/app/src/components/InfoPanel/InfoPanel.scss
@@ -20,7 +20,7 @@
     &__value {
       display: block;
       margin-top: 3px;
-      word-break: break-all;
+      word-break: break-word;
 
       &.-positive {
         color: $positive-green;


### PR DESCRIPTION
Break-all was causing weird issues with actual word breaks (IE words being split off arbitrarily when they shouldn't be).