### PR TITLE
Allow scrolling through remove players modal

### DIFF
--- a/app/src/modals/RemovePlayersModal/RemovePlayersModal.jsx
+++ b/app/src/modals/RemovePlayersModal/RemovePlayersModal.jsx
@@ -14,7 +14,7 @@ function RemovePlayersModal({ modalView, players, onConfirm, onClose }) {
           <img src="/img/icons/clear.svg" alt="X" />
         </button>
         <b className="modal-title">Are you sure you want to remove the following players?</b>
-        <p>{players.join(', ')}</p>
+        <p className="remove-players__list">{players.join(', ')}</p>
         <Button text="Remove players" onClick={onConfirm} />
       </div>
     </div>

--- a/app/src/modals/RemovePlayersModal/RemovePlayersModal.scss
+++ b/app/src/modals/RemovePlayersModal/RemovePlayersModal.scss
@@ -18,9 +18,10 @@
     width: 300px;
     max-height: 80vh;
     max-width: 90%;
-    overflow-y: scroll;
     text-align: center;
     padding: 40px 25px 25px;
+    display: flex;
+    flex-direction: column;
     position: relative;
 
     .close-btn {
@@ -51,5 +52,9 @@
         background: $negative-red;
       }
     }
+  }
+
+  &__list {
+    overflow-y: scroll;
   }
 }

--- a/app/src/modals/RemovePlayersModal/RemovePlayersModal.scss
+++ b/app/src/modals/RemovePlayersModal/RemovePlayersModal.scss
@@ -7,7 +7,7 @@
   right: 0;
   bottom: 0;
   background: rgba(0, 0, 0, 0.7);
-  z-index: 300;
+  z-index: 501;
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -16,10 +16,11 @@
   &__modal {
     @extend %panel;
     width: 300px;
+    max-height: 80vh;
     max-width: 90%;
+    overflow-y: scroll;
     text-align: center;
-    padding: 25px;
-    padding-top: 40px;
+    padding: 40px 25px 25px;
     position: relative;
 
     .close-btn {


### PR DESCRIPTION
Fixes a problem reported on Discord earlier today which prevents users from confirming removal of players from groups/competitions with a lot of members.

Preview:
![Dec-06-2020 11-10-14](https://user-images.githubusercontent.com/11782/101277375-571b9b00-37b4-11eb-9668-0add564dfe75.gif)

