### PR TITLE
Fix buildQuery function for empty strings

### DIFF
--- a/server/src/api/util/query.ts
+++ b/server/src/api/util/query.ts
@@ -2,7 +2,11 @@ export function buildQuery(params: any): any {
   const query: any = {};
 
   Object.keys(params).forEach(k => {
-    if (params[k] !== undefined && params[k] !== null) {
+    if (
+      params[k] !== undefined &&
+      params[k] !== null &&
+      (typeof params[k] !== 'string' || params[k].length > 0)
+    ) {
       query[k] = params[k];
     }
   });


### PR DESCRIPTION
The recent changes made it ignore empty strings, so the `/competitions` page was showing 0 results