### PR TITLE
Show total ehp under EHP instead of Experience

### DIFF
--- a/app/src/pages/Player/components/PlayerDeltasTable/PlayerDeltasTable.jsx
+++ b/app/src/pages/Player/components/PlayerDeltasTable/PlayerDeltasTable.jsx
@@ -30,9 +30,9 @@ function getSkillsTable(delta) {
   rows.push({
     metric: 'ehp',
     level: '',
-    experience: delta.ehp.value.gained,
+    experience: '',
     rank: delta.ehp.rank.gained,
-    ehp: ''
+    ehp: delta.ehp.value.gained
   });
 
   const uniqueKeySelector = row => row.metric;
@@ -95,9 +95,9 @@ function getBossesTable(delta) {
   rows.push({
     metric: 'ehb',
     level: '',
-    kills: delta.ehb.value.gained,
+    kills: '',
     rank: delta.ehb.rank.gained,
-    ehb: ''
+    ehb: delta.ehb.value.gained
   });
 
   const uniqueKeySelector = row => row.metric;

--- a/app/src/pages/Player/components/PlayerStatsTable/PlayerStatsTable.jsx
+++ b/app/src/pages/Player/components/PlayerStatsTable/PlayerStatsTable.jsx
@@ -30,7 +30,7 @@ function renderSkillsTable(snapshot, showVirtualLevels) {
     metric: 'ehp',
     level: '',
     experience: '',
-    ehp: snapshot.ehp.value,
+    ehp: round(snapshot.ehp.value, 2),
     rank: snapshot.ehp.rank
   });
 
@@ -82,7 +82,7 @@ function renderBossesTable(snapshot) {
     metric: 'ehb',
     kills: '',
     rank: snapshot.ehb.rank,
-    ehb: snapshot.ehb.value
+    ehb: round(snapshot.ehb.value, 2)
   });
 
   const uniqueKeySelector = row => row.metric;


### PR DESCRIPTION
The total EHP is currently shown under the Experience category in the Gains section. This puts it under the EHP category instead which also makes it sortable correctly.

Before
![before](https://user-images.githubusercontent.com/5983417/102207836-ec164680-3ece-11eb-98c6-6a81f9b4b7ba.png)
After
![after](https://user-images.githubusercontent.com/5983417/102207846-efa9cd80-3ece-11eb-967c-6ad0c89debb8.png)

EHP and EHB were also not rounded in the Overview. Currently shows 5 decimals, this rounds it to 2 decimals like everything else.
