### PR TITLE
Name Change Improvements

### DIFF
--- a/app/src/pages/Group/Group.jsx
+++ b/app/src/pages/Group/Group.jsx
@@ -18,13 +18,23 @@ import {
   GainedTable,
   HiscoresTable,
   RecordsTable,
-  Statistics
+  Statistics,
+  NameChangesTable
 } from './containers';
 import { GroupInfo } from './components';
 import { GroupContext } from './context';
 import './Group.scss';
 
-const TABS = ['Members', 'Competitions', 'Hiscores', 'Gained', 'Records', 'Achievements', 'Statistics'];
+const TABS = [
+  'Members',
+  'Competitions',
+  'Hiscores',
+  'Gained',
+  'Records',
+  'Achievements',
+  'Name Changes',
+  'Statistics'
+];
 
 function Group() {
   const dispatch = useDispatch();
@@ -97,6 +107,7 @@ function Group() {
             {section === 'gained' && <GainedTable />}
             {section === 'records' && <RecordsTable />}
             {section === 'achievements' && <AchievementsTable />}
+            {section === 'name changes' && <NameChangesTable />}
             {section === 'statistics' && <Statistics />}
             {section === 'competitions' && <CompetitionsTable handleRedirect={handleRedirect} />}
           </div>
@@ -132,7 +143,7 @@ function encodeContext({ id, section }) {
   const nextURL = new URL(`/groups/${id}`);
 
   if (section && section !== 'members') {
-    nextURL.appendToPath(`/${section}`);
+    nextURL.appendToPath(`/${section.replace(' ', '-')}`);
   }
 
   return nextURL.getPath();
@@ -142,9 +153,11 @@ function decodeURL(params) {
   const { id, section } = params;
   const validSections = ['delete', ...TABS.map(t => t.toLowerCase())];
 
+  const formattedSection = section ? section.replace('-', ' ') : undefined;
+
   return {
     id: parseInt(id, 10),
-    section: section && validSections.includes(section) ? section : 'members'
+    section: section && validSections.includes(formattedSection) ? formattedSection : 'members'
   };
 }
 

--- a/app/src/pages/Group/containers/NameChangesTable.jsx
+++ b/app/src/pages/Group/containers/NameChangesTable.jsx
@@ -1,43 +1,43 @@
 import React, { useContext, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
-import { achievementActions, achievementSelectors } from 'redux/achievements';
+import { nameActions, nameSelectors } from 'redux/names';
 import { Table, TablePlaceholder, PlayerTag } from 'components';
-import { getMetricIcon, formatDate } from 'utils';
+import { durationBetween } from 'utils';
 import { useLazyLoading } from 'hooks';
 import { GroupContext } from '../context';
 
 const TABLE_CONFIG = {
-  uniqueKey: row => `${row.player.id}-${row.type}`,
+  uniqueKey: row => row.id,
   columns: [
+    {
+      key: 'oldName',
+      className: () => '-primary'
+    },
+    {
+      key: 'arrow',
+      className: () => '-break-small',
+      transform: () => '→'
+    },
     {
       key: 'displayName',
       get: row => row.player.displayName,
       className: () => '-primary',
       transform: (value, row) => (
-        <Link to={`/players/${row.player.username}/achievements`}>
+        <Link to={`/players/${row.player.username}/names`}>
           <PlayerTag name={value} type={row.player.type} flagged={row.player.flagged} />
         </Link>
       )
     },
     {
-      key: 'metric',
-      className: () => '-no-padding -break-small',
-      transform: value => <img src={getMetricIcon(value, true)} alt="" />
-    },
-    {
-      key: 'type',
-      className: () => '-no-padding'
-    },
-    {
-      key: 'createdAt',
+      key: 'resolvedAt',
       className: () => '-break-medium',
-      transform: value => formatDate(value, 'DD MMM, YYYY')
+      transform: value => `Approved ${durationBetween(value, new Date(), 2, true)} ago`
     }
   ]
 };
 
-function AchievementsTable() {
+function NameChangesTable() {
   const dispatch = useDispatch();
 
   const { context } = useContext(GroupContext);
@@ -46,29 +46,29 @@ function AchievementsTable() {
   const { isFullyLoaded, pageIndex, reloadData } = useLazyLoading({
     resultsPerPage: 20,
     action: handleReload,
-    selector: state => achievementSelectors.getGroupAchievements(state, id)
+    selector: state => nameSelectors.getGroupNameChanges(state, id)
   });
 
-  const achievements = useSelector(state => achievementSelectors.getGroupAchievements(state, id));
-  const isLoading = useSelector(achievementSelectors.isFetchingGroupAchievements);
+  const nameChanges = useSelector(state => nameSelectors.getGroupNameChanges(state, id));
+  const isLoading = useSelector(nameSelectors.isFetching);
   const isReloading = isLoading && pageIndex === 0;
 
   function handleReload(limit, offset) {
-    dispatch(achievementActions.fetchGroupAchievements(id, limit, offset));
+    dispatch(nameActions.fetchGroupNameChanges(id, limit, offset));
   }
 
-  // When the selected metric changes, reload the achievements
+  // When the selected metric changes, reload the name changes
   useEffect(reloadData, [id]);
 
   return (
     <>
-      <span className="widget-label">Most recent achievements</span>
+      <span className="widget-label">Most recent name changes</span>
       {isReloading ? (
         <TablePlaceholder size={20} />
       ) : (
         <Table
           uniqueKeySelector={TABLE_CONFIG.uniqueKey}
-          rows={achievements}
+          rows={nameChanges}
           columns={TABLE_CONFIG.columns}
           listStyle
         />
@@ -78,4 +78,4 @@ function AchievementsTable() {
   );
 }
 
-export default AchievementsTable;
+export default NameChangesTable;

--- a/app/src/pages/Group/containers/index.js
+++ b/app/src/pages/Group/containers/index.js
@@ -4,6 +4,7 @@ export { default as GainedTable } from './GainedTable';
 export { default as Header } from './Header';
 export { default as HiscoresTable } from './HiscoresTable';
 export { default as MembersTable } from './MembersTable';
+export { default as NameChangesTable } from './NameChangesTable';
 export { default as RecordsTable } from './RecordsTable';
 export { default as Statistics } from './Statistics';
 export { default as Widgets } from './Widgets';

--- a/app/src/pages/NamesList/NamesList.jsx
+++ b/app/src/pages/NamesList/NamesList.jsx
@@ -1,10 +1,14 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Helmet } from 'react-helmet';
+import { debounce } from 'lodash';
 import { nameActions, nameSelectors } from 'redux/names';
 import { Table, TablePlaceholder, TextButton, PageTitle } from 'components';
 import { durationBetween } from 'utils';
-import { useLazyLoading } from 'hooks';
+import URL from 'utils/url';
+import { useLazyLoading, useUrlContext } from 'hooks';
+import { NamesListContext } from './context';
+import { Controls } from './containers';
 import './NamesList.scss';
 
 const TABLE_CONFIG = {
@@ -18,9 +22,9 @@ const TABLE_CONFIG = {
       className: () => '-primary'
     },
     {
-      key: 'newName',
+      key: 'arrow',
       className: () => '-break-small',
-      transform: () => '-->'
+      transform: () => '→'
     },
     {
       key: 'newName',
@@ -42,8 +46,14 @@ const TABLE_CONFIG = {
 function NamesList() {
   const dispatch = useDispatch();
 
-  const { isFullyLoaded } = useLazyLoading({
-    resultsPerPage: 20,
+  // State variables
+  const [usernameSearch, setUsernameSearch] = useState('');
+
+  const { context, updateContext } = useUrlContext(encodeContext, decodeURL);
+  const { status } = context;
+
+  const { isFullyLoaded, reloadData } = useLazyLoading({
+    resultsPerPage: 50,
     selector: nameSelectors.getNameChanges,
     action: handleLoadData
   });
@@ -53,40 +63,51 @@ function NamesList() {
   const isLoading = useSelector(nameSelectors.isFetching);
 
   function handleLoadData(limit, offset) {
-    dispatch(nameActions.fetchNameChanges(limit, offset));
+    dispatch(nameActions.fetchNameChanges(usernameSearch, status, limit, offset));
   }
 
+  // Debounce search input keystrokes by 500ms
+  const handleSubmitSearch = debounce(reloadData, 500, { leading: true, trailing: false });
+
+  // Submit search each time any of the search variable change
+  useEffect(handleSubmitSearch, [usernameSearch, status]);
+
   return (
-    <div className="names__container container">
-      <Helmet>
-        <title>Name changes</title>
-      </Helmet>
-      <div className="names__header row">
-        <div className="col">
-          <PageTitle title="Name changes" />
+    <NamesListContext.Provider value={{ context, updateContext }}>
+      <div className="names__container container">
+        <Helmet>
+          <title>Name changes</title>
+        </Helmet>
+        <div className="names__header row">
+          <div className="col">
+            <PageTitle title="Name changes" />
+          </div>
+          <div className="col">
+            <TextButton text="Submit new" url="/names/submit" />
+          </div>
         </div>
-        <div className="col">
-          <TextButton text="Submit new" url="/names/submit" />
+        <div className="names__options row">
+          <Controls onSearchInputChanged={e => setUsernameSearch(e.target.value)} />
+        </div>
+        <div className="names__list row">
+          <div className="col">
+            {isLoading && (!nameChanges || nameChanges.length === 0) ? (
+              <TablePlaceholder size={5} />
+            ) : (
+              <Table
+                uniqueKeySelector={TABLE_CONFIG.uniqueKey}
+                columns={TABLE_CONFIG.columns}
+                rows={nameChanges}
+                listStyle
+              />
+            )}
+          </div>
+        </div>
+        <div className="row">
+          <div className="col">{!isFullyLoaded && <b className="loading-indicator">Loading...</b>}</div>
         </div>
       </div>
-      <div className="names__list row">
-        <div className="col">
-          {isLoading && (!nameChanges || nameChanges.length === 0) ? (
-            <TablePlaceholder size={5} />
-          ) : (
-            <Table
-              uniqueKeySelector={TABLE_CONFIG.uniqueKey}
-              columns={TABLE_CONFIG.columns}
-              rows={nameChanges}
-              listStyle
-            />
-          )}
-        </div>
-      </div>
-      <div className="row">
-        <div className="col">{!isFullyLoaded && <b className="loading-indicator">Loading...</b>}</div>
-      </div>
-    </div>
+    </NamesListContext.Provider>
   );
 }
 
@@ -110,6 +131,23 @@ function statusClassName(status) {
     default:
       return '';
   }
+}
+
+function encodeContext({ status }) {
+  const nextURL = new URL('/names');
+
+  if (status !== undefined) {
+    nextURL.appendSearchParam('status', status);
+  }
+
+  return nextURL.getPath();
+}
+
+function decodeURL(_, query) {
+  const statusInt = parseInt(query.status, 10);
+  const isValidStatus = query.status && statusInt >= 0 && statusInt <= 2;
+
+  return { status: isValidStatus ? parseInt(query.status, 10) : null };
 }
 
 export default NamesList;

--- a/app/src/pages/NamesList/NamesList.scss
+++ b/app/src/pages/NamesList/NamesList.scss
@@ -5,6 +5,10 @@
   width: 800px !important;
   max-width: 90%;
 
+  .text-input {
+    border: 1px solid $gray-12;
+  }
+
   .names__header {
     .text-button {
       float: right;

--- a/app/src/pages/NamesList/containers/Controls.jsx
+++ b/app/src/pages/NamesList/containers/Controls.jsx
@@ -1,0 +1,44 @@
+import React, { useContext } from 'react';
+import PropTypes from 'prop-types';
+import { TextInput, Selector } from 'components';
+import { NamesListContext } from '../context';
+
+const STATUS_OPTIONS = [
+  { label: 'Any status', value: null },
+  { label: 'Pending', value: 0 },
+  { label: 'Denied', value: 1 },
+  { label: 'Approved', value: 2 }
+];
+
+function Controls({ onSearchInputChanged }) {
+  const { context, updateContext } = useContext(NamesListContext);
+
+  const selectedStatusIndex = STATUS_OPTIONS.findIndex(o => o.value === context.status);
+
+  const onStatusSelected = e => {
+    if (!e || e.value === undefined) return;
+    updateContext({ status: e.value === undefined ? null : e.value });
+  };
+
+  return (
+    <>
+      <div className="col-lg-8 col-md-6 col-sm-6">
+        <TextInput onChange={onSearchInputChanged} placeholder="Search username" />
+      </div>
+      <div className="col-lg-4 col-md-6 col-sm-6">
+        <Selector
+          options={STATUS_OPTIONS}
+          selectedIndex={selectedStatusIndex}
+          onSelect={onStatusSelected}
+          search
+        />
+      </div>
+    </>
+  );
+}
+
+Controls.propTypes = {
+  onSearchInputChanged: PropTypes.func.isRequired
+};
+
+export default Controls;

--- a/app/src/pages/NamesList/containers/index.js
+++ b/app/src/pages/NamesList/containers/index.js
@@ -1,0 +1,1 @@
+export { default as Controls } from './Controls';

--- a/app/src/pages/NamesList/context.js
+++ b/app/src/pages/NamesList/context.js
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+
+const NamesListContext = createContext({});
+
+export { NamesListContext };

--- a/app/src/pages/Player/containers/Names.jsx
+++ b/app/src/pages/Player/containers/Names.jsx
@@ -34,7 +34,7 @@ function Names() {
   const { context } = useContext(PlayerContext);
   const { username } = context;
 
-  const nameChanges = useSelector(state => nameSelectors.getPlayerNames(state, username));
+  const nameChanges = useSelector(state => nameSelectors.getPlayerNames(state, username)) || [];
   const adjustedNames = [...nameChanges];
 
   if (nameChanges.length > 0) {

--- a/app/src/redux/names/actions.js
+++ b/app/src/redux/names/actions.js
@@ -29,6 +29,21 @@ const fetchPlayerNameChanges = username => async dispatch => {
   }
 };
 
+const fetchGroupNameChanges = (groupId, limit, offset) => async dispatch => {
+  dispatch(reducers.onFetchGroupNameChangesRequest());
+
+  try {
+    const params = { limit, offset };
+    const url = endpoints.fetchGroupNameChanges.replace(':id', groupId);
+
+    const { data } = await api.get(url, { params });
+
+    dispatch(reducers.onFetchGroupNameChangesSuccess({ groupId, data, refresh: !offset }));
+  } catch (e) {
+    dispatch(reducers.onFetchGroupNameChangesError(e.message.toString()));
+  }
+};
+
 const submitNameChange = (oldName, newName) => async dispatch => {
   dispatch(reducers.onSubmitRequest());
 
@@ -42,4 +57,4 @@ const submitNameChange = (oldName, newName) => async dispatch => {
   }
 };
 
-export { fetchNameChanges, submitNameChange, fetchPlayerNameChanges };
+export { fetchNameChanges, submitNameChange, fetchPlayerNameChanges, fetchGroupNameChanges };

--- a/app/src/redux/names/actions.js
+++ b/app/src/redux/names/actions.js
@@ -1,11 +1,11 @@
 import api, { endpoints } from 'services/api';
 import { reducers } from './reducer';
 
-const fetchNameChanges = (limit, offset) => async dispatch => {
+const fetchNameChanges = (username, status, limit, offset) => async dispatch => {
   dispatch(reducers.onFetchRequest());
 
   try {
-    const params = { limit, offset };
+    const params = { username, status, limit, offset };
     const { data } = await api.get(endpoints.fetchNameChanges, { params });
 
     const refresh = !offset;

--- a/app/src/redux/names/reducer.js
+++ b/app/src/redux/names/reducer.js
@@ -6,7 +6,8 @@ const initialState = {
   isSubmitting: false,
   error: { message: null, data: null },
   nameChanges: {},
-  playerNameChanges: {}
+  playerNameChanges: {},
+  groupNameChanges: {}
 };
 
 const slice = createSlice({
@@ -55,6 +56,21 @@ const slice = createSlice({
       state.playerNameChanges[username] = data;
     },
     onFetchPlayerNameChangesError(state, action) {
+      state.isFetchingList = false;
+      state.error = { message: action.payload.error };
+    },
+    onFetchGroupNameChangesRequest(state) {
+      state.isFetchingList = true;
+      state.error = initialState.error;
+    },
+    onFetchGroupNameChangesSuccess(state, action) {
+      const { groupId, data, refresh } = action.payload;
+
+      state.isFetchingList = false;
+      state.error = initialState.error;
+      state.groupNameChanges[groupId] = refresh ? data : [...state.groupNameChanges[groupId], ...data];
+    },
+    onFetchGroupNameChangesError(state, action) {
       state.isFetchingList = false;
       state.error = { message: action.payload.error };
     }

--- a/app/src/redux/names/selectors.js
+++ b/app/src/redux/names/selectors.js
@@ -3,6 +3,7 @@ import { createSelector } from 'reselect';
 const rootSelector = state => state.names;
 const namesSelector = state => state.names.nameChanges;
 const playerNamesSelector = state => state.names.playerNameChanges;
+const groupNamesSelector = state => state.names.groupNameChanges;
 
 export const getError = createSelector(rootSelector, root => root.error);
 export const isFetching = createSelector(rootSelector, root => root.isFetching);
@@ -13,5 +14,7 @@ export const getNameChanges = createSelector(namesSelector, map => {
 });
 
 const getPlayerNamesMap = createSelector(playerNamesSelector, map => map);
+const getGroupNameChangesMap = createSelector(groupNamesSelector, map => map);
 
 export const getPlayerNames = (state, username) => getPlayerNamesMap(state)[username];
+export const getGroupNameChanges = (state, groupId) => getGroupNameChangesMap(state)[groupId];

--- a/app/src/services/api.js
+++ b/app/src/services/api.js
@@ -35,6 +35,7 @@ const endpoints = {
   fetchGroupStatistics: '/groups/:id/statistics/',
   fetchGroupMonthlyTop: '/groups/:id/monthly-top/',
   fetchGroupAchievements: '/groups/:id/achievements/',
+  fetchGroupNameChanges: '/groups/:id/name-changes/',
   fetchGroupCompetitions: '/groups/:id/competitions/',
   updateAllMembers: '/groups/:id/update-all',
 

--- a/docs/src/configs/docs/groups/endpoints.js
+++ b/docs/src/configs/docs/groups/endpoints.js
@@ -59,7 +59,7 @@ export default [
             createdAt: '2020-05-06T08:36:27.420Z',
             updatedAt: '2020-12-13T06:00:08.793Z',
             memberCount: 63
-          },
+          }
         ]
       }
     ],
@@ -67,13 +67,13 @@ export default [
       {
         description: 'If the given limit is lower than 1.',
         body: {
-          message: "Invalid limit: must be > 0"
+          message: 'Invalid limit: must be > 0'
         }
       },
       {
         description: 'If the given offset is negative.',
         body: {
-          message: "Invalid offset: must a positive number."
+          message: 'Invalid offset: must a positive number.'
         }
       }
     ]
@@ -110,7 +110,7 @@ export default [
       {
         description: 'If no id is given.',
         body: {
-          message: "Invalid group id."
+          message: 'Invalid group id.'
         }
       },
       {
@@ -301,7 +301,7 @@ export default [
       {
         description: 'If no id is given.',
         body: {
-          message: "Invalid group id."
+          message: 'Invalid group id.'
         }
       },
       {
@@ -353,7 +353,7 @@ export default [
       {
         description: 'If no id is given.',
         body: {
-          message: "Invalid group id."
+          message: 'Invalid group id.'
         }
       },
       {
@@ -412,7 +412,7 @@ export default [
       {
         description: 'If no id is given.',
         body: {
-          message: "Invalid group id."
+          message: 'Invalid group id.'
         }
       },
       {
@@ -539,7 +539,7 @@ export default [
       {
         description: 'If no id is given.',
         body: {
-          message: "Invalid group id."
+          message: 'Invalid group id.'
         }
       },
       {
@@ -581,13 +581,13 @@ export default [
       {
         description: 'If the given limit is lower than 1.',
         body: {
-          message: "Invalid limit: must be > 0"
+          message: 'Invalid limit: must be > 0'
         }
       },
       {
         description: 'If the given offset is negative.',
         body: {
-          message: "Invalid offset: must a positive number."
+          message: 'Invalid offset: must a positive number.'
         }
       }
     ]
@@ -695,7 +695,7 @@ export default [
       {
         description: 'If no id is given.',
         body: {
-          message: "Invalid group id."
+          message: 'Invalid group id.'
         }
       },
       {
@@ -719,13 +719,13 @@ export default [
       {
         description: 'If the given limit is lower than 1.',
         body: {
-          message: "Invalid limit: must be > 0"
+          message: 'Invalid limit: must be > 0'
         }
       },
       {
         description: 'If the given offset is negative.',
         body: {
-          message: "Invalid offset: must a positive number."
+          message: 'Invalid offset: must a positive number.'
         }
       }
     ]
@@ -847,7 +847,7 @@ export default [
       {
         description: 'If no id is given.',
         body: {
-          message: "Invalid group id."
+          message: 'Invalid group id.'
         }
       },
       {
@@ -877,13 +877,13 @@ export default [
       {
         description: 'If the given limit is lower than 1.',
         body: {
-          message: "Invalid limit: must be > 0"
+          message: 'Invalid limit: must be > 0'
         }
       },
       {
         description: 'If the given offset is negative.',
         body: {
-          message: "Invalid offset: must a positive number."
+          message: 'Invalid offset: must a positive number.'
         }
       }
     ]
@@ -992,7 +992,7 @@ export default [
       {
         description: 'If no id is given.',
         body: {
-          message: "Invalid group id."
+          message: 'Invalid group id.'
         }
       },
       {
@@ -1010,13 +1010,155 @@ export default [
       {
         description: 'If the given limit is lower than 1.',
         body: {
-          message: "Invalid limit: must be > 0"
+          message: 'Invalid limit: must be > 0'
         }
       },
       {
         description: 'If the given offset is negative.',
         body: {
-          message: "Invalid offset: must a positive number."
+          message: 'Invalid offset: must a positive number.'
+        }
+      }
+    ]
+  },
+  {
+    title: "Get a group's recent name changes",
+    url: '/groups/:id/name-changes',
+    method: 'GET',
+    params: [
+      {
+        field: 'id',
+        type: 'integer',
+        description: "The group's id."
+      },
+      {
+        field: 'limit',
+        type: 'integer',
+        description: 'The maximum amount of results to return - Optional (Default is 20)'
+      },
+      {
+        field: 'offset',
+        type: 'integer',
+        description: 'The amount of results to offset the response by - Optional (Default is 0)'
+      }
+    ],
+    successResponses: [
+      {
+        description: '',
+        body: [
+          {
+            id: 1609,
+            playerId: 15293,
+            oldName: 'tugassassino',
+            newName: 'lary9',
+            status: 0,
+            resolvedAt: null,
+            createdAt: '2021-01-17T21:13:16.009Z',
+            updatedAt: '2021-01-17T21:13:16.009Z',
+            player: {
+              exp: 81364290,
+              id: 15293,
+              username: 'tugassassino',
+              displayName: 'tugassassino',
+              type: 'regular',
+              build: 'main',
+              flagged: false,
+              ehp: 328.09792,
+              ehb: 56.85112,
+              ttm: 965.68161,
+              tt200m: 14634.35313,
+              lastImportedAt: '2021-01-13T14:00:12.332Z',
+              lastChangedAt: '2021-01-13T14:00:08.503Z',
+              registeredAt: '2020-06-09T18:01:58.643Z',
+              updatedAt: '2021-01-13T14:00:12.333Z'
+            }
+          },
+          {
+            id: 1608,
+            playerId: 135826,
+            oldName: 'tricky hypah',
+            newName: '0 purp hypah',
+            status: 0,
+            resolvedAt: null,
+            createdAt: '2021-01-17T21:13:16.007Z',
+            updatedAt: '2021-01-17T21:13:16.007Z',
+            player: {
+              exp: 45916120,
+              id: 135826,
+              username: 'tricky hypah',
+              displayName: 'tricky hypah',
+              type: 'regular',
+              build: 'main',
+              flagged: false,
+              ehp: 210.8715,
+              ehb: 70.0381,
+              ttm: 1082.88445,
+              tt200m: 14751.57955,
+              lastImportedAt: null,
+              lastChangedAt: '2021-01-13T13:58:49.322Z',
+              registeredAt: '2021-01-12T19:55:14.802Z',
+              updatedAt: '2021-01-13T13:58:49.938Z'
+            }
+          },
+          {
+            id: 1607,
+            playerId: 13678,
+            oldName: 'also rng',
+            newName: 'rajit0',
+            status: 0,
+            resolvedAt: null,
+            createdAt: '2021-01-17T21:13:16.005Z',
+            updatedAt: '2021-01-17T21:13:16.005Z',
+            player: {
+              exp: 70957320,
+              id: 13678,
+              username: 'also rng',
+              displayName: 'Also RNG',
+              type: 'regular',
+              build: 'main',
+              flagged: false,
+              ehp: 312.08797,
+              ehb: 20.84375,
+              ttm: 981.66799,
+              tt200m: 14650.36308,
+              lastImportedAt: '2020-10-20T09:27:05.480Z',
+              lastChangedAt: null,
+              registeredAt: '2020-06-03T15:42:08.609Z',
+              updatedAt: '2020-10-20T09:27:05.481Z'
+            }
+          }
+        ]
+      }
+    ],
+    errorResponses: [
+      {
+        description: 'If no id is given.',
+        body: {
+          message: 'Invalid group id.'
+        }
+      },
+      {
+        description: 'If the given id does not exist.',
+        body: {
+          message: 'Group not found.'
+        }
+      },
+      {
+        description: 'If the group with the given id has no members.',
+        body: {
+          message: 'That group has no members.'
+        }
+      },
+      {
+        description: 'If the given limit is lower than 1.',
+        body: {
+          message: 'Invalid limit: must be > 0'
+        }
+      },
+      {
+        description: 'If the given offset is negative.',
+        body: {
+          message: 'Invalid offset: must a positive number.'
         }
       }
     ]
@@ -1089,7 +1231,7 @@ export default [
       {
         description: 'If no id is given.',
         body: {
-          message: "Invalid group id."
+          message: 'Invalid group id.'
         }
       },
       {
@@ -1119,8 +1261,7 @@ export default [
       },
       {
         type: 'warning',
-        content:
-          "If no role has been specified for a member, it will default the role to 'member'."
+        content: "If no role has been specified for a member, it will default the role to 'member'."
       },
       {
         type: 'warning',
@@ -1246,12 +1387,10 @@ export default [
       },
       {
         description: "If one or more of the members' usernames are invalid",
-        body: { 
-          message: "2 Invalid usernames: Names must be 1-12 characters long,\n         contain no special characters, and/or contain no space at the beginning or end of the name.",
-          data: [
-            "Ps@ikoi",
-            "Zez?ima"
-          ]
+        body: {
+          message:
+            '2 Invalid usernames: Names must be 1-12 characters long,\n         contain no special characters, and/or contain no space at the beginning or end of the name.',
+          data: ['Ps@ikoi', 'Zez?ima']
         }
       },
       {
@@ -1260,7 +1399,7 @@ export default [
       },
       {
         description: 'If an invalid role has been specified.',
-        body: { message: "Invalid member roles. Must be 'member' or 'leader'."}
+        body: { message: "Invalid member roles. Must be 'member' or 'leader'." }
       }
     ]
   },
@@ -1301,50 +1440,50 @@ export default [
         description: '',
         body: {
           id: 9,
-          name: "Some new name",
-          clanChat: "fallyK",
-          description: "The big lebowski",
+          name: 'Some new name',
+          clanChat: 'fallyK',
+          description: 'The big lebowski',
           homeworld: 490,
           score: 0,
           verified: false,
-          createdAt: "2020-12-15T17:54:06.251Z",
-          updatedAt: "2020-12-15T17:55:57.669Z",
+          createdAt: '2020-12-15T17:54:06.251Z',
+          updatedAt: '2020-12-15T17:55:57.669Z',
           members: [
             {
               exp: 27957906,
               id: 2,
-              username: "zezima",
-              displayName: "Zezima",
-              type: "regular",
-              build: "main",
+              username: 'zezima',
+              displayName: 'Zezima',
+              type: 'regular',
+              build: 'main',
               flagged: false,
               ehp: 170.56992,
               ehb: 0,
               ttm: 1123.18632,
               tt200m: 14791.88113,
-              lastImportedAt: "2020-12-15T12:06:37.857Z",
-              lastChangedAt: "2020-12-15T12:06:35.467Z",
-              registeredAt: "2020-12-15T12:04:12.671Z",
-              updatedAt: "2020-12-15T12:06:37.864Z",
-              role: "member"
+              lastImportedAt: '2020-12-15T12:06:37.857Z',
+              lastChangedAt: '2020-12-15T12:06:35.467Z',
+              registeredAt: '2020-12-15T12:04:12.671Z',
+              updatedAt: '2020-12-15T12:06:37.864Z',
+              role: 'member'
             },
             {
               exp: 287727070,
               id: 3,
-              username: "psikoi",
-              displayName: "Psikoi",
-              type: "regular",
-              build: "main",
+              username: 'psikoi',
+              displayName: 'Psikoi',
+              type: 'regular',
+              build: 'main',
               flagged: false,
               ehp: 957.66169,
               ehb: 292.20288,
               ttm: 465.33077,
               tt200m: 14004.78936,
-              lastImportedAt: "2020-12-15T15:40:06.388Z",
-              lastChangedAt: "2020-12-15T15:40:02.052Z",
-              registeredAt: "2020-12-15T12:04:12.669Z",
-              updatedAt: "2020-12-15T15:40:06.388Z",
-              role: "leader"
+              lastImportedAt: '2020-12-15T15:40:06.388Z',
+              lastChangedAt: '2020-12-15T15:40:02.052Z',
+              registeredAt: '2020-12-15T12:04:12.669Z',
+              updatedAt: '2020-12-15T15:40:06.388Z',
+              role: 'leader'
             }
           ]
         }
@@ -1354,7 +1493,7 @@ export default [
       {
         description: 'If no id is given.',
         body: {
-          message: "Invalid group id."
+          message: 'Invalid group id.'
         }
       },
       {
@@ -1370,11 +1509,9 @@ export default [
       {
         description: "If one or more of the members' usernames are invalid.",
         body: {
-          message: "2 Invalid usernames: Names must be 1-12 characters long,\n         contain no special characters, and/or contain no space at the beginning or end of the name.",
-          data: [
-            "Ps@ikoi",
-            "Ze?zima"
-          ]
+          message:
+            '2 Invalid usernames: Names must be 1-12 characters long,\n         contain no special characters, and/or contain no space at the beginning or end of the name.',
+          data: ['Ps@ikoi', 'Ze?zima']
         }
       },
       {
@@ -1423,7 +1560,7 @@ export default [
       {
         description: 'If no id is given.',
         body: {
-          message: "Invalid group id."
+          message: 'Invalid group id.'
         }
       },
       {
@@ -1515,7 +1652,7 @@ export default [
       {
         description: 'If no id is given.',
         body: {
-          message: "Invalid group id."
+          message: 'Invalid group id.'
         }
       },
       {
@@ -1577,7 +1714,7 @@ export default [
       {
         description: 'If no id is given.',
         body: {
-          message: "Invalid group id."
+          message: 'Invalid group id.'
         }
       },
       {
@@ -1627,32 +1764,31 @@ export default [
     successResponses: [
       {
         description: '',
-        body: 
-          {
-            exp: 3332232052,
-            id: 5,
-            username: 'zulu',
-            displayName: 'Zulu',
-            type: 'regular',
-            build: 'main',
-            flagged: false,
-            ehp: 7126.74163,
-            ehb: 3536.61133,
-            ttm: 0,
-            tt200m: 7835.70942,
-            lastImportedAt: '2020-12-15T15:41:09.270Z',
-            lastChangedAt: '2020-12-15T15:32:21.940Z',
-            registeredAt: '2020-12-15T12:40:28.486Z',
-            updatedAt: '2020-12-15T15:41:09.270Z',
-            role: 'leader'
-          }
+        body: {
+          exp: 3332232052,
+          id: 5,
+          username: 'zulu',
+          displayName: 'Zulu',
+          type: 'regular',
+          build: 'main',
+          flagged: false,
+          ehp: 7126.74163,
+          ehb: 3536.61133,
+          ttm: 0,
+          tt200m: 7835.70942,
+          lastImportedAt: '2020-12-15T15:41:09.270Z',
+          lastChangedAt: '2020-12-15T15:32:21.940Z',
+          registeredAt: '2020-12-15T12:40:28.486Z',
+          updatedAt: '2020-12-15T15:41:09.270Z',
+          role: 'leader'
+        }
       }
     ],
     errorResponses: [
       {
         description: 'If no id is given.',
         body: {
-          message: "Invalid group id."
+          message: 'Invalid group id.'
         }
       },
       {
@@ -1683,7 +1819,7 @@ export default [
       },
       {
         description: 'If player already has the given role.',
-        body: { message: "Psikoi is already a leader." }
+        body: { message: 'Psikoi is already a leader.' }
       },
       {
         description: 'If the role is not valid',
@@ -1719,7 +1855,8 @@ export default [
       {
         description: '',
         body: {
-          message: '19 outdated (updated < 60 mins ago) players are being updated. This can take up to a few minutes.'
+          message:
+            '19 outdated (updated < 60 mins ago) players are being updated. This can take up to a few minutes.'
         }
       }
     ],
@@ -1727,7 +1864,7 @@ export default [
       {
         description: 'If no id is given.',
         body: {
-          message: "Invalid group id."
+          message: 'Invalid group id.'
         }
       },
       {

--- a/docs/src/configs/docs/names/endpoints.js
+++ b/docs/src/configs/docs/names/endpoints.js
@@ -5,6 +5,17 @@ export default [
     method: 'GET',
     query: [
       {
+        field: 'username',
+        type: 'string',
+        description: 'A partial username search, for either the old or new username - Optional'
+      },
+      {
+        field: 'status',
+        type: 'integer',
+        description:
+          'The name change status - Optional (Default is 0) (0 = pending, 1 = denied, 2 = approved)'
+      },
+      {
         field: 'limit',
         type: 'integer',
         description: 'The maximum amount of results to return - Optional (Default is 20)'

--- a/docs/src/configs/docs/names/endpoints.js
+++ b/docs/src/configs/docs/names/endpoints.js
@@ -12,8 +12,7 @@ export default [
       {
         field: 'status',
         type: 'integer',
-        description:
-          'The name change status - Optional (Default is 0) (0 = pending, 1 = denied, 2 = approved)'
+        description: 'The name change status - Optional (0 = pending, 1 = denied, 2 = approved)'
       },
       {
         field: 'limit',

--- a/server/src/api/controllers/group.controller.ts
+++ b/server/src/api/controllers/group.controller.ts
@@ -329,6 +329,25 @@ async function hiscores(req: Request, res: Response, next: NextFunction) {
   }
 }
 
+// GET /groups/:id/name-changes
+async function nameChanges(req: Request, res: Response, next: NextFunction) {
+  try {
+    const id = extractNumber(req.params, { key: 'id', required: true });
+    const limit = extractNumber(req.query, { key: 'limit' });
+    const offset = extractNumber(req.query, { key: 'offset' });
+
+    // Ensure this group Id exists (if not, it'll throw a 404 error)
+    await groupService.resolve(id);
+
+    const paginationConfig = getPaginationConfig(limit, offset);
+    const results = await groupService.getNameChanges(id, paginationConfig);
+
+    res.json(results);
+  } catch (e) {
+    next(e);
+  }
+}
+
 // GET /groups/:id/statistics
 async function statistics(req: Request, res: Response, next: NextFunction) {
   try {
@@ -357,6 +376,7 @@ export {
   achievements,
   records,
   hiscores,
+  nameChanges,
   statistics,
   competitions,
   listMembers,

--- a/server/src/api/controllers/name.controller.ts
+++ b/server/src/api/controllers/name.controller.ts
@@ -6,12 +6,13 @@ import * as pagination from '../util/pagination';
 // GET /names
 async function index(req: Request, res: Response, next: NextFunction) {
   try {
+    const username = extractString(req.query, { key: 'username' });
     const status = extractNumber(req.query, { key: 'status' });
     const limit = extractNumber(req.query, { key: 'limit' });
     const offset = extractNumber(req.query, { key: 'offset' });
 
     const paginationConfig = pagination.getPaginationConfig(limit, offset);
-    const results = await nameService.getList(status, paginationConfig);
+    const results = await nameService.getList(username, status, paginationConfig);
 
     res.json(results);
   } catch (e) {

--- a/server/src/api/events/name.events.ts
+++ b/server/src/api/events/name.events.ts
@@ -1,0 +1,8 @@
+import { NameChange } from '../../database/models';
+import * as nameService from '../services/internal/name.service';
+
+async function onNameChangeCreated(nameChange: NameChange) {
+  await nameService.autoReview(nameChange.id);
+}
+
+export { onNameChangeCreated };

--- a/server/src/api/events/name.events.ts
+++ b/server/src/api/events/name.events.ts
@@ -2,7 +2,11 @@ import { NameChange } from '../../database/models';
 import * as nameService from '../services/internal/name.service';
 
 async function onNameChangeCreated(nameChange: NameChange) {
-  await nameService.autoReview(nameChange.id);
+  // Delay this action to prevent proccessing too many
+  // simoultaneous name changes after a bulk submission
+  setTimeout(async () => {
+    await nameService.autoReview(nameChange.id);
+  }, Math.random() * 120_000);
 }
 
 export { onNameChangeCreated };

--- a/server/src/api/hooks.ts
+++ b/server/src/api/hooks.ts
@@ -1,9 +1,18 @@
 import { DestroyOptions, UpdateOptions } from 'sequelize/types';
-import { Achievement, Competition, Delta, Membership, Player, Snapshot } from '../database/models';
+import {
+  Achievement,
+  Competition,
+  Delta,
+  Membership,
+  Player,
+  Snapshot,
+  NameChange
+} from '../database/models';
 import { onAchievementsCreated } from './events/achievement.events';
 import { onCompetitionCreated, onCompetitionUpdated } from './events/competition.events';
 import { onDeltaUpdated } from './events/delta.events';
 import { onMembersJoined, onMembersLeft } from './events/group.events';
+import { onNameChangeCreated } from './events/name.events';
 import {
   onPlayerCreated,
   onPlayerImported,
@@ -12,6 +21,10 @@ import {
 } from './events/player.events';
 
 function setup() {
+  NameChange.afterCreate((nameChange: NameChange) => {
+    onNameChangeCreated(nameChange);
+  });
+
   Player.afterUpdate((player: Player, options: UpdateOptions) => {
     if (!options.fields || !options.fields.includes('username')) return;
     onPlayerNameChanged(player);

--- a/server/src/api/jobs/instances/RefreshNameChanges.ts
+++ b/server/src/api/jobs/instances/RefreshNameChanges.ts
@@ -16,7 +16,7 @@ class RefreshNameChanges implements Job {
   }
 
   async handle(): Promise<void> {
-    const pending = await nameService.getList(NameChangeStatus.PENDING, { limit: 100, offset: 0 });
+    const pending = await nameService.getList(null, NameChangeStatus.PENDING, { limit: 100, offset: 0 });
 
     pending.forEach((p, i) => {
       const delay = (i + 1) * REVIEW_COOLDOWN;

--- a/server/src/api/routes/group.routes.ts
+++ b/server/src/api/routes/group.routes.ts
@@ -22,6 +22,7 @@ api.get('/:id/gained', controller.gained);
 api.get('/:id/achievements', controller.achievements);
 api.get('/:id/records', controller.records);
 api.get('/:id/hiscores', controller.hiscores);
+api.get('/:id/name-changes', controller.nameChanges);
 api.get('/:id/statistics', controller.statistics);
 
 export default api;

--- a/server/src/api/services/internal/name.service.ts
+++ b/server/src/api/services/internal/name.service.ts
@@ -59,7 +59,7 @@ async function getPlayerNames(playerId: number): Promise<NameChange[]> {
 
 async function findAllForGroup(playerIds: number[], pagination: Pagination): Promise<NameChange[]> {
   const nameChanges = await NameChange.findAll({
-    where: { playerId: playerIds },
+    where: { playerId: playerIds, status: NameChangeStatus.APPROVED },
     include: [{ model: Player }],
     order: [['createdAt', 'DESC']],
     limit: pagination.limit,

--- a/server/src/api/services/internal/name.service.ts
+++ b/server/src/api/services/internal/name.service.ts
@@ -288,7 +288,16 @@ async function getDetails(id: number) {
 }
 
 async function autoReview(id: number): Promise<void> {
-  const details = await getDetails(id);
+  let details;
+
+  try {
+    details = await getDetails(id);
+  } catch (error) {
+    if (error.message === 'Old stats could not be found.') {
+      await deny(id, env.ADMIN_PASSWORD);
+      return;
+    }
+  }
 
   if (!details || details.nameChange.status !== NameChangeStatus.PENDING) return;
 

--- a/server/src/api/services/internal/name.service.ts
+++ b/server/src/api/services/internal/name.service.ts
@@ -23,14 +23,23 @@ import * as snapshotService from './snapshot.service';
 /**
  * List all name changes, filtered by a specific status
  */
-async function getList(status: number, pagination: Pagination): Promise<NameChange[]> {
+async function getList(username: string, status: number, pagination: Pagination): Promise<NameChange[]> {
   // Isn't a valid NameChangeStatus
   if (status && !NameChangeStatus[status]) {
     throw new BadRequestError('Invalid status.');
   }
 
+  const query = buildQuery({ status });
+
+  if (username && username.length > 0) {
+    query[Op.or] = [
+      { oldName: { [Op.like]: `${username}%` } },
+      { newName: { [Op.like]: `${username}%` } }
+    ];
+  }
+
   const nameChanges = await NameChange.findAll({
-    where: buildQuery({ status }),
+    where: query,
     order: [['createdAt', 'DESC']],
     limit: pagination.limit,
     offset: pagination.offset

--- a/server/src/api/services/internal/name.service.ts
+++ b/server/src/api/services/internal/name.service.ts
@@ -57,6 +57,18 @@ async function getPlayerNames(playerId: number): Promise<NameChange[]> {
   return nameChanges;
 }
 
+async function findAllForGroup(playerIds: number[], pagination: Pagination): Promise<NameChange[]> {
+  const nameChanges = await NameChange.findAll({
+    where: { playerId: playerIds },
+    include: [{ model: Player }],
+    order: [['createdAt', 'DESC']],
+    limit: pagination.limit,
+    offset: pagination.offset
+  });
+
+  return nameChanges;
+}
+
 async function bulkSubmit(nameChanges: { oldName: string; newName: string }[]) {
   if (!nameChanges || !Array.isArray(nameChanges)) {
     throw new BadRequestError('Invalid name change list format.');
@@ -448,4 +460,14 @@ async function transferRecords(filter: WhereOptions, targetId: number, transacti
   );
 }
 
-export { getList, getDetails, getPlayerNames, submit, bulkSubmit, deny, approve, autoReview };
+export {
+  getList,
+  getDetails,
+  getPlayerNames,
+  findAllForGroup,
+  submit,
+  bulkSubmit,
+  deny,
+  approve,
+  autoReview
+};

--- a/server/src/api/services/internal/name.service.ts
+++ b/server/src/api/services/internal/name.service.ts
@@ -306,8 +306,11 @@ async function autoReview(id: number): Promise<void> {
     return;
   }
 
-  // If the transition period is over 3 weeks
-  if (hoursDiff > 504) {
+  const baseMaxHours = 504;
+  const extraHours = (oldStats['overall'].experience / 2_000_000) * 168;
+
+  // If the transition period is over (3 weeks + 1 week per each 2m exp)
+  if (hoursDiff > baseMaxHours + extraHours) {
     return;
   }
 


### PR DESCRIPTION
Resolves #614
Resolves #615 

API:
- Auto review will now run once on submission
- Added "username" query param to the `/names` endpoint
- The maximum transition period for automatic approval is now scaled by the player's total exp
- Auto deny name changes for unregistered "old names"
- Added `/group/{id}/name-changes` endpoint
- Added bundling modifiers. Since a lot of the new name changes are registered in bulk via the new RuneLite plugin, it is fair to assume a name that has been submitted as part of a bulk submission is more likely to be legit. In this scenario, I will introduce a modifier that makes it easer for the name change to pass the auto approval (ex: min total goes from 700 to 350, max hours goes from 1000 to 2000)


App:
- Added username search bar to the names list page
- Added status dropdown selector to the names list page
- Added "Name Changes" tab to group page
