### PR TITLE
Custom Period Player Gains 

### DIFF
--- a/app/public/img/icons/warn_blue.svg
+++ b/app/public/img/icons/warn_blue.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#2980b9" width="24px" height="24px"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"/></svg>

--- a/app/src/modals/CustomPeriodSelectionModal/CustomPeriodSelectionModal.jsx
+++ b/app/src/modals/CustomPeriodSelectionModal/CustomPeriodSelectionModal.jsx
@@ -1,0 +1,49 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { DateRangeSelector, Button } from 'components';
+import './CustomPeriodSelectionModal.scss';
+
+const WEEK_IN_MS = 604800000;
+
+function CustomPeriodSelectionModal({ defaultStartDate, defaultEndDate, onConfirm, onCancel }) {
+  const [startDate, setStartDate] = useState(defaultStartDate || new Date(Date.now() - WEEK_IN_MS));
+  const [endDate, setEndDate] = useState(defaultEndDate || new Date());
+
+  function handleDateRangedChanged(dates) {
+    const [start, end] = dates;
+    setStartDate(start);
+    setEndDate(end);
+  }
+
+  function handleConfirm() {
+    onConfirm({ startDate, endDate });
+  }
+
+  return (
+    <div className="custom-period-selection">
+      <div className="custom-period-selection__modal">
+        <button className="modal-close-btn" type="button" onClick={onCancel}>
+          <img src="/img/icons/clear.svg" alt="X" />
+        </button>
+        <h4 className="modal-title">Select a custom time range</h4>
+        <b className="modal-label">Time range</b>
+        <DateRangeSelector start={startDate} end={endDate} onRangeChanged={handleDateRangedChanged} />
+        <Button text="Confirm" onClick={handleConfirm} disabled={!startDate || !endDate} />
+      </div>
+    </div>
+  );
+}
+
+CustomPeriodSelectionModal.defaultProps = {
+  defaultStartDate: undefined,
+  defaultEndDate: undefined
+};
+
+CustomPeriodSelectionModal.propTypes = {
+  defaultStartDate: PropTypes.instanceOf(Date),
+  defaultEndDate: PropTypes.instanceOf(Date),
+  onConfirm: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired
+};
+
+export default CustomPeriodSelectionModal;

--- a/app/src/modals/CustomPeriodSelectionModal/CustomPeriodSelectionModal.scss
+++ b/app/src/modals/CustomPeriodSelectionModal/CustomPeriodSelectionModal.scss
@@ -1,0 +1,55 @@
+@import '../../styles.scss';
+
+.custom-period-selection {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.7);
+  z-index: 300;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+
+  &__modal {
+    @extend %panel;
+    width: 400px;
+    max-width: 90%;
+    padding: 25px;
+    position: relative;
+    display: flex;
+    flex-direction: column;
+
+    .modal-title {
+      text-align: center;
+      padding: 0;
+      margin: 0;
+    }
+
+    .modal-label {
+      margin-top: 40px;
+      margin-bottom: 10px;
+      display: block;
+      font-size: 0.8em;
+    }
+
+    .modal-close-btn {
+      background: none;
+      border: none;
+      padding: 0;
+      align-self: flex-end;
+    }
+
+    .date-range-selector {
+      .date-input {
+        background: $gray-12;
+      }
+    }
+
+    .button {
+      margin-top: 25px;
+    }
+  }
+}

--- a/app/src/modals/CustomPeriodSelectionModal/index.js
+++ b/app/src/modals/CustomPeriodSelectionModal/index.js
@@ -1,0 +1,3 @@
+import CustomPeriodSelectionModal from './CustomPeriodSelectionModal';
+
+export default CustomPeriodSelectionModal;

--- a/app/src/pages/Competition/components/TeamPlayersTable/TeamPlayersTable.jsx
+++ b/app/src/pages/Competition/components/TeamPlayersTable/TeamPlayersTable.jsx
@@ -2,7 +2,8 @@ import React, { useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { durationBetween, getMinimumBossKc, getMetricName, isBoss, isSkill } from 'utils';
+import { durationBetween, getMinimumBossKc, getMetricName, isBoss, isSkill, isActivity } from 'utils';
+import URL from 'utils/url';
 import { SKILLS } from 'config';
 import { Table, PlayerTag, NumberLabel, TextLabel } from 'components';
 
@@ -20,7 +21,7 @@ function TeamPlayersTable({ competition, updatingUsernames, team, onUpdateClicke
         label: 'Name',
         className: () => '-primary',
         transform: (value, row) => (
-          <Link to={`/players/${row.username}`}>
+          <Link to={getPlayerRedirectURL(row, competition)}>
             <PlayerTag name={value} type={row.type} flagged={row.flagged} country={row.country} />
           </Link>
         )
@@ -122,6 +123,26 @@ function TableUpdateButton({ username, isUpdating, onUpdate }) {
       <img src="/img/icons/sync.svg" alt="" />
     </button>
   );
+}
+
+function getPlayerRedirectURL(player, competition) {
+  const { displayName } = player;
+  const { startsAt, endsAt, metric } = competition;
+
+  let metricType = 'skilling';
+  if (isBoss(metric) || metric === 'ehb') metricType = 'bossing';
+  if (isActivity(metric)) metricType = 'activities';
+
+  const nextURL = new URL(`/players`);
+  nextURL.appendToPath(`/${displayName.replace(' ', '_')}`);
+  nextURL.appendToPath('/gained');
+  nextURL.appendToPath(`/${metricType}`);
+
+  nextURL.appendSearchParam('period', 'custom');
+  nextURL.appendSearchParam('startDate', startsAt.toISOString());
+  nextURL.appendSearchParam('endDate', endsAt.toISOString());
+
+  return nextURL.getPath();
 }
 
 TeamPlayersTable.defaultProps = {

--- a/app/src/pages/Competition/containers/ParticipantsTable.jsx
+++ b/app/src/pages/Competition/containers/ParticipantsTable.jsx
@@ -4,7 +4,8 @@ import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { SKILLS } from 'config';
-import { durationBetween, getMinimumBossKc, getMetricName, isBoss, isSkill } from 'utils';
+import { durationBetween, getMinimumBossKc, getMetricName, isBoss, isSkill, isActivity } from 'utils';
+import URL from 'utils/url';
 import { Table, PlayerTag, NumberLabel, TextLabel, TablePlaceholder } from 'components';
 import { competitionSelectors } from 'redux/competitions';
 import { playerSelectors } from 'redux/players';
@@ -29,7 +30,7 @@ function ParticipantsTable({ competition, onUpdateClicked }) {
         label: 'Name',
         className: () => '-primary',
         transform: (value, row) => (
-          <Link to={`/players/${row.username}`}>
+          <Link to={getPlayerRedirectURL(row, competition)}>
             <PlayerTag name={value} type={row.type} flagged={row.flagged} country={row.country} />
           </Link>
         )
@@ -137,6 +138,26 @@ function TableUpdateButton({ username, isUpdating, onUpdate }) {
       <img src="/img/icons/sync.svg" alt="" />
     </button>
   );
+}
+
+function getPlayerRedirectURL(player, competition) {
+  const { displayName } = player;
+  const { startsAt, endsAt, metric } = competition;
+
+  let metricType = 'skilling';
+  if (isBoss(metric) || metric === 'ehb') metricType = 'bossing';
+  if (isActivity(metric)) metricType = 'activities';
+
+  const nextURL = new URL(`/players`);
+  nextURL.appendToPath(`/${displayName.replace(' ', '_')}`);
+  nextURL.appendToPath('/gained');
+  nextURL.appendToPath(`/${metricType}`);
+
+  nextURL.appendSearchParam('period', 'custom');
+  nextURL.appendSearchParam('startDate', startsAt.toISOString());
+  nextURL.appendSearchParam('endDate', endsAt.toISOString());
+
+  return nextURL.getPath();
 }
 
 ParticipantsTable.propTypes = {

--- a/app/src/pages/Player/Player.scss
+++ b/app/src/pages/Player/Player.scss
@@ -181,6 +181,30 @@
         opacity: 0.6;
         margin-right: 10px;
       }
+
+      &.-info {
+        border: 1px dashed $brand-color;
+        color: $gray-60;
+
+        button {
+          background: none;
+          border: none;
+          padding: 0;
+          margin: 0;
+          color: white;
+          font-weight: 700;
+
+          &:hover {
+            opacity: 0.5;
+            cursor: pointer;
+          }
+        }
+
+        img {
+          filter: none;
+          opacity: 1;
+        }
+      }
     }
 
     .chart__container {

--- a/app/src/pages/Player/components/PlayerDeltasTable/PlayerDeltasTable.jsx
+++ b/app/src/pages/Player/components/PlayerDeltasTable/PlayerDeltasTable.jsx
@@ -1,5 +1,4 @@
 import React, { useCallback } from 'react';
-import { filter } from 'lodash';
 import PropTypes from 'prop-types';
 import { Table, NumberLabel } from 'components';
 import { getLevel, getMetricIcon, getMetricName, round } from 'utils';
@@ -7,10 +6,7 @@ import { SKILLS, BOSSES, ACTIVITIES } from 'config';
 
 function PlayerDeltasTable({ deltas, period, metricType, highlightedMetric, onMetricSelected }) {
   const { data } = deltas[period];
-
   const [rows, columns, uniqueKeySelector] = getTableData(data, metricType);
-
-  const warning = filter(data, ({ rank }) => rank.start !== rank.end && rank.gained === 0).length > 0;
 
   function handleRowClicked(index) {
     if (rows && rows[index]) {
@@ -25,24 +21,13 @@ function PlayerDeltasTable({ deltas, period, metricType, highlightedMetric, onMe
   }
 
   return (
-    <>
-      {warning && (
-        <div className="deltas-warning">
-          <img src="/img/icons/warn_orange.svg" alt="" />
-          <span>
-            If your skill ranks wrongfuly show 0 gained, don&apos;t worry, this was caused by a bug and
-            it will go away on its own within a few days/weeks.
-          </span>
-        </div>
-      )}
-      <Table
-        rows={rows}
-        columns={columns}
-        uniqueKeySelector={uniqueKeySelector}
-        onRowClicked={onRowClicked}
-        highlightedRowKey={highlightedMetric}
-      />
-    </>
+    <Table
+      rows={rows}
+      columns={columns}
+      uniqueKeySelector={uniqueKeySelector}
+      onRowClicked={onRowClicked}
+      highlightedRowKey={highlightedMetric}
+    />
   );
 }
 

--- a/app/src/pages/Player/containers/Gained.jsx
+++ b/app/src/pages/Player/containers/Gained.jsx
@@ -172,9 +172,12 @@ function InvalidRanksWarning() {
 }
 
 function hasInvalidRanks(periodDeltas) {
-  return some(periodDeltas, ({ rank }) => {
-    return rank && rank.start !== rank.end && rank.gained === 0;
-  });
+  return (
+    periodDeltas &&
+    some(periodDeltas, data => {
+      return data && data.rank && data.rank.start !== data.rank.end && data.rank.gained === 0;
+    })
+  );
 }
 
 function getSelectedMetric(metric, metricType) {

--- a/app/src/redux/deltas/actions.js
+++ b/app/src/redux/deltas/actions.js
@@ -14,12 +14,14 @@ const fetchLeaderboards = (metric, period, type, build, country) => async dispat
   }
 };
 
-const fetchPlayerDeltas = username => async dispatch => {
+const fetchPlayerDeltas = (username, startDate = null, endDate = null) => async dispatch => {
   dispatch(reducers.onFetchPlayerDeltasRequest());
 
   try {
     const url = endpoints.fetchPlayerDeltas.replace(':username', username);
-    const { data } = await api.get(url);
+    const params = { startDate, endDate };
+
+    const { data } = await api.get(url, { params });
 
     dispatch(reducers.onFetchPlayerDeltasSuccess({ username, data }));
   } catch (e) {

--- a/app/src/redux/deltas/reducer.js
+++ b/app/src/redux/deltas/reducer.js
@@ -51,10 +51,13 @@ const slice = createSlice({
     },
     onFetchPlayerDeltasSuccess(state, action) {
       const { username, data } = action.payload;
+      const customPeriod = 'startsAt' in data;
 
       state.error = null;
       state.isFetchingPlayerDeltas = false;
-      state.playerDeltas[username] = data;
+      state.playerDeltas[username] = customPeriod
+        ? { ...state.playerDeltas[username], custom: data }
+        : data;
     },
     onFetchPlayerDeltasError(state, action) {
       state.isFetchingPlayerDeltas = false;

--- a/app/src/redux/snapshots/actions.js
+++ b/app/src/redux/snapshots/actions.js
@@ -1,12 +1,12 @@
 import api, { endpoints } from 'services/api';
 import { reducers } from './reducer';
 
-const fetchSnapshots = (username, period) => async dispatch => {
+const fetchSnapshots = (username, period, startDate, endDate) => async dispatch => {
   dispatch(reducers.onFetchRequest());
 
   try {
     const url = endpoints.fetchPlayerSnapshots.replace(':username', username);
-    const { data } = await api.get(url, { params: { period } });
+    const { data } = await api.get(url, { params: { period, startDate, endDate } });
 
     dispatch(reducers.onFetchSuccess({ username, period, data }));
   } catch (e) {

--- a/app/src/redux/snapshots/reducer.js
+++ b/app/src/redux/snapshots/reducer.js
@@ -19,7 +19,7 @@ const slice = createSlice({
 
       state.isFetching = false;
       state.error = null;
-      state.snapshots[username] = { ...state.snapshots[username], [period]: data };
+      state.snapshots[username] = { ...state.snapshots[username], [period || 'custom']: data };
     },
     onFetchError(state, action) {
       state.isFetching = false;

--- a/app/src/utils/dates.js
+++ b/app/src/utils/dates.js
@@ -1,5 +1,9 @@
 import moment from 'moment';
 
+export function isValidDate(date) {
+  return date && moment(date, moment.ISO_8601).isValid();
+}
+
 export function formatDate(date, mask = 'MM-DD-YYYY HH:mm') {
   return moment(date).format(mask);
 }

--- a/app/src/utils/url.js
+++ b/app/src/utils/url.js
@@ -6,6 +6,10 @@ class URL {
     this.basePath = basePath;
   }
 
+  getSearchParam(key) {
+    return this.params && this.params.find(p => p.key === key);
+  }
+
   appendSearchParam(key, value) {
     if (!this.params) {
       this.params = [];

--- a/docs/src/configs/docs/players/endpoints.js
+++ b/docs/src/configs/docs/players/endpoints.js
@@ -877,6 +877,12 @@ export default [
       {
         type: 'info',
         content: 'This endpoint has two valid URLs, by player id or username.'
+      },
+      {
+        type: 'warning',
+        content:
+          'To see values within a specific custom time period, you can use the "startDate" and "endDate" query params. \
+          Or to simply see values within the last fixed time period, use the "period" param.'
       }
     ],
     params: [
@@ -895,7 +901,18 @@ export default [
       {
         field: 'period',
         type: 'string',
-        description: 'The time period to filter the snapshots by (See accepted values above)'
+        description:
+          'The time period to filter the snapshots by - Optional only if supplying "startDate" and "endDate"'
+      },
+      {
+        field: 'startDate',
+        type: 'string',
+        description: "The snapshot history's start date - Optional"
+      },
+      {
+        field: 'endDate',
+        type: 'string',
+        description: "The snapshot history's end date - Optional"
       }
     ],
     successResponses: [
@@ -958,11 +975,14 @@ export default [
       },
       {
         type: 'warning',
-        content: 'The response will be formatted into a json-friendlier format. See example below.'
+        content:
+          'If the "period", "startDate" and "endDate" params are not supplied, it will return the deltas for all fixed periods.'
       },
       {
         type: 'warning',
-        content: 'If the "period" param is not supplied, it will return the deltas for all periods.'
+        content:
+          'To see values within a specific custom time period, you can use the "startDate" and "endDate" query params. \
+          Or to simply see values within the last fixed time period, use the "period" param.'
       }
     ],
     params: [
@@ -981,7 +1001,17 @@ export default [
       {
         field: 'period',
         type: 'string',
-        description: "The delta's period (See accepted values above) - Optional"
+        description: "The delta's period - Optional"
+      },
+      {
+        field: 'startDate',
+        type: 'string',
+        description: "The delta's start date - Optional"
+      },
+      {
+        field: 'endDate',
+        type: 'string',
+        description: "The delta's end date - Optional"
       }
     ],
     successResponses: [
@@ -1293,7 +1323,7 @@ export default [
       {
         field: 'period',
         type: 'string',
-        description: "The record's period (See accepted values above) - Optional"
+        description: "The record's period - Optional"
       },
       {
         field: 'metric',

--- a/server/src/api/controllers/player.controller.ts
+++ b/server/src/api/controllers/player.controller.ts
@@ -258,7 +258,7 @@ async function snapshots(req: Request, res: Response, next: NextFunction) {
 
     const playerSnapshots = period
       ? await snapshotService.getPlayerPeriodSnapshots(playerId, period)
-      : await snapshotService.getPlayerTimeRangeSnapshots(id, startDate, endDate);
+      : await snapshotService.getPlayerTimeRangeSnapshots(playerId, startDate, endDate);
 
     if (id && playerSnapshots.length === 0) {
       // Ensure this player Id exists (if not, it'll throw a 404 error)

--- a/server/src/api/controllers/player.controller.ts
+++ b/server/src/api/controllers/player.controller.ts
@@ -251,10 +251,14 @@ async function snapshots(req: Request, res: Response, next: NextFunction) {
     const id = extractNumber(req.params, { key: 'id' });
     const username = extractString(req.params, { key: 'username' });
     const period = extractString(req.query, { key: 'period' });
+    const startDate = extractDate(req.query, { key: 'startDate', required: !period });
+    const endDate = extractDate(req.query, { key: 'endDate', required: !period });
 
     const playerId = await playerService.resolveId({ id, username });
 
-    const playerSnapshots = await snapshotService.getSnapshots(playerId, period);
+    const playerSnapshots = period
+      ? await snapshotService.getPlayerPeriodSnapshots(playerId, period)
+      : await snapshotService.getPlayerTimeRangeSnapshots(id, startDate, endDate);
 
     if (id && playerSnapshots.length === 0) {
       // Ensure this player Id exists (if not, it'll throw a 404 error)

--- a/server/src/api/services/internal/delta.service.ts
+++ b/server/src/api/services/internal/delta.service.ts
@@ -118,14 +118,18 @@ async function getPlayerPeriodDeltas(
   initial?: InitialValues,
   player?: Player
 ) {
-  if (!PERIODS.includes(period)) {
+  const [periodStr, durationMs] = parsePeriod(period);
+
+  if (!periodStr) {
     throw new BadRequestError(`Invalid period: ${period}.`);
   }
 
-  const startDate = new Date(Date.now() - getMilliseconds(period));
-  const delta = await getPlayerTimeRangeDeltas(playerId, startDate, new Date(), latest, initial, player);
+  const startDate = new Date(Date.now() - durationMs);
+  const endDate = new Date();
 
-  return { ...delta, period };
+  const deltas = await getPlayerTimeRangeDeltas(playerId, startDate, endDate, latest, initial, player);
+
+  return { period: periodStr, ...deltas };
 }
 
 /**

--- a/server/src/api/services/internal/delta.service.ts
+++ b/server/src/api/services/internal/delta.service.ts
@@ -5,7 +5,7 @@ import { Delta, InitialValues, Player, Snapshot } from '../../../database/models
 import { Pagination } from '../../../types';
 import { ALL_METRICS, PERIODS, PLAYER_BUILDS, PLAYER_TYPES } from '../../constants';
 import { BadRequestError } from '../../errors';
-import { getSeconds } from '../../util/dates';
+import { getMilliseconds, parsePeriod } from '../../util/dates';
 import { getMeasure, getRankKey, getValueKey, isBoss, isSkill, isVirtual } from '../../util/metrics';
 import { round } from '../../util/numbers';
 import { buildQuery } from '../../util/query';
@@ -37,7 +37,7 @@ async function syncDeltas(player: Player, latestSnapshot: Snapshot) {
 
   await Promise.all(
     PERIODS.map(async period => {
-      const startingDate = moment().subtract(getSeconds(period), 'seconds').toDate();
+      const startingDate = moment().subtract(getMilliseconds(period), 'milliseconds').toDate();
       const startSnapshot = await snapshotService.findFirstSince(player.id, startingDate);
 
       const currentDelta = await Delta.findOne({
@@ -122,7 +122,7 @@ async function getPlayerPeriodDeltas(
     throw new BadRequestError(`Invalid period: ${period}.`);
   }
 
-  const startDate = new Date(Date.now() - getSeconds(period) * 1000);
+  const startDate = new Date(Date.now() - getMilliseconds(period));
   const delta = await getPlayerTimeRangeDeltas(playerId, startDate, new Date(), latest, initial, player);
 
   return { ...delta, period };
@@ -180,7 +180,7 @@ async function getLeaderboard(filter: GlobalDeltasFilter, pagination: Pagination
   }
 
   const query = buildQuery({ type: playerType, build: playerBuild, country: countryCode });
-  const startingDate = moment().subtract(getSeconds(period), 'seconds').toDate();
+  const startingDate = moment().subtract(getMilliseconds(period), 'milliseconds').toDate();
 
   // When filtering by player type, the ironman filter should include UIM and HCIM
   if (query.type && query.type === 'ironman') {

--- a/server/src/api/services/internal/name.service.ts
+++ b/server/src/api/services/internal/name.service.ts
@@ -9,7 +9,6 @@ import {
   Record,
   Snapshot
 } from '../../../database/models';
-import env from '../../../env';
 import { NameChangeStatus, Pagination } from '../../../types';
 import { SKILLS } from '../../constants';
 import { BadRequestError, NotFoundError, ServerError } from '../../errors';

--- a/server/src/api/services/internal/snapshot.service.ts
+++ b/server/src/api/services/internal/snapshot.service.ts
@@ -4,7 +4,7 @@ import { Op } from 'sequelize';
 import { Snapshot } from '../../../database/models';
 import { ACTIVITIES, ALL_METRICS, BOSSES, PERIODS, SKILLS } from '../../constants';
 import { BadRequestError, ServerError } from '../../errors';
-import { getSeconds } from '../../util/dates';
+import { getMilliseconds } from '../../util/dates';
 import { getMeasure, getRankKey, getValueKey, isBoss, isSkill } from '../../util/metrics';
 import * as efficiencyService from './efficiency.service';
 
@@ -112,7 +112,7 @@ async function getSnapshots(playerId: number, period: string) {
     throw new BadRequestError(`Invalid period: ${period}.`);
   }
 
-  const before = moment().subtract(getSeconds(period), 'seconds').toDate();
+  const before = moment().subtract(getMilliseconds(period), 'milliseconds').toDate();
 
   const result = await Snapshot.findAll({
     where: {

--- a/server/src/api/services/internal/snapshot.service.ts
+++ b/server/src/api/services/internal/snapshot.service.ts
@@ -123,7 +123,7 @@ async function getPlayerPeriodSnapshots(playerId: number, period: string) {
 
 async function getPlayerTimeRangeSnapshots(playerId: number, startDate: Date, endDate: Date) {
   const snapshots = await findAllBetween([playerId], startDate, endDate);
-  return snapshots.map(format);
+  return snapshots.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime()).map(format);
 }
 
 /**

--- a/server/src/api/services/internal/snapshot.service.ts
+++ b/server/src/api/services/internal/snapshot.service.ts
@@ -145,9 +145,9 @@ async function findAll(playerId: number, limit: number): Promise<Snapshot[]> {
 /**
  * Finds the latest snapshot for a given player.
  */
-async function findLatest(playerId: number): Promise<Snapshot | null> {
+async function findLatest(playerId: number, maxDate = new Date()): Promise<Snapshot | null> {
   const result = await Snapshot.findOne({
-    where: { playerId },
+    where: { playerId, createdAt: { [Op.lte]: maxDate } },
     order: [['createdAt', 'DESC']]
   });
 

--- a/server/src/api/services/internal/snapshot.service.ts
+++ b/server/src/api/services/internal/snapshot.service.ts
@@ -2,9 +2,9 @@ import csv from 'csvtojson';
 import moment from 'moment';
 import { Op } from 'sequelize';
 import { Snapshot } from '../../../database/models';
-import { ACTIVITIES, ALL_METRICS, BOSSES, PERIODS, SKILLS } from '../../constants';
+import { ACTIVITIES, ALL_METRICS, BOSSES, SKILLS } from '../../constants';
 import { BadRequestError, ServerError } from '../../errors';
-import { getMilliseconds } from '../../util/dates';
+import { parsePeriod } from '../../util/dates';
 import { getMeasure, getRankKey, getValueKey, isBoss, isSkill } from '../../util/metrics';
 import * as efficiencyService from './efficiency.service';
 
@@ -108,11 +108,13 @@ function hasNegativeGains(before: Snapshot, after: Snapshot): boolean {
  * Finds all snapshots within a time period, for a given player.
  */
 async function getSnapshots(playerId: number, period: string) {
-  if (!PERIODS.includes(period)) {
+  const [periodStr, durationMs] = parsePeriod(period);
+
+  if (!periodStr) {
     throw new BadRequestError(`Invalid period: ${period}.`);
   }
 
-  const before = moment().subtract(getMilliseconds(period), 'milliseconds').toDate();
+  const before = moment().subtract(durationMs, 'milliseconds').toDate();
 
   const result = await Snapshot.findAll({
     where: {

--- a/server/src/api/util/dates.ts
+++ b/server/src/api/util/dates.ts
@@ -13,7 +13,7 @@ function parsePeriod(period: string): [string, number] | null {
   const result = fixed.match(CUSTOM_PERIOD_REGEX);
 
   if (!result || result.length === 0 || result[0] !== fixed) {
-    return null;
+    return [null, null];
   }
 
   const years = result[1] ? parseInt(result[1].replace(/\D/g, '')) : null;

--- a/server/src/api/util/dates.ts
+++ b/server/src/api/util/dates.ts
@@ -1,4 +1,37 @@
 import moment from 'moment';
+import { PERIODS } from '../constants';
+
+const CUSTOM_PERIOD_REGEX = /(\d+y)?(\d+m)?(\d+w)?(\d+d)?(\d+h)?/;
+
+function parsePeriod(period: string): [string, number] | null {
+  const fixed = period.toLowerCase();
+
+  if (PERIODS.includes(fixed)) {
+    return [fixed, getMilliseconds(fixed)];
+  }
+
+  const result = fixed.match(CUSTOM_PERIOD_REGEX);
+
+  if (!result || result.length === 0 || result[0] !== fixed) {
+    return null;
+  }
+
+  const years = result[1] ? parseInt(result[1].replace(/\D/g, '')) : null;
+  const months = result[2] ? parseInt(result[2].replace(/\D/g, '')) : null;
+  const weeks = result[3] ? parseInt(result[3].replace(/\D/g, '')) : null;
+  const days = result[4] ? parseInt(result[4].replace(/\D/g, '')) : null;
+  const hours = result[5] ? parseInt(result[5].replace(/\D/g, '')) : null;
+
+  const yearsMs = years ? years * getMilliseconds('year') : 0;
+  const monthsMs = months ? months * getMilliseconds('month') : 0;
+  const weeksMs = weeks ? weeks * getMilliseconds('week') : 0;
+  const daysMs = days ? days * getMilliseconds('day') : 0;
+  const hoursMs = hours ? hours * getMilliseconds('hour') : 0;
+
+  const totalMs = yearsMs + monthsMs + weeksMs + daysMs + hoursMs;
+
+  return [result[0], totalMs];
+}
 
 // TODO: This should be removed after TS migration is done
 // and we're using Date types for the other methods in this file
@@ -65,21 +98,23 @@ function durationBetween(startDate, endDate) {
   return str;
 }
 
-function getSeconds(period: string) {
+function getMilliseconds(period: string) {
   switch (period) {
+    case 'hour':
+      return 3600 * 1000;
     case '6h':
-      return 3600 * 6;
+      return 3600 * 6 * 1000;
     case 'day':
-      return 3600 * 24;
+      return 3600 * 24 * 1000;
     case 'week':
-      return 3600 * 24 * 7;
+      return 3600 * 24 * 7 * 1000;
     case 'month':
-      return 3600 * 24 * 31;
+      return 3600 * 24 * 31 * 1000;
     case 'year':
-      return 31556926;
+      return 31556926 * 1000;
     default:
       return -1;
   }
 }
 
-export { isValidDate, isPast, durationBetween, getSeconds };
+export { parsePeriod, isValidDate, isPast, durationBetween, getMilliseconds };


### PR DESCRIPTION
Resolves #390 

**Adds support for custom time periods and time ranges to the player gain calcs.** 

This was previously restricted to: `year`, `month`, `week`, `day`, `6h` but now supports a more flexible format such as `6m2d5h` and `1y5h` and time ranges.

### API: 
- Adds custom period parsing
- Adds "startDate" & "endDate" query parameters to `/players/.../gained`
- Adds "startDate" & "endDate" query parameters to `/players/.../snapshots`

### App:
- App: Added "Custom Period" option to period dropdown selector in the Player page
- App: Added Time range selector pop-up to Player page
- App: Added startDate/endDate query params to /players/:username
- App: Tweak gains and snapshots redux actions to support time ranges
- App: Add info panel above the gains table detailing this selected time range
- App: Add direct link to time range player gains from a competition's page

### Bot:
- Bot: Test and ensure the custom periods are supported
- Bot: Add custom periods to command tip
- Bot: Update docs