### PR TITLE
Show full build name in player info section

### DIFF
--- a/app/src/pages/Player/containers/Overview.jsx
+++ b/app/src/pages/Player/containers/Overview.jsx
@@ -9,7 +9,8 @@ import {
   durationBetween,
   getMetricName,
   getExperienceAt,
-  formatNumber
+  formatNumber,
+  getPlayerBuild
 } from 'utils';
 import { ALL_METRICS, SKILLS, BOSSES, ACTIVITIES } from 'config';
 import { InfoPanel, CardList, Selector } from 'components';
@@ -214,7 +215,7 @@ function Info({ player }) {
   const data = [
     { key: 'Id', value: id },
     { key: 'Type', value: capitalize(type) },
-    { key: 'Build', value: capitalize(build) },
+    { key: 'Build', value: getPlayerBuild(build) },
     { key: 'Last updated at', value: formatDate(updatedAt, 'DD MMM YYYY, HH:mm') },
     { key: 'Last changed at', value: lastChangedDate },
     { key: 'Registered at', value: formatDate(registeredAt, 'DD MMM YYYY, HH:mm') }


### PR DESCRIPTION
Show full build name in player info section instead of the capitalized short version (`1def`/`F2p`/`Lvl3`/`10hp`).

### Example
![image](https://user-images.githubusercontent.com/14054353/107082344-51622600-67f4-11eb-919a-f707dfbc3520.png)
