### PR TITLE
Add missing `SKIP_PREFLIGHT_CHECK` in `.env.example` file

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -1,1 +1,2 @@
 REACT_APP_API_BASE_URL=http://localhost:5000/api
+SKIP_PREFLIGHT_CHECK=true


### PR DESCRIPTION
Add missing `SKIP_PREFLIGHT_CHECK` in `.env.example` file that are described in the `Environment Variables` section in the [App Development Guide](https://github.com/wise-old-man/wise-old-man/blob/master/.github/contributing/app-guide.md#environment-variables).
