### PR TITLE
Fix auto adding new members to team competitions

### DIFF
--- a/server/src/api/services/internal/competition.service.ts
+++ b/server/src/api/services/internal/competition.service.ts
@@ -829,6 +829,7 @@ async function addToGroupCompetitions(groupId, playerIds) {
     attributes: ['id'],
     where: {
       groupId,
+      type: 'classic',
       endsAt: { [Op.gt]: new Date() }
     }
   });


### PR DESCRIPTION
Any new group member was being added to all upcoming/ongoing competitions.

This was fine except for the recently added team competitions, since they don't usually include all the group members.