### PR TITLE
Fix team competition progress reset

### DIFF
--- a/app/src/pages/Competition/containers/TeamsTable.jsx
+++ b/app/src/pages/Competition/containers/TeamsTable.jsx
@@ -54,7 +54,7 @@ function TeamsTable({ competition, onUpdateClicked }) {
         className: () => '-break-small',
         transform: val => {
           const lowThreshold = isSkill(competition.metric) ? 10000 : 5;
-          return <NumberLabel value={val} lowThreshold={lowThreshold} isColored isSigned />;
+          return <NumberLabel value={Math.floor(val)} lowThreshold={lowThreshold} isColored isSigned />;
         }
       },
       {


### PR DESCRIPTION
Fixes #667 

- Fixes the team progress being reset when a team competition was edited (updating players would fix it)
- Fixes the decimals on the team's average gained