### PR TITLE
Feat/achievement expansion refactor

### DIFF
--- a/app/src/pages/Group/containers/AchievementsTable.jsx
+++ b/app/src/pages/Group/containers/AchievementsTable.jsx
@@ -31,7 +31,7 @@ const TABLE_CONFIG = {
       transform: value => <img src={getMetricIcon(value, true)} alt="" />
     },
     {
-      key: 'type',
+      key: 'name',
       className: () => '-no-padding'
     },
     {

--- a/app/src/pages/Player/components/AchievementGroup/AchievementGroup.scss
+++ b/app/src/pages/Player/components/AchievementGroup/AchievementGroup.scss
@@ -3,7 +3,7 @@
 .achievement-group {
   @extend %panel;
   background: $gray-07;
-  padding: 10px 15px;
+  padding: 10px 12px;
   margin-bottom: 15px;
   display: flex;
   flex-direction: row;
@@ -11,12 +11,12 @@
 
   .group-icon {
     width: 30px;
-    margin-right: 10px;
+    margin-right: 5px;
   }
 
   .group-title {
-    font-size: 0.9em;
-    min-width: 130px;
+    font-size: 0.8em;
+    min-width: 80px;
 
     &.-bossing {
       min-width: 181px;

--- a/app/src/pages/Player/containers/Achievements.jsx
+++ b/app/src/pages/Player/containers/Achievements.jsx
@@ -21,33 +21,15 @@ function Achievements() {
     achievementSelectors.getPlayerAchievementsGrouped(state, username)
   );
 
-  const achievements = useSelector(state => achievementSelectors.getPlayerAchievements(state, username));
+  const allAchievements = useSelector(state =>
+    achievementSelectors.getPlayerAchievements(state, username, true)
+  );
+
+  const completedAchievements = useSelector(state =>
+    achievementSelectors.getPlayerAchievements(state, username)
+  );
 
   const groups = getFilteredAchievements(groupedAchievements, metricType);
-
-  const nearest = groups
-    .map(g => g.achievements)
-    .flat()
-    .filter(a => a.progress.absolutePercent < 1 && a.measure !== 'levels')
-    .sort((a, b) => b.progress.absolutePercent - a.progress.absolutePercent)
-    .slice(0, 20);
-
-  const completedAchievements = achievements
-    .filter(a => a.createdAt !== null)
-    .sort((a, b) => b.createdAt - a.createdAt)
-    .slice(0, 20);
-
-  const nearestItems = nearest.map(i => ({
-    icon: getMetricIcon(i.metric),
-    title: i.type,
-    subtitle: `${Math.round(i.progress.absolutePercent * 10000) / 100}% completed`
-  }));
-
-  const achievementItems = completedAchievements.map(a => ({
-    icon: getMetricIcon(a.metric),
-    title: a.type,
-    subtitle: a.unknownDate ? 'Unknown date' : formatDate(a.createdAt, 'DD MMM, YYYY')
-  }));
 
   const metricTypeIndex = METRIC_TYPE_OPTIONS.findIndex(o => o.value === metricType);
 
@@ -61,6 +43,29 @@ function Achievements() {
     }
   }
 
+  if (!groupedAchievements || !completedAchievements || !allAchievements) {
+    return null;
+  }
+
+  const nearestItems = allAchievements
+    .filter(a => a.absoluteProgress < 1)
+    .sort((a, b) => b.absoluteProgress - a.absoluteProgress)
+    .slice(0, 20)
+    .map(i => ({
+      icon: getMetricIcon(i.metric),
+      title: i.name,
+      subtitle: `${Math.round(i.absoluteProgress * 10000) / 100}% completed`
+    }));
+
+  const recentItems = completedAchievements
+    .sort((a, b) => b.createdAt - a.createdAt)
+    .slice(0, 20)
+    .map(a => ({
+      icon: getMetricIcon(a.metric),
+      title: a.name,
+      subtitle: a.unknownDate ? 'Unknown date' : formatDate(a.createdAt, 'DD MMM, YYYY')
+    }));
+
   return (
     <>
       <div className="row achievements-controls">
@@ -73,10 +78,10 @@ function Achievements() {
         </div>
       </div>
       <div className="player-nearest-achievements__container col-lg-3 col-md-12">
-        {achievementItems && achievementItems.length > 0 && (
+        {recentItems && recentItems.length > 0 && (
           <>
             <span className="panel-label">Recent achievements</span>
-            <CardList items={achievementItems} />
+            <CardList items={recentItems} />
           </>
         )}
         {nearestItems && nearestItems.length > 0 && (

--- a/app/src/pages/Player/containers/Achievements.jsx
+++ b/app/src/pages/Player/containers/Achievements.jsx
@@ -29,8 +29,6 @@ function Achievements() {
     achievementSelectors.getPlayerAchievements(state, username)
   );
 
-  const groups = getFilteredAchievements(groupedAchievements, metricType);
-
   const metricTypeIndex = METRIC_TYPE_OPTIONS.findIndex(o => o.value === metricType);
 
   function handleMetricTypeSelected(e) {
@@ -47,8 +45,10 @@ function Achievements() {
     return null;
   }
 
+  const groups = groupedAchievements.filter(a => isOfMetricType(a, metricType));
+
   const nearestItems = allAchievements
-    .filter(a => a.absoluteProgress < 1)
+    .filter(a => isOfMetricType(a, metricType) && a.absoluteProgress < 1)
     .sort((a, b) => b.absoluteProgress - a.absoluteProgress)
     .slice(0, 20)
     .map(i => ({
@@ -57,7 +57,8 @@ function Achievements() {
       subtitle: `${Math.round(i.absoluteProgress * 10000) / 100}% completed`
     }));
 
-  const recentItems = completedAchievements
+  const latestItems = completedAchievements
+    .filter(a => isOfMetricType(a, metricType))
     .sort((a, b) => b.createdAt - a.createdAt)
     .slice(0, 20)
     .map(a => ({
@@ -78,10 +79,10 @@ function Achievements() {
         </div>
       </div>
       <div className="player-nearest-achievements__container col-lg-3 col-md-12">
-        {recentItems && recentItems.length > 0 && (
+        {latestItems && latestItems.length > 0 && (
           <>
-            <span className="panel-label">Recent achievements</span>
-            <CardList items={recentItems} />
+            <span className="panel-label">Latest achievements</span>
+            <CardList items={latestItems} />
           </>
         )}
         {nearestItems && nearestItems.length > 0 && (
@@ -104,20 +105,10 @@ function Achievements() {
   );
 }
 
-function getFilteredAchievements(groups, metricType) {
-  if (!groups) {
-    return [];
-  }
-
-  if (metricType === 'skilling') {
-    return groups.filter(r => isSkill(r.metric) || r.metric === 'combat');
-  }
-
-  if (metricType === 'activities') {
-    return groups.filter(r => isActivity(r.metric));
-  }
-
-  return groups.filter(r => isBoss(r.metric) || r.metric === 'bossing');
+function isOfMetricType(achievement, metricType) {
+  if (metricType === 'skilling') return isSkill(achievement.metric) || achievement.metric === 'combat';
+  if (metricType === 'activities') return isActivity(achievement.metric);
+  return isBoss(achievement.metric) || achievement.metric === 'bossing';
 }
 
 export default Achievements;

--- a/app/src/pages/Player/containers/Overview.jsx
+++ b/app/src/pages/Player/containers/Overview.jsx
@@ -7,7 +7,6 @@ import {
   capitalize,
   getMetricIcon,
   durationBetween,
-  getMetricName,
   getExperienceAt,
   formatNumber,
   getPlayerBuild
@@ -129,20 +128,16 @@ function ClosestSkills({ player }) {
 }
 
 function RecentAchievements({ player, achievements }) {
-  const completedAchievements = achievements
-    .filter(a => a.createdAt !== null)
+  if (!achievements || achievements.length === 0) return null;
+
+  const achievementItems = achievements
     .sort((a, b) => b.createdAt - a.createdAt)
-    .slice(0, 3);
-
-  if (completedAchievements.length === 0) {
-    return null;
-  }
-
-  const achievementItems = completedAchievements.map(a => ({
-    icon: getAchievementIcon(a.type),
-    title: a.type,
-    subtitle: a.unknownDate ? 'Unknown date' : formatDate(a.createdAt, 'DD MMM, YYYY')
-  }));
+    .slice(0, 3)
+    .map(a => ({
+      icon: getAchievementIcon(a.metric),
+      title: a.name,
+      subtitle: a.unknownDate ? 'Unknown date' : formatDate(a.createdAt, 'DD MMM, YYYY')
+    }));
 
   return (
     <>
@@ -224,18 +219,12 @@ function Info({ player }) {
   return <InfoPanel data={data} />;
 }
 
-function getAchievementIcon(type) {
-  for (let i = 0; i < ALL_METRICS.length; i++) {
-    if (type.includes(getMetricName(ALL_METRICS[i]))) {
-      return getMetricIcon(ALL_METRICS[i]);
-    }
+function getAchievementIcon(metric) {
+  if (ALL_METRICS.includes(metric)) {
+    return getMetricIcon(metric);
   }
 
-  if (type === '126 Combat') {
-    return getMetricIcon('combat');
-  }
-
-  return getMetricIcon('overall');
+  return getMetricIcon('combat');
 }
 
 ClosestSkills.propTypes = {
@@ -245,10 +234,16 @@ ClosestSkills.propTypes = {
 };
 
 RecentAchievements.propTypes = {
+  player: PropTypes.shape({
+    displayName: PropTypes.string
+  }).isRequired,
   achievements: PropTypes.arrayOf(PropTypes.shape({})).isRequired
 };
 
 Competitions.propTypes = {
+  player: PropTypes.shape({
+    displayName: PropTypes.string
+  }).isRequired,
   competitions: PropTypes.arrayOf(PropTypes.shape({})).isRequired
 };
 

--- a/app/src/redux/achievements/actions.js
+++ b/app/src/redux/achievements/actions.js
@@ -5,10 +5,9 @@ const fetchPlayerAchievements = username => async dispatch => {
   dispatch(reducers.onFetchPlayerAchievementsRequest());
 
   try {
-    const params = { includeMissing: true };
     const url = endpoints.fetchPlayerAchievements.replace(':username', username);
 
-    const { data } = await api.get(url, { params });
+    const { data } = await api.get(url);
 
     dispatch(reducers.onFetchPlayerAchievementsSuccess({ username, data }));
   } catch (e) {

--- a/app/src/redux/achievements/selectors.js
+++ b/app/src/redux/achievements/selectors.js
@@ -1,12 +1,18 @@
 import { createSelector } from 'reselect';
+import { mapValues } from 'lodash';
 import { ALL_METRICS } from 'config';
 
 const rootSelector = state => state.achievements;
 const playerAchievementsSelector = state => state.achievements.playerAchievements;
 const groupAchievementsSelector = state => state.achievements.groupAchievements;
 
-const getPlayerAchievementsMap = createSelector(playerAchievementsSelector, map => map);
-const getGroupAchievementsMap = createSelector(groupAchievementsSelector, map => map);
+const getPlayerAchievementsMap = createSelector(playerAchievementsSelector, map => {
+  return mapValues(map, p => p.map(formatAchievement));
+});
+
+const getGroupAchievementsMap = createSelector(groupAchievementsSelector, map => {
+  return mapValues(map, p => p.map(formatAchievement));
+});
 
 export const isFetchingGroupAchievements = createSelector(
   rootSelector,
@@ -47,3 +53,8 @@ export const getPlayerAchievementsGrouped = (state, username) => {
 
   return groups.sort((a, b) => ALL_METRICS.indexOf(a.metric) - ALL_METRICS.indexOf(b.metric));
 };
+
+function formatAchievement(a) {
+  const isDateUnknown = a.createdAt && a.createdAt.getFullYear() < 2000;
+  return { ...a, unknownDate: !!isDateUnknown };
+}

--- a/app/src/redux/achievements/selectors.js
+++ b/app/src/redux/achievements/selectors.js
@@ -1,138 +1,49 @@
 import { createSelector } from 'reselect';
-import { mapValues } from 'lodash';
-import { getPlayer } from 'redux/players/selectors';
-import { getCappedTotalXp } from 'utils';
-import { ALL_METRICS, CAPPED_MAX_TOTAL_XP } from 'config';
+import { ALL_METRICS } from 'config';
 
 const rootSelector = state => state.achievements;
 const playerAchievementsSelector = state => state.achievements.playerAchievements;
 const groupAchievementsSelector = state => state.achievements.groupAchievements;
 
-const getPlayerAchievementsMap = createSelector(playerAchievementsSelector, map => {
-  return mapValues(map, p => p.map(a => formatAchievement(a)));
-});
-
-const getGroupAchievementsMap = createSelector(groupAchievementsSelector, map => {
-  return mapValues(map, p => p.map(a => formatAchievement(a)));
-});
+const getPlayerAchievementsMap = createSelector(playerAchievementsSelector, map => map);
+const getGroupAchievementsMap = createSelector(groupAchievementsSelector, map => map);
 
 export const isFetchingGroupAchievements = createSelector(
   rootSelector,
   root => root.isFetchingGroupAchievements
 );
 
-export const getPlayerAchievements = (state, username) => getPlayerAchievementsMap(state)[username];
 export const getGroupAchievements = (state, groupId) => getGroupAchievementsMap(state)[groupId];
 
-export const getPlayerAchievementsGrouped = (state, username) => {
-  const player = getPlayer(state, username);
-  const list = getPlayerAchievements(state, username);
+export const getPlayerAchievements = (state, username, includeMissing = false) => {
+  const achievements = getPlayerAchievementsMap(state)[username];
 
-  if (!list) {
+  if (!achievements || achievements.length === 0 || includeMissing) {
+    return achievements;
+  }
+
+  return achievements.filter(a => !!a.createdAt);
+};
+
+export const getPlayerAchievementsGrouped = (state, username) => {
+  const achievements = getPlayerAchievementsMap(state)[username];
+
+  if (!achievements) {
     return [];
   }
 
-  const sorted = list.sort(
-    (a, b) =>
-      a.metric.localeCompare(b.metric) || a.measure.localeCompare(b.measure) || a.threshold - b.threshold
-  );
-
   const groups = [];
-  let previousMetric = '';
-  let previousMeasure = '';
 
-  sorted.forEach(s => {
-    if (s.metric === 'overall' && s.measure === 'experience' && s.threshold === CAPPED_MAX_TOTAL_XP) {
-      groups.push({ metric: s.metric, measure: s.measure, achievements: [s] });
-    } else {
-      if (s.metric === previousMetric && s.measure === previousMeasure) {
-        groups[groups.length - 1].achievements.push(s);
-      } else {
-        groups.push({ metric: s.metric, measure: s.measure, achievements: [s] });
-      }
+  achievements.forEach(a => {
+    let group = groups.find(g => g.measure === a.measure && g.metric === a.metric);
 
-      previousMetric = s.metric;
-      previousMeasure = s.measure;
+    if (!group) {
+      group = { metric: a.metric, measure: a.measure, achievements: [] };
+      groups.push(group);
     }
+
+    group.achievements.push(a);
   });
 
-  const processed = groups
-    .map(group => processGroup(player, group))
-    .sort((a, b) => ALL_METRICS.indexOf(a.metric) - ALL_METRICS.indexOf(b.metric))
-    .sort((a, b) => a.achievements.length - b.achievements.length);
-
-  return processed;
+  return groups.sort((a, b) => ALL_METRICS.indexOf(a.metric) - ALL_METRICS.indexOf(b.metric));
 };
-
-function processGroup(player, group) {
-  if (!player || !player.latestSnapshot) {
-    return group;
-  }
-
-  const { latestSnapshot } = player;
-
-  if (group.metric === 'combat') {
-    const progress = {
-      start: 0,
-      end: 126,
-      current: player.combatLevel,
-      percentToNextTier: player.combatLevel / 126,
-      absolutePercent: player.combatLevel / 126
-    };
-    return { ...group, achievements: [...group.achievements.map(a => ({ ...a, progress }))] };
-  }
-
-  if (group.metric === 'overall' && group.measure === 'experience' && group.achievements.length === 1) {
-    const totalXp = getCappedTotalXp(latestSnapshot);
-    const progress = {
-      start: 0,
-      end: CAPPED_MAX_TOTAL_XP,
-      current: totalXp,
-      percentToNextTier: totalXp / CAPPED_MAX_TOTAL_XP,
-      absolutePercent: totalXp / CAPPED_MAX_TOTAL_XP
-    };
-    return { ...group, achievements: [...group.achievements.map(a => ({ ...a, progress }))] };
-  }
-
-  if (latestSnapshot[group.metric]) {
-    const currentValue = latestSnapshot[group.metric][group.measure];
-
-    const processedAchievements = group.achievements.map((achievement, i) => {
-      if (currentValue >= achievement.threshold) {
-        return {
-          ...achievement,
-          progress: {
-            start: 0,
-            end: achievement.threshold,
-            current: currentValue,
-            percentToNextTier: 1,
-            absolutePercent: 1
-          }
-        };
-      }
-
-      const prevStart = i === 0 ? 0 : group.achievements[i - 1].threshold;
-      const nextTierProgress = (currentValue - prevStart) / (achievement.threshold - prevStart);
-
-      return {
-        ...achievement,
-        progress: {
-          start: 0,
-          end: achievement.threshold,
-          current: currentValue,
-          percentToNextTier: Math.max(0, nextTierProgress),
-          absolutePercent: currentValue / achievement.threshold
-        }
-      };
-    });
-
-    return { ...group, achievements: processedAchievements };
-  }
-
-  return group;
-}
-
-function formatAchievement(a) {
-  const isDateUnknown = a.createdAt && a.createdAt.getFullYear() < 2000;
-  return { ...a, unknownDate: !!isDateUnknown };
-}

--- a/app/src/services/api.js
+++ b/app/src/services/api.js
@@ -56,7 +56,7 @@ const endpoints = {
   assertPlayerName: '/players/assert-name/',
   fetchPlayerDetails: '/players/username/:username/',
   fetchPlayerGroups: '/players/username/:username/groups/',
-  fetchPlayerAchievements: '/players/username/:username/achievements/',
+  fetchPlayerAchievements: '/players/username/:username/achievements/progress',
   fetchPlayerCompetitions: '/players/username/:username/competitions/',
   fetchPlayerSnapshots: '/players/username/:username/snapshots/',
   fetchPlayerRecords: '/players/username/:username/records/',

--- a/docs/src/configs/docs/achievements/entities.js
+++ b/docs/src/configs/docs/achievements/entities.js
@@ -9,14 +9,19 @@ export default [
         description: 'The id of the corresponding player.'
       },
       {
-        field: 'type',
+        field: 'name',
         type: 'string',
-        description: 'The achievement type (See accepted values below).'
+        description: 'The achievement name. (Ex: 99 Smithing)'
       },
       {
         field: 'metric',
         type: 'string',
         description: 'The achievement metric (See accepted values below).'
+      },
+      {
+        field: 'measure',
+        type: 'string',
+        description: 'The achievement measure (See accepted values below).'
       },
       {
         field: 'threshold',
@@ -31,45 +36,495 @@ export default [
     ]
   },
   {
-    name: 'Achievement Type',
+    name: 'Achievement Name',
     description:
-      'All the possible values for the "type" field. Note: {skill} is replaced by every skill\'s name.',
+      'All the possible values for the "name" field. Note: {skill} is replaced by every skill\'s name.',
     structure: [
       {
-        type: '{threshold} {skill}',
-        metric: '{skill}',
-        measure: 'experience',
-        thresholds: '13034431, 50000000, 100000000, 200000000'
-      },
-      {
-        type: '{threshold} Overall Exp.',
+        name: 'Base {level} Stats',
         metric: 'overall',
-        measure: 'experience',
-        thresholds: '500000000, 1000000000, 2000000000, 4600000000'
+        measure: 'levels',
+        thresholds: '273k (60), 737k (70), 1.98m (80), 5.34m (90), 13m (99)'
       },
       {
-        type: 'Maxed Overall',
-        metric: 'overall',
-        measure: 'experience',
-        thresholds: '299791913'
-      },
-      {
-        type: '126 Combat',
+        name: '126 Combat',
         metric: 'combat',
         measure: 'levels',
         thresholds: '126'
       },
       {
-        type: '{threshold} {activity}',
-        metric: '{activity}',
-        measure: 'score',
-        thresholds: '1000, 5000, 10000'
+        name: '{threshold} Overall Exp.',
+        metric: 'overall',
+        measure: 'experience',
+        thresholds: '100m, 200m, 500m, 1b, 2b, 4.6b'
       },
       {
-        type: '{threshold} {boss}',
-        metric: '{boss}',
+        name: '{threshold} Attack',
+        metric: 'attack',
+        measure: 'experience',
+        thresholds: '13m (99), 50m, 100m, 200m'
+      },
+      {
+        name: '{threshold} Defence',
+        metric: 'defence',
+        measure: 'experience',
+        thresholds: '13m (99), 50m, 100m, 200m'
+      },
+      {
+        name: '{threshold} Strength',
+        metric: 'strength',
+        measure: 'experience',
+        thresholds: '13m (99), 50m, 100m, 200m'
+      },
+      {
+        name: '{threshold} Hitpoints',
+        metric: 'hitpoints',
+        measure: 'experience',
+        thresholds: '13m (99), 50m, 100m, 200m'
+      },
+      {
+        name: '{threshold} Ranged',
+        metric: 'ranged',
+        measure: 'experience',
+        thresholds: '13m (99), 50m, 100m, 200m'
+      },
+      {
+        name: '{threshold} Prayer',
+        metric: 'prayer',
+        measure: 'experience',
+        thresholds: '13m (99), 50m, 100m, 200m'
+      },
+      {
+        name: '{threshold} Magic',
+        metric: 'magic',
+        measure: 'experience',
+        thresholds: '13m (99), 50m, 100m, 200m'
+      },
+      {
+        name: '{threshold} Cooking',
+        metric: 'cooking',
+        measure: 'experience',
+        thresholds: '13m (99), 50m, 100m, 200m'
+      },
+      {
+        name: '{threshold} Woodcutting',
+        metric: 'woodcutting',
+        measure: 'experience',
+        thresholds: '13m (99), 50m, 100m, 200m'
+      },
+      {
+        name: '{threshold} Fletching',
+        metric: 'fletching',
+        measure: 'experience',
+        thresholds: '13m (99), 50m, 100m, 200m'
+      },
+      {
+        name: '{threshold} Fishing',
+        metric: 'fishing',
+        measure: 'experience',
+        thresholds: '13m (99), 50m, 100m, 200m'
+      },
+      {
+        name: '{threshold} Firemaking',
+        metric: 'firemaking',
+        measure: 'experience',
+        thresholds: '13m (99), 50m, 100m, 200m'
+      },
+      {
+        name: '{threshold} Crafting',
+        metric: 'crafting',
+        measure: 'experience',
+        thresholds: '13m (99), 50m, 100m, 200m'
+      },
+      {
+        name: '{threshold} Smithing',
+        metric: 'smithing',
+        measure: 'experience',
+        thresholds: '13m (99), 50m, 100m, 200m'
+      },
+      {
+        name: '{threshold} Mining',
+        metric: 'mining',
+        measure: 'experience',
+        thresholds: '13m (99), 50m, 100m, 200m'
+      },
+      {
+        name: '{threshold} Herblore',
+        metric: 'herblore',
+        measure: 'experience',
+        thresholds: '13m (99), 50m, 100m, 200m'
+      },
+      {
+        name: '{threshold} Agility',
+        metric: 'agility',
+        measure: 'experience',
+        thresholds: '13m (99), 50m, 100m, 200m'
+      },
+      {
+        name: '{threshold} Thieving',
+        metric: 'thieving',
+        measure: 'experience',
+        thresholds: '13m (99), 50m, 100m, 200m'
+      },
+      {
+        name: '{threshold} Slayer',
+        metric: 'slayer',
+        measure: 'experience',
+        thresholds: '13m (99), 50m, 100m, 200m'
+      },
+      {
+        name: '{threshold} Farming',
+        metric: 'farming',
+        measure: 'experience',
+        thresholds: '13m (99), 50m, 100m, 200m'
+      },
+      {
+        name: '{threshold} Runecrafting',
+        metric: 'runecrafting',
+        measure: 'experience',
+        thresholds: '13m (99), 50m, 100m, 200m'
+      },
+      {
+        name: '{threshold} Hunter',
+        metric: 'hunter',
+        measure: 'experience',
+        thresholds: '13m (99), 50m, 100m, 200m'
+      },
+      {
+        name: '{threshold} Construction',
+        metric: 'construction',
+        measure: 'experience',
+        thresholds: '13m (99), 50m, 100m, 200m'
+      },
+      {
+        name: '{threshold} Abyssal Sire kills',
+        metric: 'abyssal_sire',
         measure: 'kills',
-        thresholds: '500, 1000, 5000, 10000'
+        thresholds: '500, 1k, 5k, 10k'
+      },
+      {
+        name: '{threshold} Alchemical Hydra kills',
+        metric: 'alchemical_hydra',
+        measure: 'kills',
+        thresholds: '500, 1k, 5k, 10k'
+      },
+      {
+        name: '{threshold} Barrows Chests',
+        metric: 'barrows_chests',
+        measure: 'kills',
+        thresholds: '500, 1k, 5k, 10k'
+      },
+      {
+        name: '{threshold} Bryophyta kills',
+        metric: 'bryophyta',
+        measure: 'kills',
+        thresholds: '50, 100, 500, 1k'
+      },
+      {
+        name: '{threshold} Callisto kills',
+        metric: 'callisto',
+        measure: 'kills',
+        thresholds: '500, 1k, 5k, 10k'
+      },
+      {
+        name: '{threshold} Cerberus kills',
+        metric: 'cerberus',
+        measure: 'kills',
+        thresholds: '500, 1k, 5k, 10k'
+      },
+      {
+        name: '{threshold} Chambers Of Xeric kills',
+        metric: 'chambers_of_xeric',
+        measure: 'kills',
+        thresholds: '100, 500, 1k, 5k'
+      },
+      {
+        name: '{threshold} Chambers Of Xeric (CM) kills',
+        metric: 'chambers_of_xeric_challenge_mode',
+        measure: 'kills',
+        thresholds: '100, 500, 1k, 5k'
+      },
+      {
+        name: '{threshold} Chaos Elemental kills',
+        metric: 'chaos_elemental',
+        measure: 'kills',
+        thresholds: '500, 1k, 5k, 10k'
+      },
+      {
+        name: '{threshold} Chaos Fanatic kills',
+        metric: 'chaos_fanatic',
+        measure: 'kills',
+        thresholds: '500, 1k, 5k, 10k'
+      },
+      {
+        name: '{threshold} Commander Zilyana kills',
+        metric: 'commander_zilyana',
+        measure: 'kills',
+        thresholds: '500, 1k, 5k, 10k'
+      },
+      {
+        name: '{threshold} Corporeal Beast kills',
+        metric: 'corporeal_beast',
+        measure: 'kills',
+        thresholds: '500, 1k, 5k, 10k'
+      },
+      {
+        name: '{threshold} Crazy Archaeologist kills',
+        metric: 'crazy_archaeologist',
+        measure: 'kills',
+        thresholds: '500, 1k, 5k, 10k'
+      },
+      {
+        name: '{threshold} Dagannoth Prime kills',
+        metric: 'dagannoth_prime',
+        measure: 'kills',
+        thresholds: '500, 1k, 5k, 10k'
+      },
+      {
+        name: '{threshold} Dagannoth Rex kills',
+        metric: 'dagannoth_rex',
+        measure: 'kills',
+        thresholds: '500, 1k, 5k, 10k'
+      },
+      {
+        name: '{threshold} Dagannoth Supreme kills',
+        metric: 'dagannoth_supreme',
+        measure: 'kills',
+        thresholds: '500, 1k, 5k, 10k'
+      },
+      {
+        name: '{threshold} Deranged Archaeologist kills',
+        metric: 'deranged_archaeologist',
+        measure: 'kills',
+        thresholds: '500, 1k, 5k, 10k'
+      },
+      {
+        name: '{threshold} General Graardor kills',
+        metric: 'general_graardor',
+        measure: 'kills',
+        thresholds: '500, 1k, 5k, 10k'
+      },
+      {
+        name: '{threshold} Giant Mole kills',
+        metric: 'giant_mole',
+        measure: 'kills',
+        thresholds: '500, 1k, 5k, 10k'
+      },
+      {
+        name: '{threshold} Grotesque Guardians kills',
+        metric: 'grotesque_guardians',
+        measure: 'kills',
+        thresholds: '500, 1k, 5k, 10k'
+      },
+      {
+        name: '{threshold} Hespori kills',
+        metric: 'hespori',
+        measure: 'kills',
+        thresholds: '50, 100, 500, 1k'
+      },
+      {
+        name: '{threshold} Kalphite Queen kills',
+        metric: 'kalphite_queen',
+        measure: 'kills',
+        thresholds: '500, 1k, 5k, 10k'
+      },
+      {
+        name: '{threshold} King Black Dragon kills',
+        metric: 'king_black_dragon',
+        measure: 'kills',
+        thresholds: '500, 1k, 5k, 10k'
+      },
+      {
+        name: '{threshold} Kraken kills',
+        metric: 'kraken',
+        measure: 'kills',
+        thresholds: '500, 1k, 5k, 10k'
+      },
+      {
+        name: "{threshold} Kree'Arra kills",
+        metric: 'kreearra',
+        measure: 'kills',
+        thresholds: '500, 1k, 5k, 10k'
+      },
+      {
+        name: "{threshold} K'ril Tsutsaroth kills",
+        metric: 'kril_tsutsaroth',
+        measure: 'kills',
+        thresholds: '500, 1k, 5k, 10k'
+      },
+      {
+        name: '{threshold} Mimic kills',
+        metric: 'mimic',
+        measure: 'kills',
+        thresholds: '10, 50, 100, 200'
+      },
+      {
+        name: '{threshold} Nightmare kills',
+        metric: 'nightmare',
+        measure: 'kills',
+        thresholds: '500, 1k, 5k, 10k'
+      },
+      {
+        name: '{threshold} Obor kills',
+        metric: 'obor',
+        measure: 'kills',
+        thresholds: '50, 100, 500, 1k'
+      },
+      {
+        name: '{threshold} Sarachnis kills',
+        metric: 'sarachnis',
+        measure: 'kills',
+        thresholds: '500, 1k, 5k, 10k'
+      },
+      {
+        name: '{threshold} Scorpia kills',
+        metric: 'scorpia',
+        measure: 'kills',
+        thresholds: '500, 1k, 5k, 10k'
+      },
+      {
+        name: '{threshold} Skotizo kills',
+        metric: 'skotizo',
+        measure: 'kills',
+        thresholds: '50, 100, 500, 1k'
+      },
+      {
+        name: '{threshold} The Gauntlet kills',
+        metric: 'the_gauntlet',
+        measure: 'kills',
+        thresholds: '100, 200, 1k, 2k'
+      },
+      {
+        name: '{threshold} The Corrupted Gauntlet kills',
+        metric: 'the_corrupted_gauntlet',
+        measure: 'kills',
+        thresholds: '100, 200, 1k, 2k'
+      },
+      {
+        name: '{threshold} Theatre Of Blood kills',
+        metric: 'theatre_of_blood',
+        measure: 'kills',
+        thresholds: '100, 500, 1k, 5k'
+      },
+      {
+        name: '{threshold} Thermonuclear Smoke Devil kills',
+        metric: 'thermonuclear_smoke_devil',
+        measure: 'kills',
+        thresholds: '500, 1k, 5k, 10k'
+      },
+      {
+        name: '{threshold} TzKal-Zuk kills',
+        metric: 'tzkal_zuk',
+        measure: 'kills',
+        thresholds: '10, 50, 100, 200'
+      },
+      {
+        name: '{threshold} TzTok-Jad kills',
+        metric: 'tztok_jad',
+        measure: 'kills',
+        thresholds: '50, 100, 500, 1k'
+      },
+      {
+        name: '{threshold} Venenatis kills',
+        metric: 'venenatis',
+        measure: 'kills',
+        thresholds: '500, 1k, 5k, 10k'
+      },
+      {
+        name: "{threshold} Vet'ion kills",
+        metric: 'vetion',
+        measure: 'kills',
+        thresholds: '500, 1k, 5k, 10k'
+      },
+      {
+        name: '{threshold} Vorkath kills',
+        metric: 'vorkath',
+        measure: 'kills',
+        thresholds: '500, 1k, 5k, 10k'
+      },
+      {
+        name: '{threshold} Wintertodt kills',
+        metric: 'wintertodt',
+        measure: 'kills',
+        thresholds: '500, 1k, 5k, 10k'
+      },
+      {
+        name: '{threshold} Zalcano kills',
+        metric: 'zalcano',
+        measure: 'kills',
+        thresholds: '500, 1k, 5k, 10k'
+      },
+      {
+        name: '{threshold} Zulrah kills',
+        metric: 'zulrah',
+        measure: 'kills',
+        thresholds: '500, 1k, 5k, 10k'
+      },
+      {
+        name: '{threshold} Bounty Hunter (Hunter) score',
+        metric: 'bounty_hunter_hunter',
+        measure: 'score',
+        thresholds: '1k, 5k, 10k'
+      },
+      {
+        name: '{threshold} Bounty Hunter (Rogue) score',
+        metric: 'bounty_hunter_rogue',
+        measure: 'score',
+        thresholds: '1k, 5k, 10k'
+      },
+      {
+        name: '{threshold} Clue Scrolls (All)',
+        metric: 'clue_scrolls_all',
+        measure: 'score',
+        thresholds: '500, 1k, 5k, 10k'
+      },
+      {
+        name: '{threshold} Clue Scrolls (Beginner)',
+        metric: 'clue_scrolls_beginner',
+        measure: 'score',
+        thresholds: '200, 500, 1k, 5k'
+      },
+      {
+        name: '{threshold} Clue Scrolls (Easy)',
+        metric: 'clue_scrolls_easy',
+        measure: 'score',
+        thresholds: '500, 1k, 5k, 10k'
+      },
+      {
+        name: '{threshold} Clue Scrolls (Medium)',
+        metric: 'clue_scrolls_medium',
+        measure: 'score',
+        thresholds: '500, 1k, 5k, 10k'
+      },
+      {
+        name: '{threshold} Clue Scrolls (Hard)',
+        metric: 'clue_scrolls_hard',
+        measure: 'score',
+        thresholds: '500, 1k, 5k, 10k'
+      },
+      {
+        name: '{threshold} Clue Scrolls (Elite)',
+        metric: 'clue_scrolls_elite',
+        measure: 'score',
+        thresholds: '100, 500, 1k, 5k'
+      },
+      {
+        name: '{threshold} Clue Scrolls (Master)',
+        metric: 'clue_scrolls_master',
+        measure: 'score',
+        thresholds: '100, 500, 1k, 5k'
+      },
+      {
+        name: '{threshold} Last Man Standing score',
+        metric: 'last_man_standing',
+        measure: 'score',
+        thresholds: '2k, 5k, 10k, 15k'
+      },
+      {
+        name: '{threshold} Soul Wars Zeal',
+        metric: 'soul_wars_zeal',
+        measure: 'score',
+        thresholds: '5k, 10k, 20k'
       }
     ]
   },
@@ -102,7 +557,6 @@ export default [
       'runecrafting',
       'hunter',
       'construction',
-      'league_points',
       'bounty_hunter_hunter',
       'bounty_hunter_rogue',
       'clue_scrolls_all',
@@ -159,5 +613,10 @@ export default [
       'zalcano',
       'zulrah'
     ]
+  },
+  {
+    name: 'Achievement Measure',
+    description: 'All the possible values for the "measure" field.',
+    values: ['experience', 'kills', 'score', 'levels']
   }
 ];

--- a/docs/src/configs/docs/groups/endpoints.js
+++ b/docs/src/configs/docs/groups/endpoints.js
@@ -923,7 +923,8 @@ export default [
           {
             threshold: 13034431,
             playerId: 1709,
-            type: '99 Hitpoints',
+            name: '99 Hitpoints',
+            measure: 'experience',
             metric: 'hitpoints',
             createdAt: '2020-10-25T22:13:33.547Z',
             player: {
@@ -947,7 +948,8 @@ export default [
           {
             threshold: 100,
             playerId: 1709,
-            type: '100 Chambers Of Xeric kills',
+            name: '100 Chambers Of Xeric kills',
+            measure: 'kills',
             metric: 'chambers_of_xeric',
             createdAt: '2020-10-21T16:05:54.100Z',
             player: {
@@ -971,7 +973,8 @@ export default [
           {
             threshold: 13034431,
             playerId: 1340,
-            type: '99 Cooking',
+            name: '99 Cooking',
+            measure: 'experience',
             metric: 'cooking',
             createdAt: '2020-10-11T12:42:57.955Z',
             player: {

--- a/docs/src/configs/docs/players/endpoints.js
+++ b/docs/src/configs/docs/players/endpoints.js
@@ -459,11 +459,6 @@ export default [
       {
         type: 'warning',
         content: 'If the achievement date is unknown, this will return it as "1970-01-01T00:00:00.000Z".'
-      },
-      {
-        type: 'warning',
-        content:
-          'If includeMissing is true, any unachieved achievements will have "createdAt: null" and "missing: true"'
       }
     ],
     params: [
@@ -478,391 +473,121 @@ export default [
         description: "The player's username. (Not required if id is supplied)"
       }
     ],
-    query: [
+    successResponses: [
       {
-        field: 'includeMissing',
-        type: 'boolean',
-        description: 'If true, it will return every achievement, even the unachieved - Optional'
+        description: '',
+        body: [
+          {
+            playerId: 2,
+            name: "500 K'ril Tsutsaroth kills",
+            measure: 'kills',
+            metric: 'kril_tsutsaroth',
+            threshold: 500,
+            createdAt: '1970-01-01T00:00:00.000Z'
+          },
+          {
+            playerId: 2,
+            name: '99 Strength',
+            measure: 'experience',
+            metric: 'strength',
+            threshold: 13034431,
+            createdAt: '2015-12-14T04:15:36.000Z'
+          },
+          {
+            playerId: 2,
+            name: '99 Hitpoints',
+            measure: 'experience',
+            metric: 'hitpoints',
+            threshold: 13034431,
+            createdAt: '2015-06-24T15:57:40.000Z'
+          }
+        ]
+      }
+    ],
+    errorResponses: []
+  },
+  {
+    title: 'View player achievement progress',
+    urls: ['/players/:id/achievements/progress', '/players/username/:username/achievements/progress'],
+    method: 'GET',
+    comments: [
+      {
+        type: 'info',
+        content: 'This endpoint has two valid URLs, by player id or username.'
+      },
+      {
+        type: 'info',
+        content:
+          'This endpoint will return all the possible achievements, regardless of whether they are completed or not.'
+      },
+      {
+        type: 'warning',
+        content: 'If the achievement date is unknown, this will return it as "1970-01-01T00:00:00.000Z".'
+      },
+      {
+        type: 'warning',
+        content: 'If the achievement is not yet completed, its date will be null.'
+      }
+    ],
+    params: [
+      {
+        field: 'id',
+        type: 'integer',
+        description: "The player's id. (Not required if username is supplied)"
+      },
+      {
+        field: 'username',
+        type: 'string',
+        description: "The player's username. (Not required if id is supplied)"
       }
     ],
     successResponses: [
       {
-        description: 'With includeMissing param set to false (Not showing the whole response)',
+        description: '',
         body: [
           {
             playerId: 2,
-            type: "500 K'ril Tsutsaroth kills",
-            metric: 'kril_tsutsaroth',
+            name: '500 Abyssal Sire kills',
+            metric: 'abyssal_sire',
+            measure: 'kills',
             threshold: 500,
+            currentValue: 1049,
+            absoluteProgress: 1,
+            relativeProgress: 1,
             createdAt: '1970-01-01T00:00:00.000Z'
           },
           {
             playerId: 2,
-            type: '99 Strength',
-            metric: 'strength',
-            threshold: 13034431,
-            createdAt: '2015-12-14T04:15:36.000Z'
+            name: '1k Abyssal Sire kills',
+            metric: 'abyssal_sire',
+            measure: 'kills',
+            threshold: 1000,
+            currentValue: 1049,
+            absoluteProgress: 1,
+            relativeProgress: 1,
+            createdAt: '1970-01-01T00:00:00.000Z'
           },
           {
             playerId: 2,
-            type: '99 Hitpoints',
-            metric: 'hitpoints',
-            threshold: 13034431,
-            createdAt: '2015-06-24T15:57:40.000Z'
-          },
-          {
-            playerId: 2,
-            type: '99 Ranged',
-            metric: 'ranged',
-            threshold: 13034431,
-            createdAt: '2015-12-14T04:15:36.000Z'
-          },
-          {
-            playerId: 2,
-            type: '99 Attack',
-            metric: 'attack',
-            threshold: 13034431,
-            createdAt: '2015-06-24T15:57:40.000Z'
-          },
-          {
-            playerId: 2,
-            type: '99 Defence',
-            metric: 'defence',
-            threshold: 13034431,
-            createdAt: '2015-12-14T04:15:36.000Z'
-          },
-          {
-            playerId: 2,
-            type: '99 Magic',
-            metric: 'magic',
-            threshold: 13034431,
-            createdAt: '2015-12-14T04:15:36.000Z'
-          },
-          {
-            playerId: 2,
-            type: '99 Woodcutting',
-            metric: 'woodcutting',
-            threshold: 13034431,
-            createdAt: '2020-05-27T23:49:34.529Z'
-          },
-          {
-            playerId: 2,
-            type: '5k Zulrah kills',
-            metric: 'zulrah',
+            name: '5k Abyssal Sire kills',
+            metric: 'abyssal_sire',
+            measure: 'kills',
             threshold: 5000,
-            createdAt: '2020-05-27T23:49:34.532Z'
+            currentValue: 1049,
+            absoluteProgress: 0.2098,
+            relativeProgress: 0.0123,
+            createdAt: null
           },
           {
             playerId: 2,
-            type: '99 Slayer',
-            metric: 'slayer',
-            threshold: 13034431,
-            createdAt: '2018-01-21T18:02:52.000Z'
-          },
-          {
-            playerId: 2,
-            type: '99 Farming',
-            metric: 'farming',
-            threshold: 13034431,
-            createdAt: '2019-10-15T23:37:08.000Z'
-          },
-          {
-            playerId: 2,
-            type: '500 Abyssal Sire kills',
-            metric: 'abyssal_sire',
-            threshold: 500,
-            createdAt: '1970-01-01T00:00:00.000Z'
-          },
-          {
-            playerId: 2,
-            type: '500 Cerberus kills',
-            metric: 'cerberus',
-            threshold: 500,
-            createdAt: '1970-01-01T00:00:00.000Z'
-          },
-          {
-            playerId: 2,
-            type: '500 Commander Zilyana kills',
-            metric: 'commander_zilyana',
-            threshold: 500,
-            createdAt: '1970-01-01T00:00:00.000Z'
-          },
-          {
-            playerId: 2,
-            type: '500 General Graardor kills',
-            metric: 'general_graardor',
-            threshold: 500,
-            createdAt: '1970-01-01T00:00:00.000Z'
-          },
-          {
-            playerId: 2,
-            type: '500 Zulrah kills',
-            metric: 'zulrah',
-            threshold: 500,
-            createdAt: '1970-01-01T00:00:00.000Z'
-          },
-          {
-            playerId: 2,
-            type: '1k Abyssal Sire kills',
-            metric: 'abyssal_sire',
-            threshold: 1000,
-            createdAt: '1970-01-01T00:00:00.000Z'
-          },
-          {
-            playerId: 2,
-            type: '1k Cerberus kills',
-            metric: 'cerberus',
-            threshold: 1000,
-            createdAt: '1970-01-01T00:00:00.000Z'
-          },
-          {
-            playerId: 2,
-            type: '1k Commander Zilyana kills',
-            metric: 'commander_zilyana',
-            threshold: 1000,
-            createdAt: '1970-01-01T00:00:00.000Z'
-          },
-          {
-            playerId: 2,
-            type: '1k Zulrah kills',
-            metric: 'zulrah',
-            threshold: 1000,
-            createdAt: '1970-01-01T00:00:00.000Z'
-          }
-        ]
-      },
-      {
-        description: 'With includeMissing param set to true (Not showing the whole response)',
-        body: [
-          {
-            playerId: 2,
-            type: "500 K'ril Tsutsaroth kills",
-            metric: 'kril_tsutsaroth',
-            threshold: 500,
-            createdAt: '1970-01-01T00:00:00.000Z'
-          },
-          {
-            playerId: 2,
-            type: '99 Strength',
-            metric: 'strength',
-            threshold: 13034431,
-            createdAt: '2015-12-14T04:15:36.000Z'
-          },
-          {
-            playerId: 2,
-            type: '99 Hitpoints',
-            metric: 'hitpoints',
-            threshold: 13034431,
-            createdAt: '2015-06-24T15:57:40.000Z'
-          },
-          {
-            playerId: 2,
-            type: '99 Ranged',
-            metric: 'ranged',
-            threshold: 13034431,
-            createdAt: '2015-12-14T04:15:36.000Z'
-          },
-          {
-            playerId: 2,
-            type: '99 Attack',
-            metric: 'attack',
-            threshold: 13034431,
-            createdAt: '2015-06-24T15:57:40.000Z'
-          },
-          {
-            playerId: 2,
-            type: '99 Defence',
-            metric: 'defence',
-            threshold: 13034431,
-            createdAt: '2015-12-14T04:15:36.000Z'
-          },
-          {
-            playerId: 2,
-            type: '99 Magic',
-            metric: 'magic',
-            threshold: 13034431,
-            createdAt: '2015-12-14T04:15:36.000Z'
-          },
-          {
-            playerId: 2,
-            type: '99 Woodcutting',
-            metric: 'woodcutting',
-            threshold: 13034431,
-            createdAt: '2020-05-27T23:49:34.529Z'
-          },
-          {
-            playerId: 2,
-            type: '5k Zulrah kills',
-            metric: 'zulrah',
-            threshold: 5000,
-            createdAt: '2020-05-27T23:49:34.532Z'
-          },
-          {
-            playerId: 2,
-            type: '99 Slayer',
-            metric: 'slayer',
-            threshold: 13034431,
-            createdAt: '2018-01-21T18:02:52.000Z'
-          },
-          {
-            playerId: 2,
-            type: '99 Farming',
-            metric: 'farming',
-            threshold: 13034431,
-            createdAt: '2019-10-15T23:37:08.000Z'
-          },
-          {
-            playerId: 2,
-            type: '500 Abyssal Sire kills',
-            metric: 'abyssal_sire',
-            threshold: 500,
-            createdAt: '1970-01-01T00:00:00.000Z'
-          },
-          {
-            playerId: 2,
-            type: '500 Cerberus kills',
-            metric: 'cerberus',
-            threshold: 500,
-            createdAt: '1970-01-01T00:00:00.000Z'
-          },
-          {
-            playerId: 2,
-            type: '500 Commander Zilyana kills',
-            metric: 'commander_zilyana',
-            threshold: 500,
-            createdAt: '1970-01-01T00:00:00.000Z'
-          },
-          {
-            playerId: 2,
-            type: '500 General Graardor kills',
-            metric: 'general_graardor',
-            threshold: 500,
-            createdAt: '1970-01-01T00:00:00.000Z'
-          },
-          {
-            playerId: 2,
-            type: '500 Zulrah kills',
-            metric: 'zulrah',
-            threshold: 500,
-            createdAt: '1970-01-01T00:00:00.000Z'
-          },
-          {
-            playerId: 2,
-            type: '1k Abyssal Sire kills',
-            metric: 'abyssal_sire',
-            threshold: 1000,
-            createdAt: '1970-01-01T00:00:00.000Z'
-          },
-          {
-            playerId: 2,
-            type: '1k Cerberus kills',
-            metric: 'cerberus',
-            threshold: 1000,
-            createdAt: '1970-01-01T00:00:00.000Z'
-          },
-          {
-            playerId: 2,
-            type: '1k Commander Zilyana kills',
-            metric: 'commander_zilyana',
-            threshold: 1000,
-            createdAt: '1970-01-01T00:00:00.000Z'
-          },
-          {
-            playerId: 2,
-            type: '1k Zulrah kills',
-            metric: 'zulrah',
-            threshold: 1000,
-            createdAt: '1970-01-01T00:00:00.000Z'
-          },
-          {
-            playerId: 2,
-            type: '50m Fletching',
-            metric: 'fletching',
-            threshold: 50000000,
-            createdAt: null,
-            missing: true,
-            measure: 'experience'
-          },
-          {
-            playerId: 2,
-            type: '50m Fishing',
-            metric: 'fishing',
-            threshold: 50000000,
-            createdAt: null,
-            missing: true,
-            measure: 'experience'
-          },
-          {
-            playerId: 2,
-            type: '50m Firemaking',
-            metric: 'firemaking',
-            threshold: 50000000,
-            createdAt: null,
-            missing: true,
-            measure: 'experience'
-          },
-          {
-            playerId: 2,
-            type: '50m Crafting',
-            metric: 'crafting',
-            threshold: 50000000,
-            createdAt: null,
-            missing: true,
-            measure: 'experience'
-          },
-          {
-            playerId: 2,
-            type: '50m Smithing',
-            metric: 'smithing',
-            threshold: 50000000,
-            createdAt: null,
-            missing: true,
-            measure: 'experience'
-          },
-          {
-            playerId: 2,
-            type: '50m Mining',
-            metric: 'mining',
-            threshold: 50000000,
-            createdAt: null,
-            missing: true,
-            measure: 'experience'
-          },
-          {
-            playerId: 2,
-            type: '50m Herblore',
-            metric: 'herblore',
-            threshold: 50000000,
-            createdAt: null,
-            missing: true,
-            measure: 'experience'
-          },
-          {
-            playerId: 2,
-            type: '50m Agility',
+            name: '99 Agility',
             metric: 'agility',
-            threshold: 50000000,
-            createdAt: null,
-            missing: true,
-            measure: 'experience'
-          },
-          {
-            playerId: 2,
-            type: '50m Thieving',
-            metric: 'thieving',
-            threshold: 50000000,
-            createdAt: null,
-            missing: true,
-            measure: 'experience'
-          },
-          {
-            playerId: 2,
-            type: '50m Slayer',
-            metric: 'slayer',
-            threshold: 50000000,
-            createdAt: null,
-            missing: true,
-            measure: 'experience'
+            measure: 'experience',
+            threshold: 13034431,
+            currentValue: 4210271,
+            absoluteProgress: 0.323,
+            relativeProgress: 0.323,
+            createdAt: null
           }
         ]
       }

--- a/server/src/api/constants.ts
+++ b/server/src/api/constants.ts
@@ -1,6 +1,3 @@
-import { Snapshot } from '../database/models';
-import { CAPPED_MAX_TOTAL_XP, getCappedTotalXp, getCombatLevel } from './util/experience';
-
 export const PERIODS = ['6h', 'day', 'week', 'month', 'year'];
 
 export const PLAYER_TYPES = ['unknown', 'regular', 'ironman', 'hardcore', 'ultimate'];
@@ -145,51 +142,6 @@ export const SKILLS = SKILLS_MAP.map(s => s.key);
 export const ACTIVITIES = ACTIVITIES_MAP.map(s => s.key);
 export const BOSSES = BOSSES_MAP.map(s => s.key);
 export const REAL_SKILLS = SKILLS.filter(s => s !== 'overall');
-
-export const SKILL_ACHIEVEMENT_TEMPLATES = [
-  {
-    type: '{threshold} {skill}',
-    measure: 'experience',
-    thresholds: [13034431, 50000000, 100000000, 200000000]
-  },
-  {
-    type: '{threshold} Overall Exp.',
-    metric: 'overall',
-    measure: 'experience',
-    thresholds: [500000000, 1000000000, 2000000000, 4600000000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.overallExperience >= threshold
-  },
-  {
-    type: 'Maxed Overall',
-    metric: 'overall',
-    measure: 'experience',
-    thresholds: [CAPPED_MAX_TOTAL_XP],
-    validate: (snapshot: Snapshot) => getCappedTotalXp(snapshot) >= CAPPED_MAX_TOTAL_XP
-  },
-  {
-    type: '126 Combat',
-    metric: 'combat',
-    measure: 'levels',
-    thresholds: [126],
-    validate: (snapshot: Snapshot) => getCombatLevel(snapshot) === 126
-  }
-];
-
-export const ACTIVITY_ACHIEVEMENT_TEMPLATES = [
-  {
-    type: '{threshold} {activity} score',
-    measure: 'score',
-    thresholds: [1000, 5000, 10000]
-  }
-];
-
-export const BOSS_ACHIEVEMENT_TEMPLATES = [
-  {
-    type: '{threshold} {boss} kills',
-    measure: 'kills',
-    thresholds: [500, 1000, 5000, 10000]
-  }
-];
 
 export const VIRTUAL = VIRTUAL_MAP.map(s => s.key);
 

--- a/server/src/api/modules/achievements/templates.ts
+++ b/server/src/api/modules/achievements/templates.ts
@@ -1,192 +1,175 @@
 import { Snapshot } from '../../../database/models';
-import { CAPPED_MAX_TOTAL_XP, getCappedTotalXp, getCombatLevel } from '../../util/experience';
+import { getCombatLevel, getMinimumExp } from '../../util/experience';
 import { AchievementTemplate } from '../../services/internal/achievement.service';
 
 export const ACHIEVEMENT_TEMPLATES: AchievementTemplate[] = [
   // ------------------
-  // SKILL ACHIEVEMENTS
+  // CUSTOM ACHIEVEMENTS
   // ------------------
   {
-    name: 'Maxed Overall',
+    name: 'Base {level} Stats',
     metric: 'overall',
-    measure: 'experience',
-    thresholds: [CAPPED_MAX_TOTAL_XP],
-    validate: (snapshot: Snapshot) => getCappedTotalXp(snapshot) >= CAPPED_MAX_TOTAL_XP
+    measure: 'levels',
+    thresholds: [737_627, 1_986_068, 5_346_332, 13_034_431],
+    getCurrentValue: (snapshot: Snapshot) => {
+      return getMinimumExp(snapshot);
+    }
   },
   {
     name: '126 Combat',
     metric: 'combat',
     measure: 'levels',
     thresholds: [126],
-    validate: (snapshot: Snapshot) => getCombatLevel(snapshot) === 126
+    getCurrentValue: (snapshot: Snapshot) => {
+      return getCombatLevel(snapshot);
+    }
   },
+  // ------------------
+  // SKILL ACHIEVEMENTS
+  // ------------------
   {
     name: '{threshold} Overall Exp.',
     metric: 'overall',
     measure: 'experience',
-    thresholds: [100_000_000, 200_000_000, 500_000_000, 1_000_000_000, 2_000_000_000, 4_600_000_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.overallExperience >= threshold
+    thresholds: [100_000_000, 200_000_000, 500_000_000, 1_000_000_000, 2_000_000_000, 4_600_000_000]
   },
   {
     name: '{threshold} Attack',
     metric: 'attack',
     measure: 'experience',
-    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.attackExperience >= threshold
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000]
   },
   {
     name: '{threshold} Defence',
     metric: 'defence',
     measure: 'experience',
-    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.defenceExperience >= threshold
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000]
   },
   {
     name: '{threshold} Strength',
     metric: 'strength',
     measure: 'experience',
-    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.strengthExperience >= threshold
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000]
   },
   {
     name: '{threshold} Hitpoints',
     metric: 'hitpoints',
     measure: 'experience',
-    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.hitpointsExperience >= threshold
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000]
   },
   {
     name: '{threshold} Ranged',
     metric: 'ranged',
     measure: 'experience',
-    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.rangedExperience >= threshold
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000]
   },
   {
     name: '{threshold} Prayer',
     metric: 'prayer',
     measure: 'experience',
-    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.prayerExperience >= threshold
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000]
   },
   {
     name: '{threshold} Magic',
     metric: 'magic',
     measure: 'experience',
-    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.magicExperience >= threshold
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000]
   },
   {
     name: '{threshold} Cooking',
     metric: 'cooking',
     measure: 'experience',
-    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.cookingExperience >= threshold
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000]
   },
   {
     name: '{threshold} Woodcutting',
     metric: 'woodcutting',
     measure: 'experience',
-    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.woodcuttingExperience >= threshold
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000]
   },
   {
     name: '{threshold} Fletching',
     metric: 'fletching',
     measure: 'experience',
-    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.fletchingExperience >= threshold
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000]
   },
   {
     name: '{threshold} Fishing',
     metric: 'fishing',
     measure: 'experience',
-    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.fishingExperience >= threshold
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000]
   },
   {
     name: '{threshold} Firemaking',
     metric: 'firemaking',
     measure: 'experience',
-    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.firemakingExperience >= threshold
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000]
   },
   {
     name: '{threshold} Crafting',
     metric: 'crafting',
     measure: 'experience',
-    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.craftingExperience >= threshold
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000]
   },
   {
     name: '{threshold} Smithing',
     metric: 'smithing',
     measure: 'experience',
-    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.smithingExperience >= threshold
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000]
   },
   {
     name: '{threshold} Mining',
     metric: 'mining',
     measure: 'experience',
-    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.miningExperience >= threshold
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000]
   },
   {
     name: '{threshold} Herblore',
     metric: 'herblore',
     measure: 'experience',
-    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.herbloreExperience >= threshold
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000]
   },
   {
     name: '{threshold} Agility',
     metric: 'agility',
     measure: 'experience',
-    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.agilityExperience >= threshold
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000]
   },
   {
     name: '{threshold} Thieving',
     metric: 'thieving',
     measure: 'experience',
-    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.thievingExperience >= threshold
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000]
   },
   {
     name: '{threshold} Slayer',
     metric: 'slayer',
     measure: 'experience',
-    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.slayerExperience >= threshold
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000]
   },
   {
     name: '{threshold} Farming',
     metric: 'farming',
     measure: 'experience',
-    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.farmingExperience >= threshold
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000]
   },
   {
     name: '{threshold} Runecrafting',
     metric: 'runecrafting',
     measure: 'experience',
-    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.runecraftingExperience >= threshold
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000]
   },
   {
     name: '{threshold} Hunter',
     metric: 'hunter',
     measure: 'experience',
-    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.hunterExperience >= threshold
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000]
   },
   {
     name: '{threshold} Construction',
     metric: 'construction',
     measure: 'experience',
-    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.constructionExperience >= threshold
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000]
   },
   // -----------------
   // BOSS ACHIEVEMENTS
@@ -195,313 +178,265 @@ export const ACHIEVEMENT_TEMPLATES: AchievementTemplate[] = [
     name: '{threshold} Abyssal Sire kills',
     metric: 'abyssal_sire',
     measure: 'kills',
-    thresholds: [500, 1000, 5000, 10_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.abyssal_sireKills >= threshold
+    thresholds: [500, 1000, 5000, 10_000]
   },
   {
     name: '{threshold} Alchemical Hydra kills',
     metric: 'alchemical_hydra',
     measure: 'kills',
-    thresholds: [500, 1000, 5000, 10_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.alchemical_hydraKills >= threshold
+    thresholds: [500, 1000, 5000, 10_000]
   },
   {
     name: '{threshold} Barrows Chests',
     metric: 'barrows_chests',
     measure: 'kills',
-    thresholds: [500, 1000, 5000, 10_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.barrows_chestsKills >= threshold
+    thresholds: [500, 1000, 5000, 10_000]
   },
   {
     name: '{threshold} Bryophyta kills',
     metric: 'bryophyta',
     measure: 'kills',
-    thresholds: [50, 100, 500, 1000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.bryophytaKills >= threshold
+    thresholds: [50, 100, 500, 1000]
   },
   {
     name: '{threshold} Callisto kills',
     metric: 'callisto',
     measure: 'kills',
-    thresholds: [500, 1000, 5000, 10_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.callistoKills >= threshold
+    thresholds: [500, 1000, 5000, 10_000]
   },
   {
     name: '{threshold} Cerberus kills',
     metric: 'cerberus',
     measure: 'kills',
-    thresholds: [500, 1000, 5000, 10_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.cerberusKills >= threshold
+    thresholds: [500, 1000, 5000, 10_000]
   },
   {
     name: '{threshold} Chambers Of Xeric kills',
     metric: 'chambers_of_xeric',
     measure: 'kills',
-    thresholds: [100, 500, 1000, 5000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.chambers_of_xericKills >= threshold
+    thresholds: [100, 500, 1000, 5000]
   },
   {
     name: '{threshold} Chambers Of Xeric (CM) kills',
     metric: 'chambers_of_xeric_challenge_mode',
     measure: 'kills',
-    thresholds: [100, 500, 1000, 5000],
-    validate: (snapshot: Snapshot, threshold: number) =>
-      snapshot.chambers_of_xeric_challenge_modeKills >= threshold
+    thresholds: [100, 500, 1000, 5000]
   },
   {
     name: '{threshold} Chaos Elemental kills',
     metric: 'chaos_elemental',
     measure: 'kills',
-    thresholds: [500, 1000, 5000, 10_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.chaos_elementalKills >= threshold
+    thresholds: [500, 1000, 5000, 10_000]
   },
   {
     name: '{threshold} Chaos Fanatic kills',
     metric: 'chaos_fanatic',
     measure: 'kills',
-    thresholds: [500, 1000, 5000, 10_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.chaos_fanaticKills >= threshold
+    thresholds: [500, 1000, 5000, 10_000]
   },
   {
     name: '{threshold} Commander Zilyana kills',
     metric: 'commander_zilyana',
     measure: 'kills',
-    thresholds: [500, 1000, 5000, 10_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.commander_zilyanaKills >= threshold
+    thresholds: [500, 1000, 5000, 10_000]
   },
   {
     name: '{threshold} Corporeal Beast kills',
     metric: 'corporeal_beast',
     measure: 'kills',
-    thresholds: [500, 1000, 5000, 10_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.corporeal_beastKills >= threshold
+    thresholds: [500, 1000, 5000, 10_000]
   },
   {
     name: '{threshold} Crazy Archaeologist kills',
     metric: 'crazy_archaeologist',
     measure: 'kills',
-    thresholds: [500, 1000, 5000, 10_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.crazy_archaeologistKills >= threshold
+    thresholds: [500, 1000, 5000, 10_000]
   },
   {
     name: '{threshold} Dagannoth Prime kills',
     metric: 'dagannoth_prime',
     measure: 'kills',
-    thresholds: [500, 1000, 5000, 10_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.dagannoth_primeKills >= threshold
+    thresholds: [500, 1000, 5000, 10_000]
   },
   {
     name: '{threshold} Dagannoth Rex kills',
     metric: 'dagannoth_rex',
     measure: 'kills',
-    thresholds: [500, 1000, 5000, 10_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.dagannoth_rexKills >= threshold
+    thresholds: [500, 1000, 5000, 10_000]
   },
   {
     name: '{threshold} Dagannoth Supreme kills',
     metric: 'dagannoth_supreme',
     measure: 'kills',
-    thresholds: [500, 1000, 5000, 10_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.dagannoth_supremeKills >= threshold
+    thresholds: [500, 1000, 5000, 10_000]
   },
   {
     name: '{threshold} Deranged Archaeologist kills',
     metric: 'deranged_archaeologist',
     measure: 'kills',
-    thresholds: [500, 1000, 5000, 10_000],
-    validate: (snapshot: Snapshot, threshold: number) =>
-      snapshot.deranged_archaeologistKills >= threshold
+    thresholds: [500, 1000, 5000, 10_000]
   },
   {
     name: '{threshold} General Graardor kills',
     metric: 'general_graardor',
     measure: 'kills',
-    thresholds: [500, 1000, 5000, 10_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.general_graardorKills >= threshold
+    thresholds: [500, 1000, 5000, 10_000]
   },
   {
     name: '{threshold} Giant Mole kills',
     metric: 'giant_mole',
     measure: 'kills',
-    thresholds: [500, 1000, 5000, 10_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.giant_moleKills >= threshold
+    thresholds: [500, 1000, 5000, 10_000]
   },
   {
     name: '{threshold} Grotesque Guardians kills',
     metric: 'grotesque_guardians',
     measure: 'kills',
-    thresholds: [500, 1000, 5000, 10_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.grotesque_guardiansKills >= threshold
+    thresholds: [500, 1000, 5000, 10_000]
   },
   {
     name: '{threshold} Hespori kills',
     metric: 'hespori',
     measure: 'kills',
-    thresholds: [50, 100, 500, 1000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.hesporiKills >= threshold
+    thresholds: [50, 100, 500, 1000]
   },
   {
     name: '{threshold} Kalphite Queen kills',
     metric: 'kalphite_queen',
     measure: 'kills',
-    thresholds: [500, 1000, 5000, 10_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.kalphite_queenKills >= threshold
+    thresholds: [500, 1000, 5000, 10_000]
   },
   {
     name: '{threshold} King Black Dragon kills',
     metric: 'king_black_dragon',
     measure: 'kills',
-    thresholds: [500, 1000, 5000, 10_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.king_black_dragonKills >= threshold
+    thresholds: [500, 1000, 5000, 10_000]
   },
   {
     name: '{threshold} Kraken kills',
     metric: 'kraken',
     measure: 'kills',
-    thresholds: [500, 1000, 5000, 10_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.krakenKills >= threshold
+    thresholds: [500, 1000, 5000, 10_000]
   },
   {
     name: "{threshold} Kree'Arra kills",
     metric: 'kreearra',
     measure: 'kills',
-    thresholds: [500, 1000, 5000, 10_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.kreearraKills >= threshold
+    thresholds: [500, 1000, 5000, 10_000]
   },
   {
     name: "{threshold} K'ril Tsutsaroth kills",
     metric: 'kril_tsutsaroth',
     measure: 'kills',
-    thresholds: [500, 1000, 5000, 10_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.kril_tsutsarothKills >= threshold
+    thresholds: [500, 1000, 5000, 10_000]
   },
   {
     name: '{threshold} Mimic kills',
     metric: 'mimic',
     measure: 'kills',
-    thresholds: [10, 50, 100, 200],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.mimicKills >= threshold
+    thresholds: [10, 50, 100, 200]
   },
   {
     name: '{threshold} Nightmare kills',
     metric: 'nightmare',
     measure: 'kills',
-    thresholds: [500, 1000, 5000, 10_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.nightmareKills >= threshold
+    thresholds: [500, 1000, 5000, 10_000]
   },
   {
     name: '{threshold} Obor kills',
     metric: 'obor',
     measure: 'kills',
-    thresholds: [50, 100, 500, 1000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.oborKills >= threshold
+    thresholds: [50, 100, 500, 1000]
   },
   {
     name: '{threshold} Sarachnis kills',
     metric: 'sarachnis',
     measure: 'kills',
-    thresholds: [500, 1000, 5000, 10_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.sarachnisKills >= threshold
+    thresholds: [500, 1000, 5000, 10_000]
   },
   {
     name: '{threshold} Scorpia kills',
     metric: 'scorpia',
     measure: 'kills',
-    thresholds: [500, 1000, 5000, 10_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.scorpiaKills >= threshold
+    thresholds: [500, 1000, 5000, 10_000]
   },
   {
     name: '{threshold} Skotizo kills',
     metric: 'skotizo',
     measure: 'kills',
-    thresholds: [50, 100, 500, 1000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.skotizoKills >= threshold
+    thresholds: [50, 100, 500, 1000]
   },
   {
     name: '{threshold} The Gauntlet kills',
     metric: 'the_gauntlet',
     measure: 'kills',
-    thresholds: [100, 200, 1000, 2000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.the_gauntletKills >= threshold
+    thresholds: [100, 200, 1000, 2000]
   },
   {
     name: '{threshold} The Corrupted Gauntlet kills',
     metric: 'the_corrupted_gauntlet',
     measure: 'kills',
-    thresholds: [100, 200, 1000, 2000],
-    validate: (snapshot: Snapshot, threshold: number) =>
-      snapshot.the_corrupted_gauntletKills >= threshold
+    thresholds: [100, 200, 1000, 2000]
   },
   {
     name: '{threshold} Theatre Of Blood kills',
     metric: 'theatre_of_blood',
     measure: 'kills',
-    thresholds: [100, 500, 1000, 5000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.theatre_of_bloodKills >= threshold
+    thresholds: [100, 500, 1000, 5000]
   },
   {
     name: '{threshold} Thermonuclear Smoke Devil kills',
     metric: 'thermonuclear_smoke_devil',
     measure: 'kills',
-    thresholds: [500, 1000, 5000, 10_000],
-    validate: (snapshot: Snapshot, threshold: number) =>
-      snapshot.thermonuclear_smoke_devilKills >= threshold
+    thresholds: [500, 1000, 5000, 10_000]
   },
   {
     name: '{threshold} TzKal-Zuk kills',
     metric: 'tzkal_zuk',
     measure: 'kills',
-    thresholds: [10, 50, 100, 200],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.tzkal_zukKills >= threshold
+    thresholds: [10, 50, 100, 200]
   },
   {
     name: '{threshold} TzTok-Jad kills',
     metric: 'tztok_jad',
     measure: 'kills',
-    thresholds: [50, 100, 500, 1000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.tztok_jadKills >= threshold
+    thresholds: [50, 100, 500, 1000]
   },
   {
     name: '{threshold} Venenatis kills',
     metric: 'venenatis',
     measure: 'kills',
-    thresholds: [500, 1000, 5000, 10_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.venenatisKills >= threshold
+    thresholds: [500, 1000, 5000, 10_000]
   },
   {
     name: "{threshold} Vet'ion kills",
     metric: 'vetion',
     measure: 'kills',
-    thresholds: [500, 1000, 5000, 10_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.vetionKills >= threshold
+    thresholds: [500, 1000, 5000, 10_000]
   },
   {
     name: '{threshold} Vorkath kills',
     metric: 'vorkath',
     measure: 'kills',
-    thresholds: [500, 1000, 5000, 10_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.vorkathKills >= threshold
+    thresholds: [500, 1000, 5000, 10_000]
   },
   {
     name: '{threshold} Wintertodt kills',
     metric: 'wintertodt',
     measure: 'kills',
-    thresholds: [500, 1000, 5000, 10_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.wintertodtKills >= threshold
+    thresholds: [500, 1000, 5000, 10_000]
   },
   {
     name: '{threshold} Zalcano kills',
     metric: 'zalcano',
     measure: 'kills',
-    thresholds: [500, 1000, 5000, 10_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.zalcanoKills >= threshold
+    thresholds: [500, 1000, 5000, 10_000]
   },
   {
     name: '{threshold} Zulrah kills',
     metric: 'zulrah',
     measure: 'kills',
-    thresholds: [500, 1000, 5000, 10_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.zulrahKills >= threshold
+    thresholds: [500, 1000, 5000, 10_000]
   },
   // ---------------------
   // ACTIVITY ACHIEVEMENTS
@@ -510,77 +445,66 @@ export const ACHIEVEMENT_TEMPLATES: AchievementTemplate[] = [
     name: '{threshold} Bounty Hunter (Hunter) score',
     metric: 'bounty_hunter_hunter',
     measure: 'score',
-    thresholds: [1000, 5000, 10_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.bounty_hunter_hunterScore >= threshold
+    thresholds: [1000, 5000, 10_000]
   },
   {
     name: '{threshold} Bounty Hunter (Rogue) score',
     metric: 'bounty_hunter_rogue',
     measure: 'score',
-    thresholds: [1000, 5000, 10_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.bounty_hunter_rogueScore >= threshold
+    thresholds: [1000, 5000, 10_000]
   },
   {
     name: '{threshold} Clue Scrolls (All)',
     metric: 'clue_scrolls_all',
     measure: 'score',
-    thresholds: [500, 1000, 5000, 10_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.clue_scrolls_allScore >= threshold
+    thresholds: [500, 1000, 5000, 10_000]
   },
   {
     name: '{threshold} Clue Scrolls (Beginner)',
     metric: 'clue_scrolls_beginner',
     measure: 'score',
-    thresholds: [200, 500, 1000, 5000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.clue_scrolls_beginnerScore >= threshold
+    thresholds: [200, 500, 1000, 5000]
   },
   {
     name: '{threshold} Clue Scrolls (Easy)',
     metric: 'clue_scrolls_easy',
     measure: 'score',
-    thresholds: [500, 1000, 5000, 10_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.clue_scrolls_easyScore >= threshold
+    thresholds: [500, 1000, 5000, 10_000]
   },
   {
     name: '{threshold} Clue Scrolls (Medium)',
     metric: 'clue_scrolls_medium',
     measure: 'score',
-    thresholds: [500, 1000, 5000, 10_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.clue_scrolls_mediumScore >= threshold
+    thresholds: [500, 1000, 5000, 10_000]
   },
   {
     name: '{threshold} Clue Scrolls (Hard)',
     metric: 'clue_scrolls_hard',
     measure: 'score',
-    thresholds: [500, 1000, 5000, 10_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.clue_scrolls_hardScore >= threshold
+    thresholds: [500, 1000, 5000, 10_000]
   },
   {
     name: '{threshold} Clue Scrolls (Elite)',
     metric: 'clue_scrolls_elite',
     measure: 'score',
-    thresholds: [100, 500, 1000, 5000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.clue_scrolls_eliteScore >= threshold
+    thresholds: [100, 500, 1000, 5000]
   },
   {
     name: '{threshold} Clue Scrolls (Master)',
     metric: 'clue_scrolls_master',
     measure: 'score',
-    thresholds: [100, 500, 1000, 5000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.clue_scrolls_masterScore >= threshold
+    thresholds: [100, 500, 1000, 5000]
   },
   {
     name: '{threshold} Last Man Standing score',
     metric: 'last_man_standing',
     measure: 'score',
-    thresholds: [2000, 5000, 10_000, 15_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.last_man_standingScore >= threshold
+    thresholds: [2000, 5000, 10_000, 15_000]
   },
   {
     name: '{threshold} Soul Wars Zeal',
     metric: 'soul_wars_zeal',
     measure: 'score',
-    thresholds: [5000, 10_000, 20_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.soul_wars_zealScore >= threshold
+    thresholds: [5000, 10_000, 20_000]
   }
 ];

--- a/server/src/api/modules/achievements/templates.ts
+++ b/server/src/api/modules/achievements/templates.ts
@@ -10,7 +10,7 @@ export const ACHIEVEMENT_TEMPLATES: AchievementTemplate[] = [
     name: 'Base {level} Stats',
     metric: 'overall',
     measure: 'levels',
-    thresholds: [737_627, 1_986_068, 5_346_332, 13_034_431],
+    thresholds: [101_333, 273_742, 737_627, 1_986_068, 5_346_332, 13_034_431],
     getCurrentValue: (snapshot: Snapshot) => {
       return getMinimumExp(snapshot);
     }

--- a/server/src/api/modules/achievements/templates.ts
+++ b/server/src/api/modules/achievements/templates.ts
@@ -24,7 +24,7 @@ export const ACHIEVEMENT_TEMPLATES: AchievementTemplate[] = [
     name: '{threshold} Overall Exp.',
     metric: 'overall',
     measure: 'experience',
-    thresholds: [500_000_000, 1_000_000_000, 2_000_000_000, 4_600_000_000],
+    thresholds: [100_000_000, 200_000_000, 500_000_000, 1_000_000_000, 2_000_000_000, 4_600_000_000],
     validate: (snapshot: Snapshot, threshold: number) => snapshot.overallExperience >= threshold
   },
   {

--- a/server/src/api/modules/achievements/templates.ts
+++ b/server/src/api/modules/achievements/templates.ts
@@ -10,7 +10,7 @@ export const ACHIEVEMENT_TEMPLATES: AchievementTemplate[] = [
     name: 'Base {level} Stats',
     metric: 'overall',
     measure: 'levels',
-    thresholds: [101_333, 273_742, 737_627, 1_986_068, 5_346_332, 13_034_431],
+    thresholds: [273_742, 737_627, 1_986_068, 5_346_332, 13_034_431],
     getCurrentValue: (snapshot: Snapshot) => {
       return getMinimumExp(snapshot);
     }

--- a/server/src/api/modules/achievements/templates.ts
+++ b/server/src/api/modules/achievements/templates.ts
@@ -237,14 +237,14 @@ export const ACHIEVEMENT_TEMPLATES: AchievementTemplate[] = [
     name: '{threshold} Chambers Of Xeric kills',
     metric: 'chambers_of_xeric',
     measure: 'kills',
-    thresholds: [100, 200, 1000, 2000],
+    thresholds: [100, 500, 1000, 5000],
     validate: (snapshot: Snapshot, threshold: number) => snapshot.chambers_of_xericKills >= threshold
   },
   {
     name: '{threshold} Chambers Of Xeric (CM) kills',
     metric: 'chambers_of_xeric_challenge_mode',
     measure: 'kills',
-    thresholds: [100, 200, 1000, 2000],
+    thresholds: [100, 500, 1000, 5000],
     validate: (snapshot: Snapshot, threshold: number) =>
       snapshot.chambers_of_xeric_challenge_modeKills >= threshold
   },
@@ -379,7 +379,7 @@ export const ACHIEVEMENT_TEMPLATES: AchievementTemplate[] = [
     name: '{threshold} Mimic kills',
     metric: 'mimic',
     measure: 'kills',
-    thresholds: [25, 50, 250, 500],
+    thresholds: [10, 50, 100, 200],
     validate: (snapshot: Snapshot, threshold: number) => snapshot.mimicKills >= threshold
   },
   {
@@ -436,7 +436,7 @@ export const ACHIEVEMENT_TEMPLATES: AchievementTemplate[] = [
     name: '{threshold} Theatre Of Blood kills',
     metric: 'theatre_of_blood',
     measure: 'kills',
-    thresholds: [100, 200, 1000, 2000],
+    thresholds: [100, 500, 1000, 5000],
     validate: (snapshot: Snapshot, threshold: number) => snapshot.theatre_of_bloodKills >= threshold
   },
   {
@@ -451,14 +451,14 @@ export const ACHIEVEMENT_TEMPLATES: AchievementTemplate[] = [
     name: '{threshold} TzKal-Zuk kills',
     metric: 'tzkal_zuk',
     measure: 'kills',
-    thresholds: [25, 50, 250, 500],
+    thresholds: [10, 50, 100, 200],
     validate: (snapshot: Snapshot, threshold: number) => snapshot.tzkal_zukKills >= threshold
   },
   {
     name: '{threshold} TzTok-Jad kills',
     metric: 'tztok_jad',
     measure: 'kills',
-    thresholds: [100, 200, 1000, 2000],
+    thresholds: [50, 100, 500, 1000],
     validate: (snapshot: Snapshot, threshold: number) => snapshot.tztok_jadKills >= threshold
   },
   {
@@ -507,13 +507,6 @@ export const ACHIEVEMENT_TEMPLATES: AchievementTemplate[] = [
   // ACTIVITY ACHIEVEMENTS
   // ---------------------
   {
-    name: '{threshold} League Points score',
-    metric: 'league_points',
-    measure: 'score',
-    thresholds: [1000, 5000, 10_000],
-    validate: (snapshot: Snapshot, threshold: number) => snapshot.league_pointsScore >= threshold
-  },
-  {
     name: '{threshold} Bounty Hunter (Hunter) score',
     metric: 'bounty_hunter_hunter',
     measure: 'score',
@@ -531,63 +524,63 @@ export const ACHIEVEMENT_TEMPLATES: AchievementTemplate[] = [
     name: '{threshold} Clue Scrolls (All)',
     metric: 'clue_scrolls_all',
     measure: 'score',
-    thresholds: [1000, 5000, 10000],
+    thresholds: [500, 1000, 5000, 10_000],
     validate: (snapshot: Snapshot, threshold: number) => snapshot.clue_scrolls_allScore >= threshold
   },
   {
     name: '{threshold} Clue Scrolls (Beginner)',
     metric: 'clue_scrolls_beginner',
     measure: 'score',
-    thresholds: [1000, 5000, 10000],
+    thresholds: [200, 500, 1000, 5000],
     validate: (snapshot: Snapshot, threshold: number) => snapshot.clue_scrolls_beginnerScore >= threshold
   },
   {
     name: '{threshold} Clue Scrolls (Easy)',
     metric: 'clue_scrolls_easy',
     measure: 'score',
-    thresholds: [1000, 5000, 10000],
+    thresholds: [500, 1000, 5000, 10_000],
     validate: (snapshot: Snapshot, threshold: number) => snapshot.clue_scrolls_easyScore >= threshold
   },
   {
     name: '{threshold} Clue Scrolls (Medium)',
     metric: 'clue_scrolls_medium',
     measure: 'score',
-    thresholds: [1000, 5000, 10000],
+    thresholds: [500, 1000, 5000, 10_000],
     validate: (snapshot: Snapshot, threshold: number) => snapshot.clue_scrolls_mediumScore >= threshold
   },
   {
     name: '{threshold} Clue Scrolls (Hard)',
     metric: 'clue_scrolls_hard',
     measure: 'score',
-    thresholds: [1000, 5000, 10000],
+    thresholds: [500, 1000, 5000, 10_000],
     validate: (snapshot: Snapshot, threshold: number) => snapshot.clue_scrolls_hardScore >= threshold
   },
   {
     name: '{threshold} Clue Scrolls (Elite)',
     metric: 'clue_scrolls_elite',
     measure: 'score',
-    thresholds: [1000, 5000, 10000],
+    thresholds: [100, 500, 1000, 5000],
     validate: (snapshot: Snapshot, threshold: number) => snapshot.clue_scrolls_eliteScore >= threshold
   },
   {
     name: '{threshold} Clue Scrolls (Master)',
     metric: 'clue_scrolls_master',
     measure: 'score',
-    thresholds: [1000, 5000, 10000],
+    thresholds: [100, 500, 1000, 5000],
     validate: (snapshot: Snapshot, threshold: number) => snapshot.clue_scrolls_masterScore >= threshold
   },
   {
     name: '{threshold} Last Man Standing score',
     metric: 'last_man_standing',
     measure: 'score',
-    thresholds: [1000, 5000, 10000],
+    thresholds: [2000, 5000, 10_000, 15_000],
     validate: (snapshot: Snapshot, threshold: number) => snapshot.last_man_standingScore >= threshold
   },
   {
     name: '{threshold} Soul Wars Zeal',
     metric: 'soul_wars_zeal',
     measure: 'score',
-    thresholds: [1000, 5000, 10000],
+    thresholds: [5000, 10_000, 20_000],
     validate: (snapshot: Snapshot, threshold: number) => snapshot.soul_wars_zealScore >= threshold
   }
 ];

--- a/server/src/api/modules/achievements/templates.ts
+++ b/server/src/api/modules/achievements/templates.ts
@@ -1,0 +1,593 @@
+import { Snapshot } from '../../../database/models';
+import { CAPPED_MAX_TOTAL_XP, getCappedTotalXp, getCombatLevel } from '../../util/experience';
+import { AchievementTemplate } from '../../services/internal/achiev.service';
+
+export const ACHIEVEMENT_TEMPLATES: AchievementTemplate[] = [
+  // ------------------
+  // SKILL ACHIEVEMENTS
+  // ------------------
+  {
+    name: 'Maxed Overall',
+    metric: 'overall',
+    measure: 'experience',
+    thresholds: [CAPPED_MAX_TOTAL_XP],
+    validate: (snapshot: Snapshot) => getCappedTotalXp(snapshot) >= CAPPED_MAX_TOTAL_XP
+  },
+  {
+    name: '126 Combat',
+    metric: 'combat',
+    measure: 'levels',
+    thresholds: [126],
+    validate: (snapshot: Snapshot) => getCombatLevel(snapshot) === 126
+  },
+  {
+    name: '{threshold} Overall Exp.',
+    metric: 'overall',
+    measure: 'experience',
+    thresholds: [500_000_000, 1_000_000_000, 2_000_000_000, 4_600_000_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.overallExperience >= threshold
+  },
+  {
+    name: '{threshold} Attack',
+    metric: 'attack',
+    measure: 'experience',
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.attackExperience >= threshold
+  },
+  {
+    name: '{threshold} Defence',
+    metric: 'defence',
+    measure: 'experience',
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.defenceExperience >= threshold
+  },
+  {
+    name: '{threshold} Strength',
+    metric: 'strength',
+    measure: 'experience',
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.strengthExperience >= threshold
+  },
+  {
+    name: '{threshold} Hitpoints',
+    metric: 'hitpoints',
+    measure: 'experience',
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.hitpointsExperience >= threshold
+  },
+  {
+    name: '{threshold} Ranged',
+    metric: 'ranged',
+    measure: 'experience',
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.rangedExperience >= threshold
+  },
+  {
+    name: '{threshold} Prayer',
+    metric: 'prayer',
+    measure: 'experience',
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.prayerExperience >= threshold
+  },
+  {
+    name: '{threshold} Magic',
+    metric: 'magic',
+    measure: 'experience',
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.magicExperience >= threshold
+  },
+  {
+    name: '{threshold} Cooking',
+    metric: 'cooking',
+    measure: 'experience',
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.cookingExperience >= threshold
+  },
+  {
+    name: '{threshold} Woodcutting',
+    metric: 'woodcutting',
+    measure: 'experience',
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.woodcuttingExperience >= threshold
+  },
+  {
+    name: '{threshold} Fletching',
+    metric: 'fletching',
+    measure: 'experience',
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.fletchingExperience >= threshold
+  },
+  {
+    name: '{threshold} Fishing',
+    metric: 'fishing',
+    measure: 'experience',
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.fishingExperience >= threshold
+  },
+  {
+    name: '{threshold} Firemaking',
+    metric: 'firemaking',
+    measure: 'experience',
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.firemakingExperience >= threshold
+  },
+  {
+    name: '{threshold} Crafting',
+    metric: 'crafting',
+    measure: 'experience',
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.craftingExperience >= threshold
+  },
+  {
+    name: '{threshold} Smithing',
+    metric: 'smithing',
+    measure: 'experience',
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.smithingExperience >= threshold
+  },
+  {
+    name: '{threshold} Mining',
+    metric: 'mining',
+    measure: 'experience',
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.miningExperience >= threshold
+  },
+  {
+    name: '{threshold} Herblore',
+    metric: 'herblore',
+    measure: 'experience',
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.herbloreExperience >= threshold
+  },
+  {
+    name: '{threshold} Agility',
+    metric: 'agility',
+    measure: 'experience',
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.agilityExperience >= threshold
+  },
+  {
+    name: '{threshold} Thieving',
+    metric: 'thieving',
+    measure: 'experience',
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.thievingExperience >= threshold
+  },
+  {
+    name: '{threshold} Slayer',
+    metric: 'slayer',
+    measure: 'experience',
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.slayerExperience >= threshold
+  },
+  {
+    name: '{threshold} Farming',
+    metric: 'farming',
+    measure: 'experience',
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.farmingExperience >= threshold
+  },
+  {
+    name: '{threshold} Runecrafting',
+    metric: 'runecrafting',
+    measure: 'experience',
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.runecraftingExperience >= threshold
+  },
+  {
+    name: '{threshold} Hunter',
+    metric: 'hunter',
+    measure: 'experience',
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.hunterExperience >= threshold
+  },
+  {
+    name: '{threshold} Construction',
+    metric: 'construction',
+    measure: 'experience',
+    thresholds: [13_034_431, 50_000_000, 100_000_000, 200_000_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.constructionExperience >= threshold
+  },
+  // -----------------
+  // BOSS ACHIEVEMENTS
+  // -----------------
+  {
+    name: '{threshold} Abyssal Sire kills',
+    metric: 'abyssal_sire',
+    measure: 'kills',
+    thresholds: [500, 1000, 5000, 10_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.abyssal_sireKills >= threshold
+  },
+  {
+    name: '{threshold} Alchemical Hydra kills',
+    metric: 'alchemical_hydra',
+    measure: 'kills',
+    thresholds: [500, 1000, 5000, 10_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.alchemical_hydraKills >= threshold
+  },
+  {
+    name: '{threshold} Barrows Chests',
+    metric: 'barrows_chests',
+    measure: 'kills',
+    thresholds: [500, 1000, 5000, 10_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.barrows_chestsKills >= threshold
+  },
+  {
+    name: '{threshold} Bryophyta kills',
+    metric: 'bryophyta',
+    measure: 'kills',
+    thresholds: [50, 100, 500, 1000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.bryophytaKills >= threshold
+  },
+  {
+    name: '{threshold} Callisto kills',
+    metric: 'callisto',
+    measure: 'kills',
+    thresholds: [500, 1000, 5000, 10_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.callistoKills >= threshold
+  },
+  {
+    name: '{threshold} Cerberus kills',
+    metric: 'cerberus',
+    measure: 'kills',
+    thresholds: [500, 1000, 5000, 10_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.cerberusKills >= threshold
+  },
+  {
+    name: '{threshold} Chambers Of Xeric kills',
+    metric: 'chambers_of_xeric',
+    measure: 'kills',
+    thresholds: [100, 200, 1000, 2000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.chambers_of_xericKills >= threshold
+  },
+  {
+    name: '{threshold} Chambers Of Xeric (CM) kills',
+    metric: 'chambers_of_xeric_challenge_mode',
+    measure: 'kills',
+    thresholds: [100, 200, 1000, 2000],
+    validate: (snapshot: Snapshot, threshold: number) =>
+      snapshot.chambers_of_xeric_challenge_modeKills >= threshold
+  },
+  {
+    name: '{threshold} Chaos Elemental kills',
+    metric: 'chaos_elemental',
+    measure: 'kills',
+    thresholds: [500, 1000, 5000, 10_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.chaos_elementalKills >= threshold
+  },
+  {
+    name: '{threshold} Chaos Fanatic kills',
+    metric: 'chaos_fanatic',
+    measure: 'kills',
+    thresholds: [500, 1000, 5000, 10_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.chaos_fanaticKills >= threshold
+  },
+  {
+    name: '{threshold} Commander Zilyana kills',
+    metric: 'commander_zilyana',
+    measure: 'kills',
+    thresholds: [500, 1000, 5000, 10_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.commander_zilyanaKills >= threshold
+  },
+  {
+    name: '{threshold} Corporeal Beast kills',
+    metric: 'corporeal_beast',
+    measure: 'kills',
+    thresholds: [500, 1000, 5000, 10_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.corporeal_beastKills >= threshold
+  },
+  {
+    name: '{threshold} Crazy Archaeologist kills',
+    metric: 'crazy_archaeologist',
+    measure: 'kills',
+    thresholds: [500, 1000, 5000, 10_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.crazy_archaeologistKills >= threshold
+  },
+  {
+    name: '{threshold} Dagannoth Prime kills',
+    metric: 'dagannoth_prime',
+    measure: 'kills',
+    thresholds: [500, 1000, 5000, 10_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.dagannoth_primeKills >= threshold
+  },
+  {
+    name: '{threshold} Dagannoth Rex kills',
+    metric: 'dagannoth_rex',
+    measure: 'kills',
+    thresholds: [500, 1000, 5000, 10_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.dagannoth_rexKills >= threshold
+  },
+  {
+    name: '{threshold} Dagannoth Supreme kills',
+    metric: 'dagannoth_supreme',
+    measure: 'kills',
+    thresholds: [500, 1000, 5000, 10_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.dagannoth_supremeKills >= threshold
+  },
+  {
+    name: '{threshold} Deranged Archaeologist kills',
+    metric: 'deranged_archaeologist',
+    measure: 'kills',
+    thresholds: [500, 1000, 5000, 10_000],
+    validate: (snapshot: Snapshot, threshold: number) =>
+      snapshot.deranged_archaeologistKills >= threshold
+  },
+  {
+    name: '{threshold} General Graardor kills',
+    metric: 'general_graardor',
+    measure: 'kills',
+    thresholds: [500, 1000, 5000, 10_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.general_graardorKills >= threshold
+  },
+  {
+    name: '{threshold} Giant Mole kills',
+    metric: 'giant_mole',
+    measure: 'kills',
+    thresholds: [500, 1000, 5000, 10_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.giant_moleKills >= threshold
+  },
+  {
+    name: '{threshold} Grotesque Guardians kills',
+    metric: 'grotesque_guardians',
+    measure: 'kills',
+    thresholds: [500, 1000, 5000, 10_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.grotesque_guardiansKills >= threshold
+  },
+  {
+    name: '{threshold} Hespori kills',
+    metric: 'hespori',
+    measure: 'kills',
+    thresholds: [50, 100, 500, 1000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.hesporiKills >= threshold
+  },
+  {
+    name: '{threshold} Kalphite Queen kills',
+    metric: 'kalphite_queen',
+    measure: 'kills',
+    thresholds: [500, 1000, 5000, 10_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.kalphite_queenKills >= threshold
+  },
+  {
+    name: '{threshold} King Black Dragon kills',
+    metric: 'king_black_dragon',
+    measure: 'kills',
+    thresholds: [500, 1000, 5000, 10_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.king_black_dragonKills >= threshold
+  },
+  {
+    name: '{threshold} Kraken kills',
+    metric: 'kraken',
+    measure: 'kills',
+    thresholds: [500, 1000, 5000, 10_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.krakenKills >= threshold
+  },
+  {
+    name: "{threshold} Kree'Arra kills",
+    metric: 'kreearra',
+    measure: 'kills',
+    thresholds: [500, 1000, 5000, 10_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.kreearraKills >= threshold
+  },
+  {
+    name: "{threshold} K'ril Tsutsaroth kills",
+    metric: 'kril_tsutsaroth',
+    measure: 'kills',
+    thresholds: [500, 1000, 5000, 10_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.kril_tsutsarothKills >= threshold
+  },
+  {
+    name: '{threshold} Mimic kills',
+    metric: 'mimic',
+    measure: 'kills',
+    thresholds: [25, 50, 250, 500],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.mimicKills >= threshold
+  },
+  {
+    name: '{threshold} Nightmare kills',
+    metric: 'nightmare',
+    measure: 'kills',
+    thresholds: [500, 1000, 5000, 10_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.nightmareKills >= threshold
+  },
+  {
+    name: '{threshold} Obor kills',
+    metric: 'obor',
+    measure: 'kills',
+    thresholds: [50, 100, 500, 1000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.oborKills >= threshold
+  },
+  {
+    name: '{threshold} Sarachnis kills',
+    metric: 'sarachnis',
+    measure: 'kills',
+    thresholds: [500, 1000, 5000, 10_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.sarachnisKills >= threshold
+  },
+  {
+    name: '{threshold} Scorpia kills',
+    metric: 'scorpia',
+    measure: 'kills',
+    thresholds: [500, 1000, 5000, 10_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.scorpiaKills >= threshold
+  },
+  {
+    name: '{threshold} Skotizo kills',
+    metric: 'skotizo',
+    measure: 'kills',
+    thresholds: [50, 100, 500, 1000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.skotizoKills >= threshold
+  },
+  {
+    name: '{threshold} The Gauntlet kills',
+    metric: 'the_gauntlet',
+    measure: 'kills',
+    thresholds: [100, 200, 1000, 2000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.the_gauntletKills >= threshold
+  },
+  {
+    name: '{threshold} The Corrupted Gauntlet kills',
+    metric: 'the_corrupted_gauntlet',
+    measure: 'kills',
+    thresholds: [100, 200, 1000, 2000],
+    validate: (snapshot: Snapshot, threshold: number) =>
+      snapshot.the_corrupted_gauntletKills >= threshold
+  },
+  {
+    name: '{threshold} Theatre Of Blood kills',
+    metric: 'theatre_of_blood',
+    measure: 'kills',
+    thresholds: [100, 200, 1000, 2000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.theatre_of_bloodKills >= threshold
+  },
+  {
+    name: '{threshold} Thermonuclear Smoke Devil kills',
+    metric: 'thermonuclear_smoke_devil',
+    measure: 'kills',
+    thresholds: [500, 1000, 5000, 10_000],
+    validate: (snapshot: Snapshot, threshold: number) =>
+      snapshot.thermonuclear_smoke_devilKills >= threshold
+  },
+  {
+    name: '{threshold} TzKal-Zuk kills',
+    metric: 'tzkal_zuk',
+    measure: 'kills',
+    thresholds: [25, 50, 250, 500],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.tzkal_zukKills >= threshold
+  },
+  {
+    name: '{threshold} TzTok-Jad kills',
+    metric: 'tztok_jad',
+    measure: 'kills',
+    thresholds: [100, 200, 1000, 2000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.tztok_jadKills >= threshold
+  },
+  {
+    name: '{threshold} Venenatis kills',
+    metric: 'venenatis',
+    measure: 'kills',
+    thresholds: [500, 1000, 5000, 10_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.venenatisKills >= threshold
+  },
+  {
+    name: "{threshold} Vet'ion kills",
+    metric: 'vetion',
+    measure: 'kills',
+    thresholds: [500, 1000, 5000, 10_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.vetionKills >= threshold
+  },
+  {
+    name: '{threshold} Vorkath kills',
+    metric: 'vorkath',
+    measure: 'kills',
+    thresholds: [500, 1000, 5000, 10_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.vorkathKills >= threshold
+  },
+  {
+    name: '{threshold} Wintertodt kills',
+    metric: 'wintertodt',
+    measure: 'kills',
+    thresholds: [500, 1000, 5000, 10_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.wintertodtKills >= threshold
+  },
+  {
+    name: '{threshold} Zalcano kills',
+    metric: 'zalcano',
+    measure: 'kills',
+    thresholds: [500, 1000, 5000, 10_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.zalcanoKills >= threshold
+  },
+  {
+    name: '{threshold} Zulrah kills',
+    metric: 'zulrah',
+    measure: 'kills',
+    thresholds: [500, 1000, 5000, 10_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.zulrahKills >= threshold
+  },
+  // ---------------------
+  // ACTIVITY ACHIEVEMENTS
+  // ---------------------
+  {
+    name: '{threshold} League Points score',
+    metric: 'league_points',
+    measure: 'score',
+    thresholds: [1000, 5000, 10_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.league_pointsScore >= threshold
+  },
+  {
+    name: '{threshold} Bounty Hunter (Hunter) score',
+    metric: 'bounty_hunter_hunter',
+    measure: 'score',
+    thresholds: [1000, 5000, 10_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.bounty_hunter_hunterScore >= threshold
+  },
+  {
+    name: '{threshold} Bounty Hunter (Rogue) score',
+    metric: 'bounty_hunter_rogue',
+    measure: 'score',
+    thresholds: [1000, 5000, 10_000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.bounty_hunter_rogueScore >= threshold
+  },
+  {
+    name: '{threshold} Clue Scrolls (All)',
+    metric: 'clue_scrolls_all',
+    measure: 'score',
+    thresholds: [1000, 5000, 10000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.clue_scrolls_allScore >= threshold
+  },
+  {
+    name: '{threshold} Clue Scrolls (Beginner)',
+    metric: 'clue_scrolls_beginner',
+    measure: 'score',
+    thresholds: [1000, 5000, 10000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.clue_scrolls_beginnerScore >= threshold
+  },
+  {
+    name: '{threshold} Clue Scrolls (Easy)',
+    metric: 'clue_scrolls_easy',
+    measure: 'score',
+    thresholds: [1000, 5000, 10000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.clue_scrolls_easyScore >= threshold
+  },
+  {
+    name: '{threshold} Clue Scrolls (Medium)',
+    metric: 'clue_scrolls_medium',
+    measure: 'score',
+    thresholds: [1000, 5000, 10000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.clue_scrolls_mediumScore >= threshold
+  },
+  {
+    name: '{threshold} Clue Scrolls (Hard)',
+    metric: 'clue_scrolls_hard',
+    measure: 'score',
+    thresholds: [1000, 5000, 10000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.clue_scrolls_hardScore >= threshold
+  },
+  {
+    name: '{threshold} Clue Scrolls (Elite)',
+    metric: 'clue_scrolls_elite',
+    measure: 'score',
+    thresholds: [1000, 5000, 10000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.clue_scrolls_eliteScore >= threshold
+  },
+  {
+    name: '{threshold} Clue Scrolls (Master)',
+    metric: 'clue_scrolls_master',
+    measure: 'score',
+    thresholds: [1000, 5000, 10000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.clue_scrolls_masterScore >= threshold
+  },
+  {
+    name: '{threshold} Last Man Standing score',
+    metric: 'last_man_standing',
+    measure: 'score',
+    thresholds: [1000, 5000, 10000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.last_man_standingScore >= threshold
+  },
+  {
+    name: '{threshold} Soul Wars Zeal',
+    metric: 'soul_wars_zeal',
+    measure: 'score',
+    thresholds: [1000, 5000, 10000],
+    validate: (snapshot: Snapshot, threshold: number) => snapshot.soul_wars_zealScore >= threshold
+  }
+];

--- a/server/src/api/modules/achievements/templates.ts
+++ b/server/src/api/modules/achievements/templates.ts
@@ -1,6 +1,6 @@
 import { Snapshot } from '../../../database/models';
 import { CAPPED_MAX_TOTAL_XP, getCappedTotalXp, getCombatLevel } from '../../util/experience';
-import { AchievementTemplate } from '../../services/internal/achiev.service';
+import { AchievementTemplate } from '../../services/internal/achievement.service';
 
 export const ACHIEVEMENT_TEMPLATES: AchievementTemplate[] = [
   // ------------------

--- a/server/src/api/routes/player.routes.ts
+++ b/server/src/api/routes/player.routes.ts
@@ -15,6 +15,7 @@ api.get('/username/:username/gained', controller.gained);
 api.get('/username/:username/records', controller.records);
 api.get('/username/:username/snapshots', controller.snapshots);
 api.get('/username/:username/achievements', controller.achievements);
+api.get('/username/:username/achievements/progress', controller.achievementsProgress);
 api.get('/username/:username/competitions', controller.competitions);
 api.get('/username/:username/names', controller.names);
 api.put('/username/:username/country', controller.updateCountry);
@@ -25,6 +26,7 @@ api.get('/:id/gained', controller.gained);
 api.get('/:id/records', controller.records);
 api.get('/:id/snapshots', controller.snapshots);
 api.get('/:id/achievements', controller.achievements);
+api.get('/:id/achievements/progress', controller.achievementsProgress);
 api.get('/:id/competitions', controller.competitions);
 api.get('/:id/names', controller.names);
 

--- a/server/src/api/services/internal/achievement.service.ts
+++ b/server/src/api/services/internal/achievement.service.ts
@@ -260,7 +260,7 @@ function formatThreshold(threshold: number): string {
   if (threshold < 1000) return String(threshold);
   if (threshold <= 10_000) return `${Math.floor(threshold / 1000)}k`;
 
-  if ([737_627, 1_986_068, 5_346_332, 13_034_431].includes(threshold)) {
+  if ([101_333, 273_742, 737_627, 1_986_068, 5_346_332, 13_034_431].includes(threshold)) {
     return getLevel(threshold).toString();
   }
 

--- a/server/src/api/services/internal/achievement.service.ts
+++ b/server/src/api/services/internal/achievement.service.ts
@@ -1,240 +1,107 @@
-import { Pagination } from 'src/types';
+import { Pagination } from '../../../types';
 import { sequelize } from '../../../database';
-import { Achievement, Player, Snapshot } from '../../../database/models';
-import {
-  ACTIVITIES,
-  ACTIVITY_ACHIEVEMENT_TEMPLATES,
-  BOSSES,
-  BOSS_ACHIEVEMENT_TEMPLATES,
-  SKILLS,
-  SKILL_ACHIEVEMENT_TEMPLATES
-} from '../..//constants';
+import { Achievement, Snapshot, Player } from '../../../database/models';
+import { isSkill, isActivity, isBoss, isVirtual, getValueKey } from '../../util/metrics';
 import { CAPPED_MAX_TOTAL_XP } from '../../util/experience';
-import { getDifficultyFactor, getFormattedName, getMeasure, getValueKey } from '../../util/metrics';
+import { ACHIEVEMENT_TEMPLATES } from '../../modules/achievements/templates';
 import * as snapshotService from './snapshot.service';
 
-function formatThreshold(threshold: number): string {
-  if (threshold === 13034431) return '99';
-  if (threshold === CAPPED_MAX_TOTAL_XP) return '2277';
-  if (threshold < 1000 || threshold === 2277) return String(threshold);
-  if (threshold <= 10000) return `${Math.floor(threshold / 1000)}k`;
+const UNKNOWN_DATE = new Date(0);
 
-  if (threshold < 1000000000)
-    return `${Math.round((threshold / 1000000 + Number.EPSILON) * 100) / 100}m`;
-
-  return `${Math.round((threshold / 1000000000 + Number.EPSILON) * 100) / 100}b`;
+export interface AchievementTemplate {
+  name: string;
+  metric: string;
+  measure: string;
+  thresholds: number[];
+  validate: (snapshot: Snapshot, threshold: number) => boolean;
 }
 
-function formatType(baseType: string, threshold: number, metric: string): string {
-  return baseType
-    .replace('{threshold}', formatThreshold(threshold))
-    .replace('{skill}', getFormattedName(metric))
-    .replace('{activity}', getFormattedName(metric))
-    .replace('{boss}', getFormattedName(metric));
+interface ExtendedAchievement extends Achievement {
+  measure: string;
 }
 
-/**
- * Get all achievement definitions (hydrated templates)
- */
-function getDefinitions() {
-  const definitions = [];
+interface AchievementDefinition {
+  name: string;
+  metric: string;
+  measure: string;
+  threshold: number;
+  validate: (snapshot: Snapshot) => boolean;
+}
 
-  SKILL_ACHIEVEMENT_TEMPLATES.forEach((template: any) => {
-    const { metric, thresholds, type, validate } = template;
-
-    // Dynamic threshold/skill templates (Ex: 99 Attack, 50m Cooking)
-    if (!metric) {
-      SKILLS.filter(s => s !== 'overall').forEach(skill => {
-        thresholds
-          .map(t => t * getDifficultyFactor(skill))
-          .forEach(threshold => {
-            const newType = formatType(type, threshold, skill);
-            const newValidate = snapshot => snapshot[getValueKey(skill)] >= threshold;
-
-            definitions.push({ type: newType, metric: skill, threshold, validate: newValidate });
-          });
-      });
-    } else if (thresholds.length > 1) {
-      // Dynamic threshold templates, fixed skill (Ex: 500m Overall, 1b Overall)
-      thresholds
-        .map(t => t * getDifficultyFactor(metric))
-        .forEach(threshold => {
-          const newType = formatType(type, threshold, metric);
-          const newValidate = snapshot => snapshot[getValueKey(metric)] >= threshold;
-
-          definitions.push({ type: newType, metric, threshold, validate: newValidate });
-        });
-    } else {
-      // Fixed threshold & metric (Ex: 126 Combat, Maxed Overall)
-      const threshold = thresholds[0] * getDifficultyFactor(metric);
-      definitions.push({ type, metric, threshold, validate });
-    }
+async function getPlayerAchievements(playerId: number) {
+  const achievements = await Achievement.findAll({
+    where: { playerId }
   });
 
-  ACTIVITY_ACHIEVEMENT_TEMPLATES.forEach((template: any) => {
-    const { metric, thresholds, type, validate } = template;
+  return achievements.map(format);
+}
 
-    // Dynamic threshold/activity templates (Ex: 1k Clues (Hard), 5k Clues (Medium))
-    if (!metric) {
-      ACTIVITIES.forEach(activity => {
-        thresholds
-          .map(t => t * getDifficultyFactor(activity))
-          .forEach(threshold => {
-            const newType = formatType(type, threshold, activity);
-            const newValidate = snapshot => snapshot[getValueKey(activity)] >= threshold;
+async function syncAchievements(playerId: number): Promise<void> {
+  // Fetch the player's latest 2 snapshots
+  const snapshots = await snapshotService.findAll(playerId, 2);
 
-            definitions.push({ type: newType, metric: activity, threshold, validate: newValidate });
-          });
-      });
-    } else if (thresholds.length > 1) {
-      thresholds
-        .map(t => t * getDifficultyFactor(metric))
-        .forEach(threshold => {
-          const newType = formatType(type, threshold, metric);
-          const newValidate = snapshot => snapshot[getValueKey(metric)] >= threshold;
+  if (!snapshots || snapshots.length < 2) return;
 
-          definitions.push({ type: newType, metric, threshold, validate: newValidate });
-        });
-    } else {
-      const threshold = thresholds[0] * getDifficultyFactor(metric);
-      definitions.push({ type, metric, threshold, validate });
-    }
+  const [current, previous] = snapshots;
+
+  // Find all achievements the player already has
+  const currentAchievements = await Achievement.findAll({ where: { playerId } });
+
+  // Find any missing achievements (by comparing the SHOULD HAVE with the HAS IN DATABASE lists)
+  const missingDefinitions = getDefinitions().filter(d => {
+    return d.validate(previous) && !currentAchievements.find(e => e.name === d.name);
   });
 
-  BOSS_ACHIEVEMENT_TEMPLATES.forEach((template: any) => {
-    const { metric, thresholds, type, validate } = template;
-
-    // Dynamic threshold/boss templates (Ex: 500 Cerberus, 1k Zulrah)
-    if (!metric) {
-      BOSSES.forEach(boss => {
-        thresholds
-          .map(t => t * getDifficultyFactor(boss))
-          .forEach(threshold => {
-            const newType = formatType(type, threshold, boss);
-            const newValidate = snapshot => snapshot[getValueKey(boss)] >= threshold;
-
-            definitions.push({ type: newType, metric: boss, threshold, validate: newValidate });
-          });
-      });
-    } else if (thresholds.length > 1) {
-      thresholds
-        .map(t => t * getDifficultyFactor(metric))
-        .forEach(threshold => {
-          const newType = formatType(type, threshold, metric);
-          const newValidate = snapshot => snapshot[getValueKey(metric)] >= threshold;
-
-          definitions.push({ type: newType, metric, threshold, validate: newValidate });
-        });
-    } else {
-      const threshold = thresholds[0] * getDifficultyFactor(metric);
-      definitions.push({ type, metric, threshold, validate });
-    }
+  // Find any new achievements (only achieved since the last snapshot)
+  const newDefinitions = getDefinitions().filter(d => {
+    return !d.validate(previous) && d.validate(current);
   });
 
-  return definitions;
+  // Nothing to add.
+  if (newDefinitions.length === 0 && missingDefinitions.length === 0) return;
+
+  // Search dates for missing definitions, based on player history
+  const missingPastDates = await calculatePastDates(playerId, missingDefinitions);
+
+  // Create achievement instances for all the missing definitions
+  const missingAchievements = missingDefinitions.map(d => {
+    return { ...d, playerId, createdAt: missingPastDates[d.name] || UNKNOWN_DATE };
+  });
+
+  // Create achievement instances for all the newly achieved definitions
+  const newAchievements = newDefinitions.map(d => {
+    return { ...d, playerId, createdAt: current.createdAt };
+  });
+
+  // Add all missing/new achievements
+  await Achievement.bulkCreate([...missingAchievements, ...newAchievements], { ignoreDuplicates: true });
 }
 
-/**
- * Searches through the player's snapshot history
- * to try and determine the date of a missing achievement.
- */
-async function addPastDates(playerId, achievements) {
-  if (!achievements || achievements.length === 0) {
-    return [];
-  }
-
-  const allSnapshots = await snapshotService.findAll(playerId, 1000);
-
-  if (!allSnapshots || allSnapshots.length < 2) {
-    return achievements;
-  }
-
-  // Format: {'1k Zulrah kills': *date*, '99 Strength': *date*}
-  const dateMap = {};
-
-  for (let i = 0; i < allSnapshots.length - 1; i++) {
-    const prev = allSnapshots[i];
-    const next = allSnapshots[i + 1];
-
-    const newAchievements = getNewAchievements(prev, next);
-
-    if (newAchievements.length > 0) {
-      newAchievements.forEach(a => {
-        if (!dateMap[a.type]) {
-          const minDate = Math.min(a.createdAt.getTime(), next.createdAt.getTime());
-          dateMap[a.type] = new Date(minDate);
-        }
-      });
-    }
-  }
-
-  return achievements.map(a => ({ ...a, createdAt: dateMap[a.type] || a.createdAt }));
-}
-
-/**
- * Calculates any new achievements whose thresholds were
- * crossed in between the current and previous snapshot.
- *
- * Ex: previous had 965 zulrah kills, now I have 1018, so I
- * should be awarded with the "1k Zulrah kills" achievement
- */
-function getNewAchievements(current, previous) {
-  if (!current || !previous) {
-    return [];
-  }
-
-  const newAchievements = getDefinitions()
-    .filter(def => !def.validate(previous) && def.validate(current))
-    .map(def => {
-      // If the previous value was untracked, the achievement date is unknown
-      const createdAt = previous[getValueKey(def.metric)] === -1 ? new Date(0) : new Date();
-      return { ...def, createdAt };
-    });
-
-  return newAchievements;
-}
-
-/**
- * Finds all achievements that a player SHOULD HAVE HAD
- * based on their previous snapshot.
- *
- * This is used to find any missing achievements (by comparing this list to the database)
- */
-function getPreviousAchievements(previousSnapshot: Snapshot) {
-  if (!previousSnapshot) {
-    return [];
-  }
-
-  const previousAchievements = getDefinitions()
-    .filter(def => def.validate(previousSnapshot))
-    .map(def => ({ ...def, createdAt: new Date(0) }));
-
-  return previousAchievements;
-}
-
-/**
- * Go through the player's "unknown" date achievements, and try
- * to determine their date by searching through the player's snapshot
- * history. (Helps when importing CML history)
- */
 async function reevaluateAchievements(playerId: number): Promise<void> {
   // Find all unknown date achievements
-  const unknown = await Achievement.findAll({
-    where: { playerId, createdAt: new Date(0) },
-    raw: true
+  const unknownAchievements = await Achievement.findAll({
+    where: { playerId, createdAt: UNKNOWN_DATE }
   });
 
-  // Attach dates to as many unknown achievements as possible
-  const datedUnknownAchievements = await addPastDates(playerId, unknown);
+  const unknownAchievementNames = unknownAchievements.map(u => u.name);
+  const unknownDefinitions = getDefinitions().filter(d => unknownAchievementNames.includes(d.name));
 
-  // Include only achievements with a valid (not unknown) date
-  const toUpdate = datedUnknownAchievements.filter(d => d.createdAt > 0).map(t => ({ ...t, playerId }));
+  // Search dates for previously unknown definitions, based on player history
+  const pastDates = await calculatePastDates(playerId, unknownDefinitions);
+
+  // Attach new dates where possible, and filter out any (still) unknown achievements
+  const toUpdate = unknownAchievements
+    .map(a => ({ ...a.toJSON(), createdAt: pastDates[a.name] || UNKNOWN_DATE }))
+    .filter(a => a.createdAt.getTime() > 0);
 
   if (toUpdate && toUpdate.length > 0) {
     const transaction = await sequelize.transaction();
 
     // Remove outdated achievements
-    await Achievement.destroy({ where: { playerId, type: toUpdate.map(t => t.type) }, transaction });
+    await Achievement.destroy({
+      where: { playerId, name: toUpdate.map((t: any) => t.name) },
+      transaction
+    });
 
     // Re-add them with the correct date
     await Achievement.bulkCreate(toUpdate, { transaction, ignoreDuplicates: true });
@@ -243,85 +110,7 @@ async function reevaluateAchievements(playerId: number): Promise<void> {
   }
 }
 
-/**
- * Adds all missing player achievements.
- * (Since ignoreDuplicates is true, it will only insert unique achievements)
- */
-async function syncAchievements(playerId: number): Promise<void> {
-  const snapshots = await snapshotService.findAll(playerId, 10);
-
-  if (!snapshots || snapshots.length < 2) {
-    return;
-  }
-
-  const current = snapshots[0];
-  const previous = snapshots[1];
-
-  // Find all achievements the player already has
-  const existingAchievements = await Achievement.findAll({ where: { playerId } });
-
-  // Find all achievements the player should have had (in the previous update)
-  const previousAchievements = getPreviousAchievements(previous).map(a => ({ ...a, playerId }));
-
-  // Find any missing achievements (by comparing the SHOULD HAVE with the HAS IN DATABASE lists)
-  const missingAchievements = previousAchievements.filter(
-    a => !existingAchievements.find(e => e.type === a.type)
-  );
-
-  const datedMissingAchievements = await addPastDates(playerId, missingAchievements);
-
-  // Find any new achievements (only achieved since the last snapshot)
-  const newAchievements = getNewAchievements(current, previous).map(a => ({ ...a, playerId }));
-
-  // Combine missing and new achievements
-  const toInsert = [...datedMissingAchievements, ...newAchievements];
-
-  if (!toInsert || !toInsert.length) {
-    return;
-  }
-
-  await Achievement.bulkCreate(toInsert, { ignoreDuplicates: true });
-}
-
-/**
- * Find all achievements for a given player id.
- *
- * If includeMissing, it will also include the missing
- * achievements, with a "missing" field set to true.
- */
-async function getPlayerAchievements(playerId: number, includeMissing = false) {
-  const achievements = await Achievement.findAll({
-    where: { playerId },
-    raw: true
-  });
-
-  if (!includeMissing) {
-    return achievements;
-  }
-
-  const achievedTypes = achievements.map((a: any) => a.type);
-  const definitions = getDefinitions();
-
-  const missingAchievements = definitions
-    .filter(d => !achievedTypes.includes(d.type))
-    .map(({ type, metric, threshold }) => ({
-      playerId,
-      type,
-      metric,
-      threshold,
-      createdAt: null,
-      missing: true
-    }));
-
-  return [...achievements, ...missingAchievements].map((a: any) => {
-    // Only 126 combat is level based
-    const isLevels = a.metric === 'combat';
-    const measure = isLevels ? 'levels' : getMeasure(a.metric);
-    return { ...a, measure, threshold: parseInt(a.threshold) };
-  });
-}
-
-async function findAllForGroup(playerIds: number[], pagination: Pagination): Promise<Achievement[]> {
+async function getGroupAchievements(playerIds: number[], pagination: Pagination) {
   const achievements = await Achievement.findAll({
     where: { playerId: playerIds },
     include: [{ model: Player }],
@@ -330,7 +119,78 @@ async function findAllForGroup(playerIds: number[], pagination: Pagination): Pro
     offset: pagination.offset
   });
 
-  return achievements;
+  return achievements.map(format);
 }
 
-export { syncAchievements, reevaluateAchievements, getPlayerAchievements, findAllForGroup };
+async function calculatePastDates(playerId: number, definitions: AchievementDefinition[]) {
+  if (!definitions || definitions.length === 0) return {};
+
+  const allSnapshots = (await snapshotService.findAll(playerId, 10_000)).reverse();
+
+  // The player must have atleast 2 snapshots to find a achievement date
+  if (!allSnapshots || allSnapshots.length < 2) return [];
+
+  const dateMap: { [definitionName: string]: Date } = {};
+
+  for (let i = 0; i < allSnapshots.length - 2; i++) {
+    const prev = allSnapshots[i];
+    const next = allSnapshots[i + 1];
+
+    // Include only definitions that are "newly" valid (between two snapshots)
+    const valid = definitions.filter(d => {
+      // Check if the previous value is > -1, this prevents this calc from setting the first snapshot
+      // after May 10th 2020 as the achievement date for any pre-WOM boss achievements
+      // (boss tracking was introduced on May 10th 2020)
+      return !d.validate(prev) && d.validate(next) && prev[getValueKey(d.metric)] > -1;
+    });
+
+    valid.forEach(v => {
+      if (!(v.name in dateMap)) {
+        dateMap[v.name] = next.createdAt;
+      }
+    });
+  }
+
+  return dateMap;
+}
+
+function getDefinitions(): AchievementDefinition[] {
+  const definitions = [];
+
+  ACHIEVEMENT_TEMPLATES.forEach(({ thresholds, name, validate, metric, measure }) => {
+    thresholds.forEach(threshold => {
+      const newName = name.replace('{threshold}', formatThreshold(threshold));
+      const validateFn = (snapshot: Snapshot) => validate(snapshot, threshold);
+
+      definitions.push({ name: newName, metric, measure, threshold, validate: validateFn });
+    });
+  });
+
+  return definitions;
+}
+
+function format(achievement: Achievement): ExtendedAchievement {
+  return { ...(achievement.toJSON() as any), measure: getAchievementMeasure(achievement.metric) };
+}
+
+function getAchievementMeasure(metric: string): string {
+  if (isBoss(metric)) return 'kills';
+  if (isSkill(metric)) return 'experience';
+  if (isActivity(metric)) return 'score';
+  if (isVirtual(metric)) return 'value';
+  return 'levels';
+}
+
+function formatThreshold(threshold: number): string {
+  if (threshold === 13_034_431) return '99';
+  if (threshold === CAPPED_MAX_TOTAL_XP) return '2277';
+  if (threshold < 1000 || threshold === 2277) return String(threshold);
+  if (threshold <= 10_000) return `${Math.floor(threshold / 1000)}k`;
+
+  if (threshold < 1_000_000_000)
+    return `${Math.round((threshold / 1_000_000 + Number.EPSILON) * 100) / 100}m`;
+
+  return `${Math.round((threshold / 1_000_000_000 + Number.EPSILON) * 100) / 100}b`;
+}
+
+export { syncAchievements, reevaluateAchievements, getPlayerAchievements, getGroupAchievements };

--- a/server/src/api/services/internal/achievement.service.ts
+++ b/server/src/api/services/internal/achievement.service.ts
@@ -260,7 +260,7 @@ function formatThreshold(threshold: number): string {
   if (threshold < 1000) return String(threshold);
   if (threshold <= 10_000) return `${Math.floor(threshold / 1000)}k`;
 
-  if ([101_333, 273_742, 737_627, 1_986_068, 5_346_332, 13_034_431].includes(threshold)) {
+  if ([273_742, 737_627, 1_986_068, 5_346_332, 13_034_431].includes(threshold)) {
     return getLevel(threshold).toString();
   }
 

--- a/server/src/api/services/internal/group.service.ts
+++ b/server/src/api/services/internal/group.service.ts
@@ -221,7 +221,7 @@ async function getAchievements(groupId: number, pagination: Pagination): Promise
   }
 
   const memberIds = memberships.map(m => m.playerId);
-  const achievements = await achievementService.findAllForGroup(memberIds, pagination);
+  const achievements = await achievementService.getGroupAchievements(memberIds, pagination);
 
   return achievements;
 }

--- a/server/src/api/util/experience.ts
+++ b/server/src/api/util/experience.ts
@@ -12,9 +12,6 @@ export const MAX_VIRTUAL_LEVEL = 126;
 // The maximum skill experience (200M experience).
 export const MAX_SKILL_EXP = 200_000_000;
 
-// The minimum amount of experience required to have maxed stats
-export const CAPPED_MAX_TOTAL_XP = 299791913;
-
 // Builds a lookup table for each level's required experience
 // exp = XP_FOR_LEVEL[level - 1] || 13m = XP_FOR_LEVEL[98]
 export const XP_FOR_LEVEL = (function () {
@@ -58,6 +55,15 @@ export function getLevel(exp: number, virtual = false): number {
   return high + 1;
 }
 
+export function getMinimumExp(snapshot: Snapshot) {
+  return REAL_SKILLS.map(s => Math.max(0, snapshot[getValueKey(s)])).sort((a, b) => a - b)[0];
+}
+
+export function getCappedExp(snapshot: Snapshot, max: number) {
+  const cappedExp = REAL_SKILLS.map(s => Math.min(snapshot[getValueKey(s)], max));
+  return cappedExp.reduce((acc, cur) => acc + cur);
+}
+
 export function getCombatLevel(snapshot: any): number {
   const combatSkillKeys = COMBAT_SKILLS.map(s => getValueKey(s));
   const combatExperiences = pick(snapshot, combatSkillKeys);
@@ -87,11 +93,6 @@ export function getCombatLevel(snapshot: any): number {
 export function getTotalLevel(snapshot) {
   const levels = REAL_SKILLS.map(s => getLevel(snapshot[getValueKey(s)]));
   return levels.reduce((acc, cur) => acc + cur);
-}
-
-export function getCappedTotalXp(snapshot) {
-  const cappedExp = REAL_SKILLS.map(s => Math.min(snapshot[getValueKey(s)], getXpForLevel(99)));
-  return cappedExp.reduce((acc, cur) => acc + cur);
 }
 
 export function get200msCount(snapshot: any) {

--- a/server/src/api/util/metrics.ts
+++ b/server/src/api/util/metrics.ts
@@ -80,28 +80,6 @@ function getFormattedName(metric: string): string {
   return 'Invalid metric name';
 }
 
-function getDifficultyFactor(metric: string): number {
-  switch (metric) {
-    case 'chambers_of_xeric':
-    case 'chambers_of_xeric_challenge_mode':
-    case 'theatre_of_blood':
-    case 'the_gauntlet':
-    case 'the_corrupted_gauntlet':
-    case 'tztok_jad':
-      return 0.2;
-    case 'bryophyta':
-    case 'obor':
-    case 'skotizo':
-    case 'hespori':
-      return 0.1;
-    case 'mimic':
-    case 'tzkal_zuk':
-      return 0.05;
-    default:
-      return 1;
-  }
-}
-
 export function getMinimumBossKc(metric: string): number {
   if (!isBoss(metric)) return 0;
 
@@ -405,6 +383,5 @@ export {
   getRankKey,
   getValueKey,
   getVirtualKey,
-  getDifficultyFactor,
   getAbbreviation
 };

--- a/server/src/database/migrations/20210206192248-rename-achievements-name.ts
+++ b/server/src/database/migrations/20210206192248-rename-achievements-name.ts
@@ -1,0 +1,11 @@
+import { QueryInterface } from 'sequelize/types';
+
+function up(queryInterface: QueryInterface): Promise<void> {
+  return queryInterface.renameColumn('achievements', 'type', 'name');
+}
+
+function down(queryInterface: QueryInterface) {
+  return queryInterface.renameColumn('achievements', 'name', 'type');
+}
+
+export { up, down };

--- a/server/src/database/models/achievement.model.ts
+++ b/server/src/database/models/achievement.model.ts
@@ -8,7 +8,7 @@ const options = {
   indexes: [
     {
       unique: true,
-      fields: ['playerId', 'type']
+      fields: ['playerId', 'name']
     },
     {
       fields: ['playerId']
@@ -23,7 +23,7 @@ export default class Achievement extends Model<Achievement> {
   playerId: number;
 
   @Column({ type: DataType.STRING, primaryKey: true, allowNull: false })
-  type: string;
+  name: string;
 
   @Column({ type: DataType.STRING })
   metric: string;


### PR DESCRIPTION
Closes #423 
Closes #403 
Closes #624 
Closes #676 

### API
- Refactored the achievements service (this makes it much easier to maintain and add new achievements in the future)
- Improved pre-WOM achievements dating calculations
- Added new endpoint `/players/.../achievements/progress` which details the player's progress for each achievement
- Removed the `includeMissing` param in `/players/.../achievements`, use the endpoint mentioned above instead
- Adjusted boss and activity achievement thresholds (details below)
- Renamed a few achievements (details below)
- Removed league points achievements as they were useless
- Added 100m and 200m Overall Exp. achievements
- Added 60, 70, 80 and 90 Base Stats achievements

### App
- The progress bars in the Player page now display the current value aswell as the relative progress to the next tier


New Achievements:
- Base 60 Stats
- Base 70 Stats
- Base 80 Stats
- Base 90 Stats
- 100m Overall Exp.
- 200m Overall Exp.

Adjusted achievements:
- CoX: `100, 200, 1k, 2k` -> `100, 500, 1k, 5k`
- CoX CM: `100, 200, 1k, 2k` -> `100, 500, 1k, 5k`
- Mimic: `25, 50, 250, 500` -> `10, 50, 100, 200`
- ToB: `100, 200, 1k, 2k` -> `100, 500, 1000, 5000`
- Zuk: `25, 50, 250, 500` -> `10, 50, 100, 200`
- Jad: `100, 200, 1k, 2k` -> `50, 100, 500, 1k`
- Clue Scrolls (All) `1k, 5k, 10k` -> `500, 1k, 5k, 10k`
- Clue Scrolls (Beginner) `1k, 5k, 10k` -> `200, 500, 1k, 5k`
- Clue Scrolls (Easy) `1k, 5k, 10k` -> `500, 1k, 5k, 10k`
- Clue Scrolls (Medium) `1k, 5k, 10k` -> `500, 1k, 5k, 10k`
- Clue Scrolls (Hard) `1k, 5k, 10k` -> `500, 1k, 5k, 10k`
- Clue Scrolls (Elite) `1k, 5k, 10k` -> `100, 500, 1k, 5k`
- Clue Scrolls (Master) `1k, 5k, 10k` -> `100, 500, 1k, 5k`
- LMS `1k, 5k, 10k` -> `2k, 5k, 10k, 15k`
- Soul Wars `1k, 5k, 10k` -> `5k, 10k, 20k`

Removed achievements:
- 1k, 5k, 10k League Points

Renamed achievement names:
- `Barrows Chests kills` -> `Barrows Chests`
- `Clue Scrolls (All) score` -> `Clue Scrolls (All)`
- `Clue Scrolls (Begin) score` -> `Clue Scrolls (Begin)`
- `Clue Scrolls (Easy) score` -> `Clue Scrolls (Easy)`
- `Clue Scrolls (Medium) score` -> `Clue Scrolls (Medium)`
- `Clue Scrolls (Hard) score` -> `Clue Scrolls (Hard)`
- `Clue Scrolls (Elite) score` -> `Clue Scrolls (Elite)`
- `Clue Scrolls (Master) score` -> `Clue Scrolls (Master)`
- `Soul Wars Zeal score` -> `Soul Wars Zeal` 