### PR TITLE
Fix zero overall exp bug

### DIFF
--- a/server/src/api/services/internal/delta.service.ts
+++ b/server/src/api/services/internal/delta.service.ts
@@ -287,8 +287,8 @@ function diff(start: Snapshot, end: Snapshot, initial: InitialValues, player: Pl
     const endValue = parseNum(metric, end[valueKey]);
     const endRank = end[rankKey];
 
-    // Do not use initial ranks for skill, to prevent -1 ranks
-    // introduced by https://github.com/wise-old-man/wise-old-man/pull/93 from creating crazy diffs
+    // Do not use initial ranks for skill, to prevent -1 ranks from creating crazy diffs
+    // (introduced by https://github.com/wise-old-man/wise-old-man/pull/93)
     const gainedRank = isSkill(metric) && start[rankKey] === -1 ? 0 : endRank - startRank;
     const gainedValue = round(endValue - startValue, 5);
 

--- a/server/src/api/services/internal/snapshot.service.ts
+++ b/server/src/api/services/internal/snapshot.service.ts
@@ -299,8 +299,10 @@ async function fromRS(playerId: number, csvData: string): Promise<Snapshot> {
   // Populate the skills' values with the values from the csv
   SKILLS.forEach((s, i) => {
     const [rank, , experience] = rows[i];
+    const expNum = parseInt(experience);
+
     stats[getRankKey(s)] = parseInt(rank);
-    stats[getValueKey(s)] = parseInt(experience);
+    stats[getValueKey(s)] = s === 'overall' && expNum === 0 ? -1 : expNum;
   });
 
   // Populate the activities' values with the values from the csv


### PR DESCRIPTION
Fixes #677 

Apparently instead of `-1` sometimes jagex's API returns `0` exp for unranked overall players.
Since the "initial values" workarounds were only meant for `-1` to be the unranked value, it would cause some players with low total levels but high exp to appear as if they gained a bunch of exp when finally ranked in overall exp.

