### PR TITLE
Feature: HCIM Died / Member Name Changed discord events

### DIFF
--- a/server/src/api/events/player.events.ts
+++ b/server/src/api/events/player.events.ts
@@ -18,13 +18,16 @@ function onPlayerTypeChanged(player: Player, previousType: string) {
   }
 }
 
-function onPlayerNameChanged(player: Player) {
+function onPlayerNameChanged(player: Player, previousDisplayName: string) {
   // Recalculate player achievements
   achievementService.syncAchievements(player.id);
 
   // Setup jobs to assert the player's name capitalization and account type
   jobs.add('AssertPlayerName', { id: player.id }, { attempts: 5, backoff: 30000 });
   jobs.add('AssertPlayerType', { id: player.id }, { attempts: 5, backoff: 30000 });
+
+  // Dispatch a "Player name changed" event to our discord bot API.
+  discordService.dispatchNameChanged(player, previousDisplayName);
 }
 
 async function onPlayerUpdated(snapshot: Snapshot) {

--- a/server/src/api/events/player.events.ts
+++ b/server/src/api/events/player.events.ts
@@ -1,5 +1,6 @@
 import { Player, Snapshot } from '../../database/models';
 import jobs from '../jobs';
+import * as discordService from '../services/external/discord.service';
 import * as achievementService from '../services/internal/achievement.service';
 import * as competitionService from '../services/internal/competition.service';
 import * as deltaService from '../services/internal/delta.service';
@@ -8,6 +9,13 @@ import * as playerService from '../services/internal/player.service';
 function onPlayerCreated(player: Player) {
   // Confirm this player's name capitalization
   jobs.add('AssertPlayerName', { id: player.id }, { attempts: 5, backoff: 30000 });
+}
+
+function onPlayerTypeChanged(player: Player, previousType: string) {
+  if (previousType === 'hardcore' && player.type === 'ironman') {
+    // Dispatch a "HCIM player died" event to our discord bot API.
+    discordService.dispatchHardcoreDied(player);
+  }
 }
 
 function onPlayerNameChanged(player: Player) {
@@ -39,4 +47,4 @@ function onPlayerImported(playerId: number) {
   achievementService.reevaluateAchievements(playerId);
 }
 
-export { onPlayerCreated, onPlayerNameChanged, onPlayerUpdated, onPlayerImported };
+export { onPlayerCreated, onPlayerTypeChanged, onPlayerNameChanged, onPlayerUpdated, onPlayerImported };

--- a/server/src/api/hooks.ts
+++ b/server/src/api/hooks.ts
@@ -28,7 +28,7 @@ function setup() {
 
   Player.afterUpdate((player: Player, options: UpdateOptions) => {
     if (!options.fields) return;
-    if (options.fields.includes('username')) onPlayerNameChanged(player);
+    if (options.fields.includes('username')) onPlayerNameChanged(player, player.previous('displayName'));
     if (options.fields.includes('type')) onPlayerTypeChanged(player, player.previous('type'));
   });
 

--- a/server/src/api/hooks.ts
+++ b/server/src/api/hooks.ts
@@ -16,6 +16,7 @@ import { onNameChangeCreated } from './events/name.events';
 import {
   onPlayerCreated,
   onPlayerImported,
+  onPlayerTypeChanged,
   onPlayerNameChanged,
   onPlayerUpdated
 } from './events/player.events';
@@ -26,8 +27,9 @@ function setup() {
   });
 
   Player.afterUpdate((player: Player, options: UpdateOptions) => {
-    if (!options.fields || !options.fields.includes('username')) return;
-    onPlayerNameChanged(player);
+    if (!options.fields) return;
+    if (options.fields.includes('username')) onPlayerNameChanged(player);
+    if (options.fields.includes('type')) onPlayerTypeChanged(player, player.previous('type'));
   });
 
   Player.afterCreate((player: Player) => {

--- a/server/src/api/services/external/discord.service.ts
+++ b/server/src/api/services/external/discord.service.ts
@@ -62,6 +62,23 @@ async function dispatchHardcoreDied(player: Player) {
 }
 
 /**
+ * Send a "Player Name Changed" notification to our discord API,
+ * so that it can notify any relevant guilds/servers.
+ */
+async function dispatchNameChanged(player: Player, previousDisplayName: string) {
+  // Find all the groups for which this player is a member
+  const groups = await groupService.getPlayerGroups(player.id, { limit: 200, offset: 0 });
+
+  // The following actions are only relevant to players
+  // that are group members, so ignore any that aren't
+  if (!groups || groups.length === 0) return;
+
+  groups.forEach(({ id }) => {
+    dispatch('MEMBER_NAME_CHANGED', { groupId: id, player, previousName: previousDisplayName });
+  });
+}
+
+/**
  * Select all new group members and dispatch them to our discord API,
  * so that it can notify any relevant guilds/servers.
  */
@@ -161,6 +178,7 @@ export {
   dispatch,
   dispatchAchievements,
   dispatchHardcoreDied,
+  dispatchNameChanged,
   dispatchMembersJoined,
   dispatchMembersLeft,
   dispatchCompetitionCreated,


### PR DESCRIPTION
Adds two new discord events, to be consumed and broadcasted to the relevant groups by the discord bot.

- Member (HCIM) Died
- Member Name Changed