### PR TITLE
Fix "0.02m" achievement threshold formatting

### DIFF
--- a/server/src/api/services/internal/achievement.service.ts
+++ b/server/src/api/services/internal/achievement.service.ts
@@ -258,7 +258,7 @@ function getAchievementStartValue(definition: AchievementDefinition) {
 
 function formatThreshold(threshold: number): string {
   if (threshold < 1000) return String(threshold);
-  if (threshold <= 10_000) return `${Math.floor(threshold / 1000)}k`;
+  if (threshold <= 100_000) return `${Math.floor(threshold / 1000)}k`;
 
   if ([273_742, 737_627, 1_986_068, 5_346_332, 13_034_431].includes(threshold)) {
     return getLevel(threshold).toString();


### PR DESCRIPTION
Achievements with 15k or 20k thresholds were being formatted as `0.02m`.