### PR TITLE
Add reaction execution tracking

### DIFF
--- a/server/src/api/events/achievement.events.ts
+++ b/server/src/api/events/achievement.events.ts
@@ -1,9 +1,12 @@
 import { Achievement } from '../../database/models';
 import * as discordService from '../services/external/discord.service';
+import metrics from '../services/external/metrics.service';
 
 async function onAchievementsCreated(achievements: Achievement[]) {
   // Dispatch this new achievements to the discord bot (for broadcasting)
-  discordService.dispatchAchievements(achievements[0].playerId, achievements);
+  await metrics.measureReaction('DiscordAchievements', () =>
+    discordService.dispatchAchievements(achievements[0].playerId, achievements)
+  );
 }
 
 export { onAchievementsCreated };

--- a/server/src/api/events/delta.events.ts
+++ b/server/src/api/events/delta.events.ts
@@ -1,9 +1,12 @@
 import { Delta } from '../../database/models';
+import metrics from '../services/external/metrics.service';
 import * as recordService from '../services/internal/record.service';
 
 async function onDeltaUpdated(delta: Delta) {
   // Check if this new delta is an all time record for this player
-  recordService.syncRecords(delta.playerId, delta.period);
+  await metrics.measureReaction('SyncRecords', () =>
+    recordService.syncRecords(delta.playerId, delta.period)
+  );
 }
 
 export { onDeltaUpdated };

--- a/server/src/api/events/group.events.ts
+++ b/server/src/api/events/group.events.ts
@@ -1,18 +1,29 @@
 import * as discordService from '../services/external/discord.service';
+import metrics from '../services/external/metrics.service';
 import * as competitionService from '../services/internal/competition.service';
 
 async function onMembersJoined(groupId: number, playerIds: number[]) {
   // Add these new members to all upcoming and ongoing competitions
-  competitionService.addToGroupCompetitions(groupId, playerIds);
+  await metrics.measureReaction('AddToGroupCompetitions', () =>
+    competitionService.addToGroupCompetitions(groupId, playerIds)
+  );
+
   // Dispatch this event to the discord service
-  discordService.dispatchMembersJoined(groupId, playerIds);
+  await metrics.measureReaction('DiscordMembersJoined', () =>
+    discordService.dispatchMembersJoined(groupId, playerIds)
+  );
 }
 
 async function onMembersLeft(groupId: number, playerIds: number[]) {
   // Remove these players from ongoing/upcoming group competitions
-  competitionService.removeFromGroupCompetitions(groupId, playerIds);
+  await metrics.measureReaction('RemoveFromGroupCompetitions', () =>
+    competitionService.removeFromGroupCompetitions(groupId, playerIds)
+  );
+
   // Dispatch this event to the discord service
-  discordService.dispatchMembersLeft(groupId, playerIds);
+  await metrics.measureReaction('DiscordMembersLeft', () =>
+    discordService.dispatchMembersLeft(groupId, playerIds)
+  );
 }
 
 export { onMembersJoined, onMembersLeft };

--- a/server/src/api/events/name.events.ts
+++ b/server/src/api/events/name.events.ts
@@ -1,11 +1,12 @@
 import { NameChange } from '../../database/models';
+import metrics from '../services/external/metrics.service';
 import * as nameService from '../services/internal/name.service';
 
 async function onNameChangeCreated(nameChange: NameChange) {
   // Delay this action to prevent proccessing too many
-  // simoultaneous name changes after a bulk submission
+  // simultaneous name changes after a bulk submission
   setTimeout(async () => {
-    await nameService.autoReview(nameChange.id);
+    await metrics.measureReaction('AutoNameReview', () => nameService.autoReview(nameChange.id));
   }, Math.random() * 120_000);
 }
 

--- a/server/src/api/events/player.events.ts
+++ b/server/src/api/events/player.events.ts
@@ -1,62 +1,69 @@
 import { Player, Snapshot } from '../../database/models';
 import jobs from '../jobs';
 import * as discordService from '../services/external/discord.service';
-import logger from '../services/external/logger.service';
+import metrics from '../services/external/metrics.service';
 import * as achievementService from '../services/internal/achievement.service';
 import * as competitionService from '../services/internal/competition.service';
 import * as deltaService from '../services/internal/delta.service';
 import * as playerService from '../services/internal/player.service';
 
-function onPlayerCreated(player: Player) {
+async function onPlayerCreated(player: Player) {
   // Confirm this player's name capitalization
   jobs.add('AssertPlayerName', { id: player.id }, { attempts: 5, backoff: 30000 });
 }
 
-function onPlayerTypeChanged(player: Player, previousType: string) {
+async function onPlayerTypeChanged(player: Player, previousType: string) {
   if (previousType === 'hardcore' && player.type === 'ironman') {
     // Dispatch a "HCIM player died" event to our discord bot API.
-    discordService.dispatchHardcoreDied(player);
+    await metrics.measureReaction('DiscordHardcoreDied', () =>
+      discordService.dispatchHardcoreDied(player)
+    );
   }
 }
 
-function onPlayerNameChanged(player: Player, previousDisplayName: string) {
+async function onPlayerNameChanged(player: Player, previousDisplayName: string) {
   // Recalculate player achievements
-  achievementService.syncAchievements(player.id);
+  await metrics.measureReaction('SyncAchievements', () =>
+    achievementService.syncAchievements(player.id)
+  );
+
+  // Dispatch a "Player name changed" event to our discord bot API.
+  await metrics.measureReaction('DiscordNameChanged', () =>
+    discordService.dispatchNameChanged(player, previousDisplayName)
+  );
 
   // Setup jobs to assert the player's name capitalization and account type
   jobs.add('AssertPlayerName', { id: player.id }, { attempts: 5, backoff: 30000 });
   jobs.add('AssertPlayerType', { id: player.id }, { attempts: 5, backoff: 30000 });
-
-  // Dispatch a "Player name changed" event to our discord bot API.
-  discordService.dispatchNameChanged(player, previousDisplayName);
 }
 
 async function onPlayerUpdated(snapshot: Snapshot) {
   // Update this player's competition participations (gains)
-  competitionService.syncParticipations(snapshot.playerId, snapshot);
+  await metrics.measureReaction('SyncParticipations', () =>
+    competitionService.syncParticipations(snapshot.playerId, snapshot)
+  );
+
   // Check for new achievements
-  achievementService.syncAchievements(snapshot.playerId);
+  await metrics.measureReaction('SyncAchievements', () =>
+    achievementService.syncAchievements(snapshot.playerId)
+  );
 
   const player = await snapshot.$get('player');
-  if (!player) return;
 
-  if (playerService.shouldReviewType(player)) {
-    // After reviewing this player's type, ensure this action
-    // isn't repeated again in the next 3 days
-    logger.debug(`Scheduling ${player.id}`, { username: player.username });
-    const debounce = { id: player.id, timeout: 86_400_000 * 3 };
-    // jobs.add('ReviewPlayerType', { id: player.id }, { delay: 30_000, debounce });
+  if (player) {
+    // Update this player's deltas (gains)
+    await metrics.measureReaction('SyncDeltas', () => deltaService.syncDeltas(player, snapshot));
+
+    // Attempt to import this player's history from CML
+    await metrics.measureReaction('ImportCML', () => playerService.importCML(player));
   }
-
-  // Update this player's deltas (gains)
-  deltaService.syncDeltas(player, snapshot);
-
-  // Attempt to import this player's history from CML
-  playerService.importCML(player);
 }
 
-function onPlayerImported(playerId: number) {
-  achievementService.reevaluateAchievements(playerId);
+async function onPlayerImported(playerId: number) {
+  // Reevaluate this player's achievements to try and find earlier completion dates
+  await metrics.measureReaction('ReevaluateAchievements', () =>
+    achievementService.reevaluateAchievements(playerId)
+  );
 }
 
 export { onPlayerCreated, onPlayerTypeChanged, onPlayerNameChanged, onPlayerUpdated, onPlayerImported };

--- a/server/src/api/jobs/instances/CompetitionEnded.ts
+++ b/server/src/api/jobs/instances/CompetitionEnded.ts
@@ -27,7 +27,7 @@ class CompetitionEnded implements Job {
       }
 
       const competitionDetails = await competitionService.getDetails(competition);
-      onCompetitionEnded(competitionDetails);
+      await onCompetitionEnded(competitionDetails);
 
       metricsService.trackJobEnded(endTimer, this.name, 1);
     } catch (error) {

--- a/server/src/api/jobs/instances/CompetitionEnding.ts
+++ b/server/src/api/jobs/instances/CompetitionEnding.ts
@@ -28,7 +28,7 @@ class CompetitionEnding implements Job {
 
       const competitionDetails = await competitionService.getDetails(competition);
       const period = minutes < 60 ? { minutes } : { hours: minutes / 60 };
-      onCompetitionEnding(competitionDetails, period);
+      await onCompetitionEnding(competitionDetails, period);
 
       metricsService.trackJobEnded(endTimer, this.name, 1);
     } catch (error) {

--- a/server/src/api/jobs/instances/CompetitionStarted.ts
+++ b/server/src/api/jobs/instances/CompetitionStarted.ts
@@ -27,7 +27,7 @@ class CompetitionStarted implements Job {
       }
 
       const competitionDetails = await competitionService.getDetails(competition);
-      onCompetitionStarted(competitionDetails);
+      await onCompetitionStarted(competitionDetails);
 
       metricsService.trackJobEnded(endTimer, this.name, 1);
     } catch (error) {

--- a/server/src/api/jobs/instances/CompetitionStarting.ts
+++ b/server/src/api/jobs/instances/CompetitionStarting.ts
@@ -28,7 +28,7 @@ class CompetitionStarting implements Job {
 
       const competitionDetails = await competitionService.getDetails(competition);
       const period = minutes < 60 ? { minutes } : { hours: minutes / 60 };
-      onCompetitionStarting(competitionDetails, period);
+      await onCompetitionStarting(competitionDetails, period);
 
       metricsService.trackJobEnded(endTimer, this.name, 1);
     } catch (error) {


### PR DESCRIPTION
Reactions are any side-effects from model hooks/events, for example:

```
Event: On Player Updated
Reactions:
    - Sync Competition Participations
    - Sync Deltas
    - Sync Achievements
```


**Adds prometheus tracking for all reactions, as well as an error-safe wrapper for each one.**