### PR TITLE
Feature: Periodic Iron Player Type Check

### DIFF
--- a/server/src/api/events/player.events.ts
+++ b/server/src/api/events/player.events.ts
@@ -56,6 +56,12 @@ async function onPlayerUpdated(snapshot: Snapshot) {
 
     // Attempt to import this player's history from CML
     await metrics.measureReaction('ImportCML', () => playerService.importCML(player));
+
+    // If this player is an inactive iron player, their type should be reviewed
+    // This allows us to catch de-iron players early, and adjust their type accordingly
+    if (await playerService.shouldReviewType(player)) {
+      jobs.add('ReviewPlayerType', { id: player.id });
+    }
   }
 }
 

--- a/server/src/api/jobs/instances/ReviewPlayerType.ts
+++ b/server/src/api/jobs/instances/ReviewPlayerType.ts
@@ -1,7 +1,11 @@
 import logger from '../../services/external/logger.service';
 import metricsService from '../../services/external/metrics.service';
+import redisService from '../../services/external/redis.service';
 import * as playerService from '../../services/internal/player.service';
 import { Job } from '../index';
+
+// This review should only be executed a maximum of once every 7 days
+const REVIEW_COOLDOWN = 604_800_000;
 
 class ReviewPlayerType implements Job {
   name: string;
@@ -21,8 +25,11 @@ class ReviewPlayerType implements Job {
 
       // Player type hasn't changed, player is just inactive
       if (previousType !== newType) {
-        logger.info('De-ironed player', { username: player.username, previousType, newType });
+        logger.info('Changed type', { username: player.username, previousType, newType });
       }
+
+      // Store the current timestamp to activate the cooldown
+      await redisService.setValue('cd:PlayerTypeReview', player.username, Date.now(), REVIEW_COOLDOWN);
 
       metricsService.trackJobEnded(endTimer, this.name, 1);
     } catch (error) {

--- a/server/src/api/services/external/redis.service.ts
+++ b/server/src/api/services/external/redis.service.ts
@@ -1,0 +1,20 @@
+import IORedis, { ValueType } from 'ioredis';
+import redisConfig from '../../jobs/config/redis';
+
+class RedisService {
+  redisClient: IORedis.Redis;
+
+  constructor() {
+    this.redisClient = new IORedis(redisConfig);
+  }
+
+  getValue(baseKey: string, paramKey: string) {
+    return this.redisClient.get(`${baseKey}:${paramKey}`);
+  }
+
+  setValue(baseKey: string, paramKey: string, value: ValueType, expiresInMs?: number) {
+    return this.redisClient.set(`${baseKey}:${paramKey}`, value, 'px', expiresInMs);
+  }
+}
+
+export default new RedisService();


### PR DESCRIPTION
When a HCIM player dies, their HCIM hiscores stay frozen forever, so if a player doesn't manually click "Re-assign player type" on their WOM page, all snapshots continue to be fetched form the frozen HCIM stats. The same happens if any iron player de-irons into a regular account.

This causes WOM to update people for weeks/months while their stats are frozen, and when they suddenly click the "Re-assign player type", it starts **fetching their correctly updated stats from the hiscores**, but they get flagged because they have gained a huge amount of exp in a matter of seconds.

To fix this, now everytime an iron player is updated, and their exp hasn't changed in over 24h, WOM will try to check if their player type is still correct, and correct it if not.

This action has a 7 day cooldown, meaning that once a player's type is checked, it won't be repeated again for the next 7 days.