### PR TITLE
Improve app timers accuracy

### DIFF
--- a/app/src/components/Countdown/Countdown.jsx
+++ b/app/src/components/Countdown/Countdown.jsx
@@ -3,19 +3,18 @@ import PropTypes from 'prop-types';
 import { padNumber, durationOf } from 'utils';
 import './Countdown.scss';
 
-function Countdown({ secondsDiff }) {
-  const [secondsLeft, setSecondsLeft] = useState(secondsDiff);
+function Countdown({ targetDate }) {
+  const [timeLeft, setTimeLeft] = useState(getTimeLeft(targetDate));
 
   useEffect(() => {
-    // Start a 1 second timer on mount
-    const nextValue = Math.max(0, secondsLeft - 1000);
-    const timer = setTimeout(() => setSecondsLeft(nextValue), 1000);
+    // Start a half second timer on mount
+    const timer = setTimeout(() => setTimeLeft(getTimeLeft(targetDate)), 500);
 
     // Clear the timer on unmount
     return () => clearTimeout(timer);
   });
 
-  const { days, hours, minutes, seconds } = durationOf(secondsLeft);
+  const { days, hours, minutes, seconds } = durationOf(timeLeft);
 
   return (
     <div className="countdown">
@@ -39,9 +38,13 @@ function Countdown({ secondsDiff }) {
   );
 }
 
+function getTimeLeft(targetDate) {
+  return Math.max(0, targetDate.getTime() - Date.now());
+}
+
 Countdown.propTypes = {
-  // The initial difference in seconds (Ex: 50 will start a 0 hour, 0 minute, 50 secs countdown)
-  secondsDiff: PropTypes.number.isRequired
+  // The target date that the timer should count down to
+  targetDate: PropTypes.instanceOf(Date).isRequired
 };
 
 export default React.memo(Countdown);

--- a/app/src/pages/Competition/containers/Widgets.jsx
+++ b/app/src/pages/Competition/containers/Widgets.jsx
@@ -6,14 +6,14 @@ import { TopParticipant, TotalGained } from '../components';
 function Widgets({ competition, metric }) {
   const { status, startsAt, endsAt } = competition;
 
-  const secondsLeft = calcSecondsLeft(status, startsAt, endsAt);
+  const targetDate = status === 'upcoming' ? startsAt : endsAt;
   const countdownLabel = status === 'upcoming' ? 'Starting in' : 'Time Remaining';
 
   return (
     <>
       <div className="col-md-4">
         <span className="widget-label">{countdownLabel}</span>
-        <Countdown secondsDiff={secondsLeft} />
+        <Countdown targetDate={targetDate} />
       </div>
       <div className="col-md-4 col-sm-6">
         <span className="widget-label">Top Player</span>
@@ -25,20 +25,6 @@ function Widgets({ competition, metric }) {
       </div>
     </>
   );
-}
-
-function calcSecondsLeft(status, startsAt, endsAt) {
-  const curDate = new Date();
-
-  if (status === 'upcoming') {
-    return startsAt - curDate;
-  }
-
-  if (status === 'ongoing') {
-    return endsAt - curDate;
-  }
-
-  return 0;
 }
 
 Widgets.defaultProps = {

--- a/app/src/pages/Player/containers/Gained.jsx
+++ b/app/src/pages/Player/containers/Gained.jsx
@@ -67,13 +67,6 @@ function Gained() {
     }
   };
 
-  // const handleTimerEndedRefresh = () => {
-  //   // Clear any currently loaded snapshots
-  //   dispatch(snapshotActions.invalidateSnapshots(username));
-  //   // Clear any currently loaded deltas
-  //   dispatch(deltasActions.invalidateDeltas(username));
-  // };
-
   const handleCustomPeriodSelected = dates => {
     // Clear any currently loaded "custom period" snapshots
     dispatch(snapshotActions.invalidateSnapshots(username, period));


### PR DESCRIPTION
Fixes #753 

Previously I was depending on a 1000ms timeout to decrease ticks (seconds). But the JavaScript event loop doesn't ensure that a 1000ms timeout will run in exactly 1000ms, so over long time periods these timers would be out of sync by a few seconds.

More importantly, setTimeout won't run accurately on any tabs that are not focused, which basically paused these timers for people who just leave the tabs open for long periods of time.

These timers now re-calculate the time left on every 500ms iteration, instead of calculating it once and decreasing it regularly.