### PR TITLE
Fix app charts minimum boss kc and label prefix

### DIFF
--- a/app/src/components/LineChart/LineChart.jsx
+++ b/app/src/components/LineChart/LineChart.jsx
@@ -4,7 +4,15 @@ import Chart from 'chart.js';
 import { formatDate, formatNumber } from 'utils';
 import './LineChart.scss';
 
-function LineChart({ datasets, distribution, onDistributionChanged, isLoading, invertYAxis }) {
+function LineChart({
+  datasets,
+  distribution,
+  onDistributionChanged,
+  isLoading,
+  invertYAxis,
+  labelPrefix,
+  yAxisPrefix
+}) {
   const hasEnoughData = datasets.filter(d => d.data.length > 1).length > 0;
 
   const chartObjectRef = useRef(null);
@@ -22,7 +30,10 @@ function LineChart({ datasets, distribution, onDistributionChanged, isLoading, i
     if (chartRef.current) {
       const ctx = chartRef.current.getContext('2d');
 
-      chartObjectRef.current = new Chart(ctx, getConfig(datasets, invertYAxis));
+      chartObjectRef.current = new Chart(
+        ctx,
+        getConfig(datasets, invertYAxis, yAxisPrefix, labelPrefix)
+      );
     }
   }
 
@@ -52,7 +63,7 @@ function LineChart({ datasets, distribution, onDistributionChanged, isLoading, i
   );
 }
 
-function getConfig(datasets, invertYAxis) {
+function getConfig(datasets, invertYAxis, yAxisPrefix, labelPrefix) {
   return {
     type: 'line',
     data: {
@@ -84,7 +95,7 @@ function getConfig(datasets, invertYAxis) {
         callbacks: {
           title: data => formatDate(data[0].xLabel, 'DD MMM, HH:mm'),
           label: ({ datasetIndex, yLabel }, data) =>
-            `${data.datasets[datasetIndex].label}: ${formatNumber(yLabel)}`,
+            `${data.datasets[datasetIndex].label}: ${labelPrefix}${formatNumber(yLabel)}`,
           labelColor: (tooltipItem, c) => ({
             backgroundColor: c.config.data.datasets[tooltipItem.datasetIndex].borderColor
           })
@@ -111,7 +122,10 @@ function getConfig(datasets, invertYAxis) {
           {
             ticks: {
               reverse: invertYAxis,
-              callback: value => formatNumber(value, true),
+              callback: value => {
+                if (value === 0 && yAxisPrefix === '+') return value;
+                return `${yAxisPrefix}${formatNumber(value, true)}`;
+              },
               beginAtZero: false,
               maxTicksLimit: 5
             }
@@ -158,6 +172,8 @@ function renderDistributionLabel(distribution, callback) {
 LineChart.defaultProps = {
   invertYAxis: false,
   isLoading: false,
+  labelPrefix: '',
+  yAxisPrefix: '',
   distribution: undefined,
   onDistributionChanged: undefined
 };
@@ -167,6 +183,9 @@ LineChart.propTypes = {
   datasets: PropTypes.arrayOf(PropTypes.shape()).isRequired,
 
   distribution: PropTypes.shape(PropTypes.shape()),
+
+  labelPrefix: PropTypes.string,
+  yAxisPrefix: PropTypes.string,
 
   onDistributionChanged: PropTypes.func,
 

--- a/app/src/pages/Competition/Competition.jsx
+++ b/app/src/pages/Competition/Competition.jsx
@@ -43,7 +43,7 @@ function Competition() {
   const competitionType = competition ? competition.type : 'classic';
 
   const tabs = getTabs(competitionType);
-  const chartData = getCompetitionChartData(competition);
+  const chartData = getCompetitionChartData(competition, metric);
   const selectedTabIndex = getSelectedTabIndex(competitionType, section);
   const showDeleteModal = section === 'delete' && !!competition;
 
@@ -136,7 +136,7 @@ function Competition() {
                 onExportParticipantsClicked={() => handleExportClicked('participants')}
               />
             )}
-            {section === 'chart' && <LineChart datasets={chartData} />}
+            {section === 'chart' && <LineChart datasets={chartData} yAxisPrefix="+" labelPrefix="+" />}
           </div>
         </div>
         {showDeleteModal && (

--- a/app/src/utils/charts.js
+++ b/app/src/utils/charts.js
@@ -1,5 +1,6 @@
 import { uniqBy } from 'lodash';
 import { capitalize } from 'utils/strings';
+import { getMinimumBossKc, isBoss } from 'utils/metrics';
 import { CHART_COLORS } from 'config/visuals';
 
 export function distribute(snapshots, limit) {
@@ -70,7 +71,7 @@ export const getDeltasChartData = (snapshots, metric, measure, reducedMode) => {
   };
 };
 
-export const getCompetitionChartData = competition => {
+export const getCompetitionChartData = (competition, previewMetric) => {
   if (!competition) return [];
 
   const datasets = [];
@@ -83,7 +84,12 @@ export const getCompetitionChartData = competition => {
 
   topParticipants.forEach((participant, i) => {
     // Convert all the history data into chart points
-    const points = participant.history.map(h => ({ x: h.date, y: h.value }));
+    const points = participant.history.map(h => ({
+      x: h.date,
+      y: isBoss(previewMetric || competition.metric)
+        ? Math.max(h.value, getMinimumBossKc(previewMetric || competition.metric) - 1)
+        : h.value
+    }));
 
     // Convert the exp values to exp delta values
     const diffPoints = points.map(p => ({ x: p.x, y: p.y - points[0].y }));

--- a/app/src/utils/metrics.js
+++ b/app/src/utils/metrics.js
@@ -29,8 +29,8 @@ export function isBoss(value) {
   return BOSSES.includes(value);
 }
 
-export function getMinimumBossKc(value) {
-  switch (value) {
+export function getMinimumBossKc(bossName) {
+  switch (bossName) {
     case 'mimic':
     case 'tzkal_zuk':
       return 2;


### PR DESCRIPTION
Fixes #725 

Also, Competition charts will display the hover labels as `+125` instead of `125` to make it clear that these numbers are the gained values, now the exp/kc values.