### PR TITLE
Fix: Competition Start/End values

### DIFF
--- a/app/src/pages/Competition/Competition.jsx
+++ b/app/src/pages/Competition/Competition.jsx
@@ -124,6 +124,7 @@ function Competition() {
             {section === 'teams' && (
               <TeamsTable
                 competition={competition}
+                metric={metric || competition.metric}
                 onUpdateClicked={handleUpdatePlayer}
                 onExportTeamsClicked={() => handleExportClicked('teams')}
                 onExportTeamClicked={teamName => handleExportClicked('team', teamName)}
@@ -132,6 +133,7 @@ function Competition() {
             {section === 'participants' && (
               <ParticipantsTable
                 competition={competition}
+                metric={metric || competition.metric}
                 onUpdateClicked={handleUpdatePlayer}
                 onExportParticipantsClicked={() => handleExportClicked('participants')}
               />

--- a/app/src/pages/Competition/Competition.scss
+++ b/app/src/pages/Competition/Competition.scss
@@ -42,6 +42,11 @@
   }
 
   .competition__content {
+    abbr {
+      text-decoration: none;
+      cursor: help;
+    }
+
     .tab-bar {
       margin-bottom: 14px;
     }

--- a/app/src/pages/Competition/components/TeamPlayersTable/TeamPlayersTable.jsx
+++ b/app/src/pages/Competition/components/TeamPlayersTable/TeamPlayersTable.jsx
@@ -34,15 +34,19 @@ function TeamPlayersTable({ competition, updatingUsernames, team, onUpdateClicke
           const minKc = getMinimumBossKc(competition.metric);
           const metricName = getMetricName(competition.metric);
 
-          if (val !== -1) return <NumberLabel value={val} />;
-          if (!isBoss(competition.metric)) return val;
+          // If is unranked on a boss metric
+          if (isBoss(competition.metric) && val < minKc)
+            return (
+              <TextLabel
+                value={`< ${minKc}`}
+                popupValue={`The Hiscores only start tracking ${metricName} kills after ${minKc} kc`}
+              />
+            );
 
-          return (
-            <TextLabel
-              value={`< ${minKc}`}
-              popupValue={`The Hiscores only start tracking ${metricName} kills after ${minKc} kc`}
-            />
-          );
+          // If unranked or not updated
+          if (val === -1) return '--';
+
+          return <NumberLabel value={val} />;
         }
       },
       {
@@ -53,15 +57,19 @@ function TeamPlayersTable({ competition, updatingUsernames, team, onUpdateClicke
           const minKc = getMinimumBossKc(competition.metric);
           const metricName = getMetricName(competition.metric);
 
-          if (val !== -1) return <NumberLabel value={val} />;
-          if (!isBoss(competition.metric)) return val;
+          // If is unranked on a boss metric
+          if (isBoss(competition.metric) && val < minKc)
+            return (
+              <TextLabel
+                value={`< ${minKc}`}
+                popupValue={`The Hiscores only start tracking ${metricName} kills after ${minKc} kc`}
+              />
+            );
 
-          return (
-            <TextLabel
-              value={`< ${minKc}`}
-              popupValue={`The Hiscores only start tracking ${metricName} kills after ${minKc} kc`}
-            />
-          );
+          // If unranked or not updated
+          if (val === -1) return '--';
+
+          return <NumberLabel value={val} />;
         }
       },
       {

--- a/app/src/pages/Competition/containers/ParticipantsTable.jsx
+++ b/app/src/pages/Competition/containers/ParticipantsTable.jsx
@@ -43,15 +43,19 @@ function ParticipantsTable({ competition, onUpdateClicked, onExportParticipantsC
           const minKc = getMinimumBossKc(competition.metric);
           const metricName = getMetricName(competition.metric);
 
-          if (val !== -1) return <NumberLabel value={val} />;
-          if (!isBoss(competition.metric)) return val;
+          // If is unranked on a boss metric
+          if (isBoss(competition.metric) && val < minKc)
+            return (
+              <TextLabel
+                value={`< ${minKc}`}
+                popupValue={`The Hiscores only start tracking ${metricName} kills after ${minKc} kc`}
+              />
+            );
 
-          return (
-            <TextLabel
-              value={`< ${minKc}`}
-              popupValue={`The Hiscores only start tracking ${metricName} kills after ${minKc} kc`}
-            />
-          );
+          // If unranked or not updated
+          if (val === -1) return '--';
+
+          return <NumberLabel value={val} />;
         }
       },
       {
@@ -62,15 +66,19 @@ function ParticipantsTable({ competition, onUpdateClicked, onExportParticipantsC
           const minKc = getMinimumBossKc(competition.metric);
           const metricName = getMetricName(competition.metric);
 
-          if (val !== -1) return <NumberLabel value={val} />;
-          if (!isBoss(competition.metric)) return val;
+          // If is unranked on a boss metric
+          if (isBoss(competition.metric) && val < minKc)
+            return (
+              <TextLabel
+                value={`< ${minKc}`}
+                popupValue={`The Hiscores only start tracking ${metricName} kills after ${minKc} kc`}
+              />
+            );
 
-          return (
-            <TextLabel
-              value={`< ${minKc}`}
-              popupValue={`The Hiscores only start tracking ${metricName} kills after ${minKc} kc`}
-            />
-          );
+          // If unranked or not updated
+          if (val === -1) return '--';
+
+          return <NumberLabel value={val} />;
         }
       },
       {

--- a/app/src/pages/Competition/containers/ParticipantsTable.jsx
+++ b/app/src/pages/Competition/containers/ParticipantsTable.jsx
@@ -6,11 +6,11 @@ import classNames from 'classnames';
 import { SKILLS } from 'config';
 import { durationBetween, getMinimumBossKc, getMetricName, isBoss, isSkill, isActivity } from 'utils';
 import URL from 'utils/url';
-import { Table, PlayerTag, NumberLabel, TextLabel, TablePlaceholder } from 'components';
+import { Table, PlayerTag, NumberLabel, TablePlaceholder } from 'components';
 import { competitionSelectors } from 'redux/competitions';
 import { playerSelectors } from 'redux/players';
 
-function ParticipantsTable({ competition, onUpdateClicked, onExportParticipantsClicked }) {
+function ParticipantsTable({ competition, metric, onUpdateClicked, onExportParticipantsClicked }) {
   const isLoading = useSelector(competitionSelectors.isFetchingDetails);
   const updatingUsernames = useSelector(playerSelectors.getUpdatingUsernames);
 
@@ -39,21 +39,34 @@ function ParticipantsTable({ competition, onUpdateClicked, onExportParticipantsC
         key: 'start',
         get: row => (row.progress ? row.progress.start : 0),
         className: () => '-break-small',
-        transform: val => {
-          const minKc = getMinimumBossKc(competition.metric);
-          const metricName = getMetricName(competition.metric);
+        transform: (val, row) => {
+          const lastUpdated = row.updatedAt;
+          const minKc = getMinimumBossKc(metric);
+          const metricName = getMetricName(metric);
+
+          // If player is outdated
+          if (competition.startsAt < Date.now() && (!lastUpdated || lastUpdated < competition.startsAt))
+            return (
+              <abbr title={"This player hasn't been updated since the competition started."}>
+                <span>--</span>
+              </abbr>
+            );
 
           // If is unranked on a boss metric
-          if (isBoss(competition.metric) && val < minKc)
+          if (isBoss(metric) && val < minKc)
             return (
-              <TextLabel
-                value={`< ${minKc}`}
-                popupValue={`The Hiscores only start tracking ${metricName} kills after ${minKc} kc`}
-              />
+              <abbr title={`The Hiscores only start tracking ${metricName} kills after ${minKc} kc.`}>
+                <span>{`< ${minKc}`}</span>
+              </abbr>
             );
 
           // If unranked or not updated
-          if (val === -1) return '--';
+          if (val === -1)
+            return (
+              <abbr title={`This player is currently unranked in ${metricName}.`}>
+                <span>--</span>
+              </abbr>
+            );
 
           return <NumberLabel value={val} />;
         }
@@ -62,21 +75,34 @@ function ParticipantsTable({ competition, onUpdateClicked, onExportParticipantsC
         key: 'end',
         get: row => (row.progress ? row.progress.end : 0),
         className: () => '-break-small',
-        transform: val => {
-          const minKc = getMinimumBossKc(competition.metric);
-          const metricName = getMetricName(competition.metric);
+        transform: (val, row) => {
+          const lastUpdated = row.updatedAt;
+          const minKc = getMinimumBossKc(metric);
+          const metricName = getMetricName(metric);
+
+          // If player is outdated
+          if (competition.startsAt < Date.now() && (!lastUpdated || lastUpdated < competition.startsAt))
+            return (
+              <abbr title={"This player hasn't been updated since the competition started."}>
+                <span>--</span>
+              </abbr>
+            );
 
           // If is unranked on a boss metric
-          if (isBoss(competition.metric) && val < minKc)
+          if (isBoss(metric) && val < minKc)
             return (
-              <TextLabel
-                value={`< ${minKc}`}
-                popupValue={`The Hiscores only start tracking ${metricName} kills after ${minKc} kc`}
-              />
+              <abbr title={`The Hiscores only start tracking ${metricName} kills after ${minKc} kc.`}>
+                <span>{`< ${minKc}`}</span>
+              </abbr>
             );
 
           // If unranked or not updated
-          if (val === -1) return '--';
+          if (val === -1)
+            return (
+              <abbr title={`This player is currently unranked in ${metricName}.`}>
+                <span>--</span>
+              </abbr>
+            );
 
           return <NumberLabel value={val} />;
         }
@@ -85,7 +111,7 @@ function ParticipantsTable({ competition, onUpdateClicked, onExportParticipantsC
         key: 'gained',
         get: row => (row.progress ? row.progress.gained : 0),
         transform: val => {
-          const lowThreshold = isSkill(competition.metric) ? 10000 : 5;
+          const lowThreshold = isSkill(metric) ? 10000 : 5;
           return <NumberLabel value={val} lowThreshold={lowThreshold} isColored isSigned />;
         }
       },
@@ -125,7 +151,7 @@ function ParticipantsTable({ competition, onUpdateClicked, onExportParticipantsC
     });
   }
 
-  if (SKILLS.filter(s => s !== 'overall').includes(competition.metric)) {
+  if (SKILLS.filter(s => s !== 'overall').includes(metric)) {
     tableConfig.columns.splice(tableConfig.columns.length - 2, 0, {
       key: 'levels',
       get: row => (row.levelsGained ? row.levelsGained : 0),
@@ -180,6 +206,7 @@ function getPlayerRedirectURL(player, competition) {
 }
 
 ParticipantsTable.propTypes = {
+  metric: PropTypes.string.isRequired,
   competition: PropTypes.shape({
     type: PropTypes.string,
     metric: PropTypes.string,

--- a/app/src/pages/Competition/containers/TeamsTable.jsx
+++ b/app/src/pages/Competition/containers/TeamsTable.jsx
@@ -8,7 +8,13 @@ import { competitionSelectors } from 'redux/competitions';
 import { playerSelectors } from 'redux/players';
 import { TeamPlayersTable } from '../components';
 
-function TeamsTable({ competition, onUpdateClicked, onExportTeamsClicked, onExportTeamClicked }) {
+function TeamsTable({
+  competition,
+  metric,
+  onUpdateClicked,
+  onExportTeamsClicked,
+  onExportTeamClicked
+}) {
   const isLoading = useSelector(competitionSelectors.isFetchingDetails);
   const updatingUsernames = useSelector(playerSelectors.getUpdatingUsernames);
 
@@ -44,7 +50,7 @@ function TeamsTable({ competition, onUpdateClicked, onExportTeamsClicked, onExpo
         key: 'totalGained',
         label: 'Total Gained',
         transform: val => {
-          const lowThreshold = isSkill(competition.metric) ? 30000 : 10;
+          const lowThreshold = isSkill(metric) ? 30000 : 10;
           return <NumberLabel value={val} lowThreshold={lowThreshold} isColored isSigned />;
         }
       },
@@ -53,7 +59,7 @@ function TeamsTable({ competition, onUpdateClicked, onExportTeamsClicked, onExpo
         label: 'Avg. Gained',
         className: () => '-break-small',
         transform: val => {
-          const lowThreshold = isSkill(competition.metric) ? 10000 : 5;
+          const lowThreshold = isSkill(metric) ? 10000 : 5;
           return <NumberLabel value={Math.floor(val)} lowThreshold={lowThreshold} isColored isSigned />;
         }
       },
@@ -109,6 +115,7 @@ function TeamsTable({ competition, onUpdateClicked, onExportTeamsClicked, onExpo
               <div style={{ marginTop: 5, marginBottom: 20 }}>
                 <TeamPlayersTable
                   competition={competition}
+                  metric={metric}
                   team={row}
                   updatingUsernames={updatingUsernames}
                   onUpdateClicked={onUpdateClicked}
@@ -128,6 +135,7 @@ function TeamsTable({ competition, onUpdateClicked, onExportTeamsClicked, onExpo
 }
 
 TeamsTable.propTypes = {
+  metric: PropTypes.string.isRequired,
   competition: PropTypes.shape({
     metric: PropTypes.string,
     status: PropTypes.string,


### PR DESCRIPTION
Fixes #780 

API:
- A competition's participant will no longer have their starting exp update on upcoming competitions.

App: 
- Fixed a bug where some preview competition tables were showing levels for boss/activity competitions
- Competition tables will now show `--` instead of `-1` for unranked players.
- Competition tables will now show `--` instead of the starting exp for upcoming competitions.
