### PR TITLE
Optimize post-update actions

### DIFF
--- a/server/src/api/events/delta.events.ts
+++ b/server/src/api/events/delta.events.ts
@@ -3,6 +3,8 @@ import metrics from '../services/external/metrics.service';
 import * as recordService from '../services/internal/record.service';
 
 async function onDeltaUpdated(delta: Delta) {
+  if (!delta.isPotentialRecord) return;
+
   // Check if this new delta is an all time record for this player
   await metrics.measureReaction('SyncRecords', () => recordService.syncRecords(delta));
 }

--- a/server/src/api/events/player.events.ts
+++ b/server/src/api/events/player.events.ts
@@ -43,10 +43,13 @@ async function onPlayerUpdated(snapshot: Snapshot) {
     competitionService.syncParticipations(snapshot.playerId, snapshot)
   );
 
-  // Check for new achievements
-  await metrics.measureReaction('SyncAchievements', () =>
-    achievementService.syncAchievements(snapshot.playerId)
-  );
+  // Only sync achievements if the player gained any exp/kc this update
+  if (snapshot.isChange) {
+    // Check for new achievements
+    await metrics.measureReaction('SyncAchievements', () =>
+      achievementService.syncAchievements(snapshot.playerId)
+    );
+  }
 
   const player = await snapshot.$get('player');
 

--- a/server/src/database/models/delta.model.ts
+++ b/server/src/database/models/delta.model.ts
@@ -44,6 +44,9 @@ export default class Delta extends Model<Delta> {
   @UpdatedAt
   updatedAt: Date;
 
+  @Column({ type: DataType.VIRTUAL, allowNull: false, defaultValue: false })
+  isPotentialRecord: boolean;
+
   @Column({ type: DataType.INTEGER, allowNull: false, defaultValue: 0 })
   overall: number;
 

--- a/server/src/database/models/snapshot.model.ts
+++ b/server/src/database/models/snapshot.model.ts
@@ -28,6 +28,9 @@ export default class Snapshot extends HiscoresValues {
   @Column({ type: DataType.INTEGER, allowNull: false, onDelete: 'CASCADE' })
   playerId: number;
 
+  @Column({ type: DataType.VIRTUAL, allowNull: false, defaultValue: false })
+  isChange: boolean;
+
   @Column({ type: DataType.DATE })
   importedAt: Date;
 


### PR DESCRIPTION
Player tracking is by far the most common action that the API executes, and it then fires a few other "reactions", such as:

- Sync Achievements
- Sync Deltas
- Sync Records
- Sync Competition Participations

Because of this, updating (+ reactions) takes up the majority of WOM's CPU usage.

I realized two things that could reduce the amount of calcs we're doing:

- There is no point in checking for new achievements if the player hasn't gained any exp/kc since the last update
   - If new achievements get added, players must get any exp to claim them, that's a fair price to pay for some performance improvement
- There is no point in checking for new records if the new deltas are lower than the previous