### PR TITLE
Fix Player name asserting

### DIFF
--- a/server/src/api/jobs/index.ts
+++ b/server/src/api/jobs/index.ts
@@ -1,4 +1,4 @@
-import Queue from 'bull';
+import Queue, { RateLimiter } from 'bull';
 import { getThreadIndex, isTesting } from '../../env';
 import logger from '../services/external/logger.service';
 import crons from './config/crons';
@@ -7,6 +7,7 @@ import jobs from './instances';
 
 export interface Job {
   name: string;
+  rateLimiter?: RateLimiter;
   handle(data: any): void;
   onSuccess?(data: any): void;
   onFailure?(data: any, error: Error): void;
@@ -29,6 +30,7 @@ class JobHandler {
     this.queues = jobs.map((job: Job) => ({
       bull: new Queue(job.name, {
         redis: redisConfig,
+        limiter: job.rateLimiter,
         defaultJobOptions: { removeOnComplete: true, removeOnFail: true }
       }),
       name: job.name,

--- a/server/src/api/jobs/instances/AssertPlayerName.ts
+++ b/server/src/api/jobs/instances/AssertPlayerName.ts
@@ -1,12 +1,15 @@
+import { RateLimiter } from 'bull';
 import metricsService from '../../services/external/metrics.service';
 import * as playerService from '../../services/internal/player.service';
 import { Job } from '../index';
 
 class AssertPlayerName implements Job {
   name: string;
+  rateLimiter: RateLimiter;
 
   constructor() {
     this.name = 'AssertPlayerName';
+    this.rateLimiter = { max: 1, duration: 15_000 };
   }
 
   async handle(data: any): Promise<void> {

--- a/server/src/api/jobs/instances/AssertPlayerType.ts
+++ b/server/src/api/jobs/instances/AssertPlayerType.ts
@@ -1,12 +1,15 @@
+import { RateLimiter } from 'bull';
 import metricsService from '../../services/external/metrics.service';
 import * as playerService from '../../services/internal/player.service';
 import { Job } from '../index';
 
 class AssertPlayerType implements Job {
   name: string;
+  rateLimiter: RateLimiter;
 
   constructor() {
     this.name = 'AssertPlayerType';
+    this.rateLimiter = { max: 1, duration: 5_000 };
   }
 
   async handle(data: any): Promise<void> {

--- a/server/src/api/jobs/instances/UpdatePlayer.ts
+++ b/server/src/api/jobs/instances/UpdatePlayer.ts
@@ -1,12 +1,15 @@
+import { RateLimiter } from 'bull';
 import metricsService from '../../services/external/metrics.service';
 import * as playerService from '../../services/internal/player.service';
 import { Job } from '../index';
 
 class UpdatePlayer implements Job {
   name: string;
+  rateLimiter: RateLimiter;
 
   constructor() {
     this.name = 'UpdatePlayer';
+    this.rateLimiter = { max: 1, duration: 1_000 };
   }
 
   async handle(data: any): Promise<void> {

--- a/server/src/api/services/external/jagex.service.ts
+++ b/server/src/api/services/external/jagex.service.ts
@@ -48,14 +48,12 @@ async function getHiscoresData(username: string, type = 'regular'): Promise<stri
  * where "username" is listed in.
  */
 async function getHiscoresNames(username: string): Promise<string[]> {
-  const proxy = proxiesService.getNextProxy();
   const URL = `${OSRS_HISCORES.nameCheck}&user=${username}`;
 
   try {
     // Fetch the data through the API Url
     const { data } = await axios({
-      url: proxy ? URL.replace('https', 'http') : URL,
-      proxy,
+      url: URL,
       responseType: 'arraybuffer',
       withCredentials: true,
       headers: SCRAPING_HEADERS


### PR DESCRIPTION
Jagex has started detecting proxies on website scrapes, apparently

We're only using website scraping for display name asserting, this is not an urgent action and can be throttled to ensure we don't over-request Jagex's servers, so we don't necessarily need to use proxies.

This PR adds optional rate limiting to jobs, we can now specify how many times a job can run in X time, and we're using that to:

- AssertPlayerName is now rate limited to once every 15s
- AssertPlayerType is now rate limited to once every 5s
- UpdatePlayerr is now rate limited to once every 1s