### PR TITLE
Fix edit pages error handling

### DIFF
--- a/app/src/pages/EditCompetition/EditCompetition.jsx
+++ b/app/src/pages/EditCompetition/EditCompetition.jsx
@@ -87,7 +87,7 @@ function EditCompetition() {
       )
     );
 
-    if (payload && payload.data) {
+    if (payload && !payload.error) {
       router.push(`/competitions/${competition.id}`);
     }
   }

--- a/app/src/pages/EditGroup/EditGroup.jsx
+++ b/app/src/pages/EditGroup/EditGroup.jsx
@@ -139,7 +139,7 @@ function EditGroup() {
       groupActions.edit(id, name, description, clanChat, homeworld, members, verificationCode)
     );
 
-    if (payload && payload.data) {
+    if (payload && !payload.error) {
       router.push(`/groups/${group.id}`);
     }
   };


### PR DESCRIPTION
Fixes #823 

These two errors actually have data in their error payloads, so the page would always redirect to the group/comp page, instead of staying and displaying the "invalid" names in red.