### PR TITLE
Allow capitalisation-only name changes

### DIFF
--- a/app/src/pages/Player/containers/Header.jsx
+++ b/app/src/pages/Player/containers/Header.jsx
@@ -6,9 +6,9 @@ import { PageHeader, Dropdown, Button, Badge } from 'components';
 
 const MENU_OPTIONS = [
   { label: 'Open official hiscores', value: 'OPEN_HISCORES' },
-  { label: 'Reset username capitalization', value: 'ASSERT_NAME' },
-  { label: 'Reassign player type', value: 'ASSERT_TYPE' },
-  { label: 'Change name', value: 'CHANGE_NAME' }
+  { label: 'Change name', value: 'CHANGE_NAME' },
+  // { label: 'Reset username capitalization', value: 'ASSERT_NAME' },
+  { label: 'Reassign player type', value: 'ASSERT_TYPE' }
 ];
 
 function Header(props) {

--- a/server/__tests__/integration/player.test.ts
+++ b/server/__tests__/integration/player.test.ts
@@ -303,59 +303,59 @@ describe('Player API', () => {
     }, 90000);
   });
 
-  describe('7. Asserting Name', () => {
-    test("7.1 - DON'T assert name for undefined username", async done => {
-      const response = await request.post(`${BASE_URL}/assert-name`).send({});
+  // describe('7. Asserting Name', () => {
+  //   test("7.1 - DON'T assert name for undefined username", async done => {
+  //     const response = await request.post(`${BASE_URL}/assert-name`).send({});
 
-      expect(response.status).toBe(400);
-      expect(response.body.message).toMatch("Parameter 'username' is undefined.");
+  //     expect(response.status).toBe(400);
+  //     expect(response.body.message).toMatch("Parameter 'username' is undefined.");
 
-      done();
-    });
+  //     done();
+  //   });
 
-    test("7.2 - DON'T assert name for empty username", async done => {
-      const response = await request.post(`${BASE_URL}/assert-name`).send({ username: '' });
+  //   test("7.2 - DON'T assert name for empty username", async done => {
+  //     const response = await request.post(`${BASE_URL}/assert-name`).send({ username: '' });
 
-      expect(response.status).toBe(400);
-      expect(response.body.message).toMatch("Parameter 'username' is undefined.");
+  //     expect(response.status).toBe(400);
+  //     expect(response.body.message).toMatch("Parameter 'username' is undefined.");
 
-      done();
-    });
+  //     done();
+  //   });
 
-    test("7.3 - DON'T assert name for unknown username", async done => {
-      const body = { username: 'assert_guy' };
-      const response = await request.post(`${BASE_URL}/assert-name`).send(body);
+  //   test("7.3 - DON'T assert name for unknown username", async done => {
+  //     const body = { username: 'assert_guy' };
+  //     const response = await request.post(`${BASE_URL}/assert-name`).send(body);
 
-      expect(response.status).toBe(404);
-      expect(response.body.message).toMatch('Player not found.');
+  //     expect(response.status).toBe(404);
+  //     expect(response.body.message).toMatch('Player not found.');
 
-      done();
-    });
+  //     done();
+  //   });
 
-    test('7.4 - Assert name for correct username', async done => {
-      const body = { username: 'Psikoi' };
-      const response = await request.post(`${BASE_URL}/assert-name`).send(body);
+  //   test('7.4 - Assert name for correct username', async done => {
+  //     const body = { username: 'Psikoi' };
+  //     const response = await request.post(`${BASE_URL}/assert-name`).send(body);
 
-      if (response.status === 200) {
-        expect(response.body.displayName).toMatch('Psikoi');
-      } else {
-        expect(response.body.message).toMatch("Couldn't find a name match for psikoi");
-      }
+  //     if (response.status === 200) {
+  //       expect(response.body.displayName).toMatch('Psikoi');
+  //     } else {
+  //       expect(response.body.message).toMatch("Couldn't find a name match for psikoi");
+  //     }
 
-      done();
-    }, 90000);
+  //     done();
+  //   }, 90000);
 
-    test('7.5 - Assert name for correct unformatted username', async done => {
-      const body = { username: 'iron_mammal' };
-      const response = await request.post(`${BASE_URL}/assert-name`).send(body);
+  //   test('7.5 - Assert name for correct unformatted username', async done => {
+  //     const body = { username: 'iron_mammal' };
+  //     const response = await request.post(`${BASE_URL}/assert-name`).send(body);
 
-      if (response.status === 200) {
-        expect(response.body.displayName).toMatch('Iron Mammal');
-      } else {
-        expect(response.body.message).toMatch("Couldn't find a name match for iron mammal");
-      }
+  //     if (response.status === 200) {
+  //       expect(response.body.displayName).toMatch('Iron Mammal');
+  //     } else {
+  //       expect(response.body.message).toMatch("Couldn't find a name match for iron mammal");
+  //     }
 
-      done();
-    }, 90000);
-  });
+  //     done();
+  //   }, 90000);
+  // });
 });

--- a/server/src/api/controllers/player.controller.ts
+++ b/server/src/api/controllers/player.controller.ts
@@ -1,5 +1,5 @@
 import { NextFunction, Request, Response } from 'express';
-import { BadRequestError, ForbiddenError } from '../errors';
+import { BadRequestError, ForbiddenError, ServerError } from '../errors';
 import * as adminGuard from '../guards/admin.guard';
 import * as achievementService from '../services/internal/achievement.service';
 import * as competitionService from '../services/internal/competition.service';
@@ -62,15 +62,16 @@ async function assertType(req: Request, res: Response, next: NextFunction) {
 // POST /players/assert-name
 async function assertName(req: Request, res: Response, next: NextFunction) {
   try {
-    const username = extractString(req.body, { key: 'username', required: true });
+    // const username = extractString(req.body, { key: 'username', required: true });
 
-    // Find the player using the username body param
-    const player = await playerService.resolve({ username });
+    // // Find the player using the username body param
+    // const player = await playerService.resolve({ username });
 
-    // Assert the player's displayName (via hiscores lookup)
-    const name = await playerService.assertName(player);
+    // // Assert the player's displayName (via hiscores lookup)
+    // const name = await playerService.assertName(player);
 
-    res.json({ displayName: name });
+    // res.json({ displayName: name });
+    throw new ServerError('This feature is currently disabled as Jagex is blocking web scrapers.');
   } catch (e) {
     next(e);
   }

--- a/server/src/api/events/player.events.ts
+++ b/server/src/api/events/player.events.ts
@@ -75,4 +75,4 @@ async function onPlayerImported(playerId: number) {
   );
 }
 
-export { onPlayerCreated, onPlayerTypeChanged, onPlayerNameChanged, onPlayerUpdated, onPlayerImported };
+export { onPlayerTypeChanged, onPlayerNameChanged, onPlayerUpdated, onPlayerImported };

--- a/server/src/api/events/player.events.ts
+++ b/server/src/api/events/player.events.ts
@@ -7,10 +7,10 @@ import * as competitionService from '../services/internal/competition.service';
 import * as deltaService from '../services/internal/delta.service';
 import * as playerService from '../services/internal/player.service';
 
-async function onPlayerCreated(player: Player) {
-  // Confirm this player's name capitalization
-  jobs.add('AssertPlayerName', { id: player.id }, { attempts: 5, backoff: 30000 });
-}
+// async function onPlayerCreated(player: Player) {
+//   // Confirm this player's name capitalization
+//   // jobs.add('AssertPlayerName', { id: player.id }, { attempts: 5, backoff: 30000 });
+// }
 
 async function onPlayerTypeChanged(player: Player, previousType: string) {
   if (previousType === 'hardcore' && player.type === 'ironman') {
@@ -33,7 +33,7 @@ async function onPlayerNameChanged(player: Player, previousDisplayName: string) 
   );
 
   // Setup jobs to assert the player's name capitalization and account type
-  jobs.add('AssertPlayerName', { id: player.id }, { attempts: 5, backoff: 30000 });
+  // jobs.add('AssertPlayerName', { id: player.id }, { attempts: 5, backoff: 30000 });
   jobs.add('AssertPlayerType', { id: player.id }, { attempts: 5, backoff: 30000 });
 }
 

--- a/server/src/api/hooks.ts
+++ b/server/src/api/hooks.ts
@@ -14,7 +14,6 @@ import { onDeltaUpdated } from './events/delta.events';
 import { onMembersJoined, onMembersLeft } from './events/group.events';
 import { onNameChangeCreated } from './events/name.events';
 import {
-  onPlayerCreated,
   onPlayerImported,
   onPlayerNameChanged,
   onPlayerTypeChanged,
@@ -38,9 +37,9 @@ function setup() {
     }
   });
 
-  Player.afterCreate((player: Player) => {
-    onPlayerCreated(player);
-  });
+  // Player.afterCreate((player: Player) => {
+  //   onPlayerCreated(player);
+  // });
 
   Snapshot.afterCreate((snapshot: Snapshot) => {
     onPlayerUpdated(snapshot);


### PR DESCRIPTION
Resolves #853 

- Adds the ability to submit a name change for the same username (different capitalization)
- Auto approval for identical usernames
- Removes "Reset username capitalization" menu option from website