### PR TITLE
Fix members/participants being added in lowercase

### DIFF
--- a/server/__tests__/integration/competition.test.ts
+++ b/server/__tests__/integration/competition.test.ts
@@ -166,7 +166,7 @@ describe('Competition API', () => {
         metric: 'overall',
         startsAt: '2025-05-17T22:00:00.000Z',
         endsAt: '2025-05-17T22:00:00.000Z',
-        participants: ['test player', 'alt player']
+        participants: ['test player', 'alt player', 'Boom']
       };
 
       const response = await request.post(BASE_URL).send(body);
@@ -177,9 +177,10 @@ describe('Competition API', () => {
       expect(response.body.metric).toMatch('overall');
       expect(response.body.startsAt).toMatch('2025-05-17T22:00:00.000Z');
       expect(response.body.endsAt).toMatch('2025-05-17T22:00:00.000Z');
-      expect(response.body.participants.length).toBe(2);
+      expect(response.body.participants.length).toBe(3);
       expect(response.body.participants[0].username).toBe('test player');
       expect(response.body.participants[1].username).toBe('alt player');
+      expect(response.body.participants[2].displayName).toBe('Boom');
       expect(response.body.verificationCode).not.toBe(undefined);
       expect(response.body.verificationHash).toBe(undefined);
 

--- a/server/__tests__/integration/group.test.ts
+++ b/server/__tests__/integration/group.test.ts
@@ -85,16 +85,22 @@ describe('Group API', () => {
         members: [
           { username: '  test_player' },
           { username: '  ALT PLAYER' },
-          { username: '__ zezima ' }
+          { username: 'New Username' },
+          { username: 'alt player   ' },
+          { username: '__ zezima ' },
+          { username: 'Jakesterwars' }
         ]
       };
 
       const response = await request.post(BASE_URL).send(body);
 
       expect(response.status).toBe(201);
-      expect(response.body.members.length).toBe(3);
-      expect(response.body.members.map(m => m.username)).toContain('alt player');
-      expect(response.body.members.map(m => m.displayName)).toContain('Test Player');
+      expect(response.body.members.length).toBe(5);
+      expect(response.body.members[0].displayName).toContain('Test Player');
+      expect(response.body.members[1].username).toBe('alt player');
+      expect(response.body.members[2].username).toBe('new username');
+      expect(response.body.members[3].username).toBe('zezima');
+      expect(response.body.members[4].displayName).toBe('Jakesterwars');
       expect(response.body.members.filter(m => m.role !== 'member').length).toBe(0);
 
       TEST_DATA.membersNoLeaders = response.body;


### PR DESCRIPTION
Closes #855 

Fixes an issue where all unregistered usernames added directly to groups/competitions would get their display names converted to lowercase.

Also added integration tests to guarantee this doesn't happen again.