### PR TITLE
Fix Hardmode ToB EHB rates

### DIFF
--- a/server/src/api/modules/efficiency/configs/ehb/f2p.ehb.ts
+++ b/server/src/api/modules/efficiency/configs/ehb/f2p.ehb.ts
@@ -34,6 +34,6 @@ export default [
   { boss: 'vorkath', rate: 0 },
   { boss: 'zulrah', rate: 0 },
   { boss: 'nightmare', rate: 0 },
-  { boss: 'theatre_of_blood_challenge_mode', rate: 0 },
+  { boss: 'theatre_of_blood_hard_mode', rate: 0 },
   { boss: 'phosanis_nightmare', rate: 0 }
 ];

--- a/server/src/api/modules/efficiency/configs/ehb/ironman.ehb.ts
+++ b/server/src/api/modules/efficiency/configs/ehb/ironman.ehb.ts
@@ -41,6 +41,6 @@ export default [
   { boss: 'vorkath', rate: 32 },
   { boss: 'zulrah', rate: 32 },
   { boss: 'nightmare', rate: 11 },
-  { boss: 'theatre_of_blood_challenge_mode', rate: 2.4 },
+  { boss: 'theatre_of_blood_hard_mode', rate: 2.4 },
   { boss: 'phosanis_nightmare', rate: 6.5 }
 ];

--- a/server/src/api/modules/efficiency/configs/ehb/lvl3.ehb.ts
+++ b/server/src/api/modules/efficiency/configs/ehb/lvl3.ehb.ts
@@ -34,6 +34,6 @@ export default [
   { boss: 'vorkath', rate: 0 },
   { boss: 'zulrah', rate: 0 },
   { boss: 'nightmare', rate: 0 },
-  { boss: 'theatre_of_blood_challenge_mode', rate: 0 },
+  { boss: 'theatre_of_blood_hard_mode', rate: 0 },
   { boss: 'phosanis_nightmare', rate: 0 }
 ];

--- a/server/src/api/modules/efficiency/configs/ehb/main.ehb.ts
+++ b/server/src/api/modules/efficiency/configs/ehb/main.ehb.ts
@@ -34,6 +34,6 @@ export default [
   { boss: 'vorkath', rate: 32 },
   { boss: 'zulrah', rate: 35 },
   { boss: 'nightmare', rate: 14 },
-  { boss: 'theatre_of_blood_challenge_mode', rate: 3 },
+  { boss: 'theatre_of_blood_hard_mode', rate: 3 },
   { boss: 'phosanis_nightmare', rate: 7.5 }
 ];


### PR DESCRIPTION
It was written as `theatre_of_blood_challenge_mode` on the EHB config files, and WOM usually uses `theatre_of_blood_hard_mode`
