### PR TITLE
Auto-update new "untracked" group members / competition participants

### DIFF
--- a/server/__tests__/integration/player.test.ts
+++ b/server/__tests__/integration/player.test.ts
@@ -40,17 +40,7 @@ beforeAll(async done => {
 
 describe('Player API', () => {
   describe('1. Tracking', () => {
-    test("1.1 - DON'T track valid username too soon", async done => {
-      const body = { username: TEST_DATA.playerA.data.username };
-      const response = await request.post(`${BASE_URL}/track`).send(body);
-
-      expect(response.status).toBe(429);
-      expect(response.body.message).toMatch('Error:');
-
-      done();
-    }, 90000);
-
-    test("1.2 - DON'T track undefined username", async done => {
+    test("1.1 - DON'T track undefined username", async done => {
       const response = await request.post(`${BASE_URL}/track`).send({});
 
       expect(response.status).toBe(400);
@@ -59,7 +49,7 @@ describe('Player API', () => {
       done();
     });
 
-    test("1.3 - DON'T track empty username", async done => {
+    test("1.2 - DON'T track empty username", async done => {
       const response = await request.post(`${BASE_URL}/track`).send({ username: '' });
 
       expect(response.status).toBe(400);
@@ -68,7 +58,7 @@ describe('Player API', () => {
       done();
     });
 
-    test("1.4 - DON'T track lengthy username", async done => {
+    test("1.3 - DON'T track lengthy username", async done => {
       const body = { username: 'ALongUsername' };
       const response = await request.post(`${BASE_URL}/track`).send(body);
 
@@ -78,7 +68,7 @@ describe('Player API', () => {
       done();
     });
 
-    test('1.5 - Track valid username', async done => {
+    test('1.4 - Track valid username', async done => {
       const body = { username: 'Psikoi' };
       const response = await request.post(`${BASE_URL}/track`).send(body);
 
@@ -88,6 +78,16 @@ describe('Player API', () => {
       } else {
         expect(response.body.message).toMatch('Failed to load hiscores: Jagex service is unavailable');
       }
+
+      done();
+    }, 90000);
+
+    test("1.5 - DON'T track valid username too soon", async done => {
+      const body = { username: 'Psikoi' };
+      const response = await request.post(`${BASE_URL}/track`).send(body);
+
+      expect(response.status).toBe(429);
+      expect(response.body.message).toMatch('Error:');
 
       done();
     }, 90000);

--- a/server/src/api/events/competition.events.ts
+++ b/server/src/api/events/competition.events.ts
@@ -4,6 +4,21 @@ import jobs from '../jobs';
 import * as discordService from '../services/external/discord.service';
 import metrics from '../services/external/metrics.service';
 import * as competitionService from '../services/internal/competition.service';
+import * as playerService from '../services/internal/player.service';
+
+async function onParticipantsJoined(_: number, playerIds: number[]) {
+  // Fetch all the newly added participants
+  const players = await playerService.findAllByIds(playerIds);
+
+  // If couldn't find any players for these ids, ignore event
+  if (!players || players.length === 0) return;
+
+  // Request updates for any new players
+  players.forEach(({ username, type }) => {
+    if (type !== 'unknown') return;
+    jobs.add('UpdatePlayer', { username }, { attempts: 3, backoff: 20_000 });
+  });
+}
 
 async function onCompetitionCreated(competition: Competition) {
   // Dispatch a competition created event to our discord bot API.
@@ -61,6 +76,7 @@ async function onCompetitionEnding(competition: Competition, period: EventPeriod
 }
 
 export {
+  onParticipantsJoined,
   onCompetitionCreated,
   onCompetitionStarted,
   onCompetitionEnded,

--- a/server/src/api/events/player.events.ts
+++ b/server/src/api/events/player.events.ts
@@ -34,7 +34,8 @@ async function onPlayerNameChanged(player: Player, previousDisplayName: string) 
 
   // Setup jobs to assert the player's name capitalization and account type
   // jobs.add('AssertPlayerName', { id: player.id }, { attempts: 5, backoff: 30000 });
-  jobs.add('AssertPlayerType', { id: player.id }, { attempts: 5, backoff: 30000 });
+  jobs.add('UpdatePlayer', { username: player.username }, { attempts: 3, backoff: 20_000 });
+  jobs.add('AssertPlayerType', { id: player.id }, { attempts: 5, backoff: 30_000 });
 }
 
 async function onPlayerUpdated(snapshot: Snapshot) {

--- a/server/src/api/hooks.ts
+++ b/server/src/api/hooks.ts
@@ -5,11 +5,12 @@ import {
   Delta,
   Membership,
   NameChange,
+  Participation,
   Player,
   Snapshot
 } from '../database/models';
 import { onAchievementsCreated } from './events/achievement.events';
-import { onCompetitionCreated } from './events/competition.events';
+import { onCompetitionCreated, onParticipantsJoined } from './events/competition.events';
 import { onDeltaUpdated } from './events/delta.events';
 import { onMembersJoined, onMembersLeft } from './events/group.events';
 import { onNameChangeCreated } from './events/name.events';
@@ -55,6 +56,13 @@ function setup() {
 
   Delta.afterCreate((delta: Delta) => {
     onDeltaUpdated(delta);
+  });
+
+  Participation.afterBulkCreate((participations: Participation[]) => {
+    const { competitionId } = participations[0];
+    const playerIds = participations.map(m => m.playerId);
+
+    onParticipantsJoined(competitionId, playerIds);
   });
 
   Membership.afterBulkCreate((memberships: Membership[]) => {

--- a/server/src/api/services/external/discord.service.ts
+++ b/server/src/api/services/external/discord.service.ts
@@ -85,13 +85,8 @@ async function dispatchNameChanged(player: Player, previousDisplayName: string) 
  * Select all new group members and dispatch them to our discord API,
  * so that it can notify any relevant guilds/servers.
  */
-async function dispatchMembersJoined(groupId: number, playerIds: number[]) {
-  // Fetch all the players for these ids
-  const players = await playerService.findAllByIds(playerIds);
-
-  // If couldn't find any players for these ids, ignore event
+async function dispatchMembersJoined(groupId: number, players: Player[]) {
   if (!players || players.length === 0) return;
-
   dispatch('GROUP_MEMBERS_JOINED', { groupId, players });
 }
 

--- a/server/src/api/services/internal/player.service.ts
+++ b/server/src/api/services/internal/player.service.ts
@@ -83,7 +83,11 @@ async function shouldReviewType(player: Player): Promise<boolean> {
  */
 function shouldUpdate(player: Player): boolean {
   if (!player.updatedAt || !isValidDate(player.updatedAt)) return true;
-  return Math.floor((Date.now() - player.updatedAt.getTime()) / 1000) >= 60;
+
+  const timeSinceLastUpdate = Math.floor((Date.now() - player.updatedAt.getTime()) / 1000);
+  const timeSinceRegistration = Math.floor((Date.now() - player.registeredAt.getTime()) / 1000);
+
+  return timeSinceLastUpdate >= 60 || (timeSinceRegistration <= 60 && !player.lastChangedAt);
 }
 
 /**


### PR DESCRIPTION
Closes #827 
Closes #777 

- Adds an auto-update to any untracked new group members
- Adds an auto-update to any untracked new competition participants
- Adds an auto-update to players after changing their name
- Fixed the `shouldUpdate` function to still allow recently registered players to be tracked, if they haven't already