### PR TITLE
#808 - Change Base X Stats Percentage Calculation

### DIFF
--- a/app/src/config/metrics.js
+++ b/app/src/config/metrics.js
@@ -97,6 +97,8 @@ const metrics = {
 export const METRICS_CONFIG = metrics;
 
 export const SKILLS = metrics.SKILLS.map(s => s.key);
+export const REAL_SKILLS = SKILLS.filter(s => s !== 'overall');
+export const TOTAL_SKILLS = REAL_SKILLS.length;
 export const ACTIVITIES = metrics.ACTIVITIES.map(s => s.key);
 export const BOSSES = metrics.BOSSES.map(s => s.key);
 export const VIRTUALS = metrics.VIRTUALS.map(s => s.key);

--- a/app/src/pages/Player/components/AchievementGroup/AchievementGroup.jsx
+++ b/app/src/pages/Player/components/AchievementGroup/AchievementGroup.jsx
@@ -2,6 +2,7 @@ import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { getMetricIcon, getMetricName, formatDate, formatNumber, getLevel } from 'utils';
+import { TOTAL_SKILLS } from 'config';
 import './AchievementGroup.scss';
 
 function AchievementGroup({ group, metricType }) {
@@ -90,6 +91,10 @@ function formatThreshold(threshold) {
 
   if ([273742, 737627, 1986068, 5346332, 13034431].includes(threshold)) {
     return getLevel(threshold + 100).toString();
+  }
+
+  if ([273742 * TOTAL_SKILLS, 737627 * TOTAL_SKILLS, 1986068 * TOTAL_SKILLS, 5346332 * TOTAL_SKILLS, 13034431 * TOTAL_SKILLS].includes(threshold)) {
+    return getLevel((threshold / TOTAL_SKILLS) + 100).toString();
   }
 
   if (threshold <= 10000) {

--- a/app/src/redux/achievements/selectors.js
+++ b/app/src/redux/achievements/selectors.js
@@ -31,7 +31,6 @@ export function getGroupAchievements(groupId) {
 export function getPlayerAchievements(username, includeMissing = false) {
   return state => {
     const achievements = getPlayerAchievementsMap(state)[username];
-
     if (!achievements || achievements.length === 0 || includeMissing) {
       return achievements;
     }

--- a/app/src/redux/achievements/selectors.js
+++ b/app/src/redux/achievements/selectors.js
@@ -31,6 +31,7 @@ export function getGroupAchievements(groupId) {
 export function getPlayerAchievements(username, includeMissing = false) {
   return state => {
     const achievements = getPlayerAchievementsMap(state)[username];
+
     if (!achievements || achievements.length === 0 || includeMissing) {
       return achievements;
     }

--- a/server/src/api/constants.ts
+++ b/server/src/api/constants.ts
@@ -418,6 +418,7 @@ export const SKILLS = SKILLS_MAP.map(s => s.key);
 export const ACTIVITIES = ACTIVITIES_MAP.map(s => s.key);
 export const BOSSES = BOSSES_MAP.map(s => s.key);
 export const REAL_SKILLS = SKILLS.filter(s => s !== 'overall');
+export const TOTAL_SKILLS = REAL_SKILLS.length;
 
 export const VIRTUAL = VIRTUAL_MAP.map(s => s.key);
 

--- a/server/src/api/modules/achievements/templates.ts
+++ b/server/src/api/modules/achievements/templates.ts
@@ -1,6 +1,7 @@
 import { Snapshot } from '../../../database/models';
 import { AchievementTemplate } from '../../services/internal/achievement.service';
-import { getCombatLevel, getMinimumExp } from '../../util/experience';
+import { getCombatLevel, getCappedExp } from '../../util/experience';
+import { TOTAL_SKILLS } from '../../constants';
 
 export const ACHIEVEMENT_TEMPLATES: AchievementTemplate[] = [
   // ------------------
@@ -10,9 +11,9 @@ export const ACHIEVEMENT_TEMPLATES: AchievementTemplate[] = [
     name: 'Base {level} Stats',
     metric: 'overall',
     measure: 'levels',
-    thresholds: [273_742, 737_627, 1_986_068, 5_346_332, 13_034_431],
-    getCurrentValue: (snapshot: Snapshot) => {
-      return getMinimumExp(snapshot);
+    thresholds: [273_742 * TOTAL_SKILLS, 737_627 * TOTAL_SKILLS, 1_986_068 * TOTAL_SKILLS, 5_346_332 * TOTAL_SKILLS, 13_034_431 * TOTAL_SKILLS],
+    getCurrentValue: (snapshot: Snapshot, threshold: number) => {
+      return getCappedExp(snapshot, threshold);
     }
   },
   {

--- a/server/src/api/services/internal/achievement.service.ts
+++ b/server/src/api/services/internal/achievement.service.ts
@@ -6,6 +6,7 @@ import { round } from '../../util/numbers';
 import { getLevel } from '../../util/experience';
 import { ACHIEVEMENT_TEMPLATES } from '../../modules/achievements/templates';
 import * as snapshotService from './snapshot.service';
+import { TOTAL_SKILLS } from '../../constants';
 
 const UNKNOWN_DATE = new Date(0);
 
@@ -228,6 +229,9 @@ function format(achievement: Achievement): ExtendedAchievement {
 }
 
 function getAchievemenName(name: string, threshold: number): string {
+  if (name.includes("Base")) {
+    threshold = threshold / TOTAL_SKILLS;
+  }
   const newName = name
     .replace('{threshold}', formatThreshold(threshold))
     .replace('{level}', formatThreshold(threshold));

--- a/server/src/api/services/internal/achievement.service.ts
+++ b/server/src/api/services/internal/achievement.service.ts
@@ -229,7 +229,7 @@ function format(achievement: Achievement): ExtendedAchievement {
 }
 
 function getAchievemenName(name: string, threshold: number): string {
-  if (name.includes("Base")) {
+  if (name === 'Base {level} Stats') {
     threshold = threshold / TOTAL_SKILLS;
   }
   const newName = name


### PR DESCRIPTION
The issue closes #808 
**Problem**
The issue is that the previous solution calculates the percentage of base stats being
`PROGRESS_TO_90_BASE = LOWEST_SKILL'S_EXP / EXP_AT_LVL_90` which doesn't give a true accuracy of how far you are to the Base stats that is being calculated.

**Solution**
We are changing the logic from this equation to this new one being `PROGRESS_TO_90_BASE = SUM_OF_ALL_SKILLS_CAPPED_AT_90 / EXP_AT_LVL_90 * TOTAL_SKILLS`

I went ahead and based the total length of skills based on the real skills so that it automatically determines the length even when a new skill is added. Because of how the achievement progresses were coded, I had to implement some logic to make sure that the solution works.