### PR TITLE
#709 - Fixes Gained Table onClick Resorting/Incorrect Metric Display When Sorted

### DIFF
--- a/app/src/components/Table/Table.jsx
+++ b/app/src/components/Table/Table.jsx
@@ -66,7 +66,7 @@ function Table({
   );
 
   // When table gets unmounted, reset sorting to defualt
-  useEffect(() => () => setSorting(DEFAULT_SORTING), [rows]);
+  useEffect(() => () => setSorting(DEFAULT_SORTING), []);
 
   const tableClass = classNames('table', {
     '-clickable': !!onRowClicked,
@@ -131,7 +131,7 @@ function Table({
             sortedRows.map((row, i) => {
               /* Rows */
               const rowUniqueKey = uniqueKeySelector(row);
-              const onClick = () => onRowClicked && onRowClicked(i);
+              const onClick = () => onRowClicked && onRowClicked(row);
 
               return (
                 <Fragment key={rowUniqueKey}>

--- a/app/src/pages/Player/components/PlayerDeltasTable/PlayerDeltasTable.jsx
+++ b/app/src/pages/Player/components/PlayerDeltasTable/PlayerDeltasTable.jsx
@@ -8,9 +8,9 @@ function PlayerDeltasTable({ deltas, period, metricType, highlightedMetric, onMe
   const { data } = deltas[period];
   const [rows, columns, uniqueKeySelector] = getTableData(data, metricType);
 
-  function handleRowClicked(index) {
-    if (rows && rows[index]) {
-      onMetricSelected(rows[index].metric);
+  function handleRowClicked(row) {
+    if (row) {
+      onMetricSelected(row.metric);
     }
   }
 


### PR DESCRIPTION
709 - Fixes Gained Table Resorting onClick and Displaying of Incorrect Metric on Graphs

- We were passing row index of the original rows. Changed to passing the
row values instead for ease of use
- useEffect cleanup function to closer resemble `componentWillUnmount`