### PR TITLE
add guide for creating database to server-guide

### DIFF
--- a/.github/contributing/server-guide.md
+++ b/.github/contributing/server-guide.md
@@ -94,6 +94,18 @@ DB_STORAGE=./__tests__/database.sqlite
 
 <br />
 
+## Creating database
+
+Follow the steps to create a server in the **Accessing the Database** section.
+
+Right click on the ` wise old man `  server.
+
+Select `Create` then `Database...`
+
+Name the Database  ` wise-old-man `  and hit save
+
+<br />
+
 **Finally! You're done with the setup and installation, now you can run the server and start developing!**
 
 <br />


### PR DESCRIPTION
Database creation isn't included in the build script for the container yet, need to manually create one through pgAdmin (on top of creating the server). Added that to the server guide doc.