### PR TITLE
Fixes wrong row/metric being selected when sort is applied to Table

### DIFF
--- a/app/src/components/Table/Table.jsx
+++ b/app/src/components/Table/Table.jsx
@@ -131,7 +131,7 @@ function Table({
             sortedRows.map((row, i) => {
               /* Rows */
               const rowUniqueKey = uniqueKeySelector(row);
-              const onClick = () => onRowClicked && onRowClicked(i);
+              const onClick = () => onRowClicked && onRowClicked(rowUniqueKey);
 
               return (
                 <Fragment key={rowUniqueKey}>

--- a/app/src/pages/Player/components/PlayerDeltasTable/PlayerDeltasTable.jsx
+++ b/app/src/pages/Player/components/PlayerDeltasTable/PlayerDeltasTable.jsx
@@ -8,10 +8,8 @@ function PlayerDeltasTable({ deltas, period, metricType, highlightedMetric, onMe
   const { data } = deltas[period];
   const [rows, columns, uniqueKeySelector] = getTableData(data, metricType);
 
-  function handleRowClicked(index) {
-    if (rows && rows[index]) {
-      onMetricSelected(rows[index].metric);
-    }
+  function handleRowClicked(metric) {
+    onMetricSelected(metric);
   }
 
   const onRowClicked = useCallback(handleRowClicked, [rows, metricType]);


### PR DESCRIPTION
This fixes the wrong index being selected on table click.
Using the rowUniqueKey, instead of the index of the sorted rows, fixed the issue.

### Behaviour before bugfix:
![Before bugfix](https://i.imgur.com/CR3LJBy.gif)

### After:
![After bugfix](https://i.imgur.com/m6zcJiK.gif)