### PR TITLE
Add delete player endpoint

### DIFF
--- a/server/src/api/controllers/player.controller.ts
+++ b/server/src/api/controllers/player.controller.ts
@@ -338,6 +338,26 @@ async function updateCountry(req: Request, res: Response, next: NextFunction) {
   }
 }
 
+// DELETE /players/username/:username
+// REQUIRES ADMIN PASSWORD
+async function deletePlayer(req: Request, res: Response, next: NextFunction) {
+  try {
+    const username = extractString(req.params, { key: 'username', required: true });
+    const adminPassword = extractString(req.body, { key: 'adminPassword', required: true });
+
+    if (!adminGuard.checkAdminPermissions(adminPassword)) {
+      throw new ForbiddenError('Incorrect admin password.');
+    }
+
+    const player = await playerService.resolve({ username });
+    await player.destroy();
+
+    res.json({ message: `Successfully deleted player: ${username}` });
+  } catch (e) {
+    next(e);
+  }
+}
+
 export {
   search,
   track,
@@ -353,5 +373,6 @@ export {
   records,
   snapshots,
   names,
-  updateCountry
+  updateCountry,
+  deletePlayer
 };

--- a/server/src/api/routes/player.routes.ts
+++ b/server/src/api/routes/player.routes.ts
@@ -19,6 +19,7 @@ api.get('/username/:username/achievements/progress', controller.achievementsProg
 api.get('/username/:username/competitions', controller.competitions);
 api.get('/username/:username/names', controller.names);
 api.put('/username/:username/country', controller.updateCountry);
+api.delete('/username/:username', controller.deletePlayer);
 
 api.get('/:id', controller.details);
 api.get('/:id/groups', controller.groups);


### PR DESCRIPTION
Adds new endpoint `DELETE /players/username/:username`.

This endpoint is protected and can only be used by entering an admin password in the request body, or by discord bot command (mod/admin only) 