### PR TITLE
Fix achievement processing (126 combat errors)

### DIFF
--- a/server/src/api/services/internal/achievement.service.ts
+++ b/server/src/api/services/internal/achievement.service.ts
@@ -187,7 +187,10 @@ async function calculatePastDates(playerId: number, definitions: AchievementDefi
       // Check if the previous value is > -1, this prevents this calc from setting the first snapshot
       // after May 10th 2020 as the achievement date for any pre-WOM boss achievements
       // (boss tracking was introduced on May 10th 2020)
-      return !d.validate(prev) && d.validate(next) && prev[getMetricValueKey(d.metric as Metric)] > -1;
+      const wasUnranked =
+        METRICS.includes(d.metric as Metric) && prev[getMetricValueKey(d.metric as Metric)] > -1;
+
+      return !d.validate(prev) && d.validate(next) && wasUnranked;
     });
 
     valid.forEach(v => {


### PR DESCRIPTION
"combat" was being trated as a metric, and `getMetricValueKey` would throw an error.