### PR TITLE
Fix RuneLite runecraft links

### DIFF
--- a/app/src/modals/UpdateAllModal/UpdateAllModal.jsx
+++ b/app/src/modals/UpdateAllModal/UpdateAllModal.jsx
@@ -39,9 +39,9 @@ function UpdateAllModal({ entityName, onCancel, onSubmit }) {
         </div>
         <Button text="Update All" onClick={handleSubmit} disabled={isButtonDisabled} />
         <span className="modal-warning">
-          We've recently updated the cooldowns for the "Update All" feature. &nbsp;
+          We&apos;ve recently updated the cooldowns for the &apos;Update All&apos; feature. &nbsp;
           <a href="https://wiseoldman.net/discord">
-            Read all about it in our discord's #announcements channel.
+            Read all about it in our discord&apos;s #announcements channel.
           </a>
         </span>
       </div>

--- a/app/src/pages/Player/Player.jsx
+++ b/app/src/pages/Player/Player.jsx
@@ -182,9 +182,14 @@ function decodeURL(params, query) {
   const sections = TABS.map(t => t.toLowerCase());
   const metricTypes = ['skilling', 'bossing', 'activities'];
 
+  // TODO: quick dirty fix, needs to take more aliases into account
+  // whenever we have the WOM utils package properly configured
+  let queryMetric = query.metric;
+  if (queryMetric === 'runecraft') queryMetric = 'runecrafting';
+
   const isValidSection = params.section && sections.includes(params.section.toLowerCase());
   const isValidMetricType = params.metricType && metricTypes.includes(params.metricType.toLowerCase());
-  const isValidMetric = query.metric && ALL_METRICS.includes(query.metric.toLowerCase());
+  const isValidMetric = queryMetric && ALL_METRICS.includes(queryMetric.toLowerCase());
   const isValidPeriod = query.period && PERIODS.includes(query.period.toLowerCase());
 
   const isValidStartDate = query.startDate && !isValidPeriod && isValidDate(query.startDate);
@@ -193,7 +198,7 @@ function decodeURL(params, query) {
   const username = standardizeUsername(params.username);
   const section = isValidSection ? params.section : 'overview';
   const virtual = query.virtual || false;
-  const metric = isValidMetric ? query.metric : null;
+  const metric = isValidMetric ? queryMetric : null;
   const period = isValidPeriod || query.period === 'custom' ? query.period : 'week';
   const startDate = isValidStartDate ? new Date(query.startDate) : null;
   const endDate = isValidEndDate ? new Date(query.endDate) : null;


### PR DESCRIPTION
The RuneLite XP tracker links people to `/gained?metric=runecraft` and we only use `runecrafting`, so this fixes it.