### PR TITLE
Add additional statistics to the group statistics tab.

### DIFF
--- a/app/src/pages/Group/containers/Statistics.jsx
+++ b/app/src/pages/Group/containers/Statistics.jsx
@@ -48,7 +48,7 @@ function Statistics() {
           </b>
         </div>
         <div className="statistics-block">
-          <span className="statistic-label">Number of a 200ms</span>
+          <span className="statistic-label">Total 200ms</span>
           <b className="statistic-value">
             {showPlaceholder ? 'Loading...' : statistics.maxed200msCount}
           </b>

--- a/app/src/pages/Group/containers/Statistics.jsx
+++ b/app/src/pages/Group/containers/Statistics.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useCallback, useContext } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { groupSelectors, groupActions } from 'redux/groups';
 import { Table, TablePlaceholder, NumberLabel } from 'components';
-import { getMetricIcon, getLevel, getMetricName } from 'utils';
+import { getMetricIcon, getLevel, getMetricName, formatNumber } from 'utils';
 import { SKILLS, BOSSES, ACTIVITIES } from 'config';
 import { GroupContext } from '../context';
 
@@ -30,6 +30,12 @@ function Statistics() {
     <div className="group-statistics">
       <div className="statistics-block__container">
         <div className="statistics-block">
+          <span className="statistic-label">Average combat level</span>
+          <b className="statistic-value">
+            {showPlaceholder ? 'Loading...' : formatNumber(statistics.averageCombatLevel)}
+          </b>
+        </div>
+        <div className="statistics-block">
           <span className="statistic-label">Maxed overall players</span>
           <b className="statistic-value">
             {showPlaceholder ? 'Loading...' : statistics.maxedTotalCount}
@@ -42,14 +48,38 @@ function Statistics() {
           </b>
         </div>
         <div className="statistics-block">
-          <span className="statistic-label">Number of 200ms</span>
+          <span className="statistic-label">Number of a 200ms</span>
           <b className="statistic-value">
             {showPlaceholder ? 'Loading...' : statistics.maxed200msCount}
           </b>
         </div>
+        <div className="statistics-block">
+          <span className="statistic-label">Players with 200m</span>
+          <b className="statistic-value">
+            {showPlaceholder ? 'Loading...' : statistics.playersWithMaxedSkill}
+          </b>
+        </div>
+        <div className="statistics-block">
+          <span className="statistic-label">Inferno Cape players</span>
+          <b className="statistic-value">
+            {showPlaceholder ? 'Loading...' : formatNumber(statistics.playersWithInferno)}
+          </b>
+        </div>
+        <div className="statistics-block">
+          <span className="statistic-label">Average EHP</span>
+          <b className="statistic-value">
+            {showPlaceholder ? 'Loading...' : formatNumber(statistics.averageEhpValue)}
+          </b>
+        </div>
+        <div className="statistics-block">
+          <span className="statistic-label">Average EHB</span>
+          <b className="statistic-value">
+            {showPlaceholder ? 'Loading...' : formatNumber(statistics.averageEhbValue)}
+          </b>
+        </div>
       </div>
       <div className="statistics-table">
-        <span className="widget-label">Average member stats</span>
+        <span className="widget-label">Member stats</span>
         {showPlaceholder ? <TablePlaceholder size={20} /> : renderTable(statistics.averageStats)}
       </div>
     </div>
@@ -69,17 +99,19 @@ function renderTable(snapshot) {
 
   const rows = [
     ...SKILLS.map(skill => {
-      const { experience, rank } = snapshot[skill];
+      const { experience, rank, total } = snapshot[skill];
+
       const level = skill === 'overall' ? totalLevel : getLevel(experience);
-      return { metric: skill, level, experience, rank, ehp: 0 };
+      const highest = skill === 'overall' ? 0 : getLevel(snapshot[skill].highest);
+      return { metric: skill, level, highest, experience, rank, ehp: 0, total };
     }),
     ...BOSSES.map(boss => {
-      const { kills, rank } = snapshot[boss];
-      return { metric: boss, kills, rank, ehp: 0 };
+      const { kills, rank, highest, total } = snapshot[boss];
+      return { metric: boss, kills, rank, ehp: 0, highest, total };
     }),
     ...ACTIVITIES.map(activity => {
-      const { score, rank } = snapshot[activity];
-      return { metric: activity, score, rank, ehp: 0 };
+      const { score, rank, highest, total } = snapshot[activity];
+      return { metric: activity, score, rank, ehp: 0, highest, total };
     })
   ];
 
@@ -98,17 +130,23 @@ function renderTable(snapshot) {
       )
     },
     {
-      key: 'level',
+      key: 'avg Level',
       get: row => row.level || -1,
       transform: val => (val === -1 ? '---' : val)
     },
     {
-      key: 'value',
+      key: 'avg value',
       get: getValue,
       transform: val => (val === -1 ? `---` : <NumberLabel value={val} />)
     },
     {
-      key: 'rank',
+      key: 'highest',
+      get: row =>  row.highest || -1,
+      transform: val => (val === -1 ? `---` : <NumberLabel value={val} />)
+    },
+    {
+      key: 'total',
+      get: row =>  row.total || -1,
       transform: val => (val === -1 ? `---` : <NumberLabel value={val} />)
     }
   ];

--- a/server/src/api/services/internal/group.service.ts
+++ b/server/src/api/services/internal/group.service.ts
@@ -29,7 +29,7 @@ import {
 } from '../../../database/models';
 import { BadRequestError, NotFoundError } from '../../errors';
 import { isValidDate } from '../../util/dates';
-import { get200msCount, getCombatLevel, getTotalLevel } from '../../util/experience';
+import { get200msCount, getCombatLevel, getTotalLevel, hasInfernoCape, hasMaxedSkill } from '../../util/experience';
 import * as cmlService from '../external/cml.service';
 import * as cryptService from '../external/crypt.service';
 import * as templeService from '../external/temple.service';
@@ -467,11 +467,16 @@ async function getStatistics(groupId: number) {
   }
 
   const maxedCombatCount = stats.filter(s => getCombatLevel(s) === 126).length;
+  const averageCombatLevel = stats.reduce((a, b) => a + getCombatLevel(b), 0) / stats.length;
+  const averageEhpValue = stats.reduce((a, b) => a + b.ehpValue, 0) / stats.length;
+  const playersWithInferno = stats.filter(s => hasInfernoCape(s)).length;
+  const averageEhbValue = stats.reduce((a, b) => a + b.ehbValue, 0) / stats.length;
   const maxedTotalCount = stats.filter(s => getTotalLevel(s) === 2277).length;
   const maxed200msCount = stats.map(s => get200msCount(s)).reduce((acc, cur) => acc + cur, 0);
   const averageStats = snapshotService.format(snapshotService.average(stats));
+  const playersWithMaxedSkill = stats.filter(s => hasMaxedSkill(s)).length;
 
-  return { maxedCombatCount, maxedTotalCount, maxed200msCount, averageStats };
+  return { maxedCombatCount, maxedTotalCount, averageEhbValue, maxed200msCount, playersWithMaxedSkill, playersWithInferno, averageStats, averageEhpValue, averageCombatLevel };
 }
 
 async function create(dto: CreateGroupDTO): Promise<[Group, Member[]]> {

--- a/server/src/api/services/internal/snapshot.service.ts
+++ b/server/src/api/services/internal/snapshot.service.ts
@@ -313,7 +313,7 @@ async function fromRS(playerId: number, csvData: string): Promise<Snapshot> {
   // If a new skill/activity/boss was added to the hiscores,
   // prevent any further snapshot saves to prevent incorrect DB data
   if (rows.length !== SKILLS.length + ACTIVITIES.length + BOSSES.length) {
-    // throw new ServerError('The OSRS Hiscores were updated. Please wait for a fix.');
+    throw new ServerError('The OSRS Hiscores were updated. Please wait for a fix.');
   }
 
   const stats = {};

--- a/server/src/api/util/experience.ts
+++ b/server/src/api/util/experience.ts
@@ -37,6 +37,14 @@ export function getCombatLevel(snapshot: Snapshot) {
   );
 }
 
+export function hasInfernoCape(snapshot: Snapshot) {
+  return snapshot.tzkal_zukKills > 0;
+}
+
+export function hasMaxedSkill(snapshot: Snapshot) {
+  return !! SKILLS.find(s => s !== Metrics.OVERALL && snapshot[getMetricValueKey(s)] === MAX_SKILL_EXP);
+}
+
 export function getTotalLevel(snapshot: Snapshot) {
   return SKILLS.filter(s => s !== Metrics.OVERALL)
     .map(s => getLevel(snapshot[getMetricValueKey(s)]))


### PR DESCRIPTION
Hi 👋,

This is my first PR so please let me know if something is incorrect and / or better way of doing things.

This is off the back of a request from @BoomOSRS.

Adds the following stats:

- Average Combat level
- Average EHP & Average EHB
- Amount of members with an Infernal cape
- Amount of members with a 200M rather than individual 200M statistics.

Also adds the following columns to the table:
- Highest value per metric - formats levels.
- The total per metric.

Also as a part of this as they are no longer average stats within this list:
- Renamed Average member stats -> Member Stats
- Renamed column: Level -> Avg Level
- Renamed column: Value -> Avg Value

Adds additional helper methods:
- `hasInfernoCapes` -> Determines if a snapshot has inferno cape by getting the count of zuk kills.
- `hasMaxedSkill` -> Determines if a snapshot has a maxed skill.

Closed #940.