### PR TITLE
Update maintenance dates

### DIFF
--- a/server/src/api/services/internal/competition.service.ts
+++ b/server/src/api/services/internal/competition.service.ts
@@ -23,8 +23,8 @@ import * as playerService from './player.service';
 import * as snapshotService from './snapshot.service';
 
 // Temporary
-const MAINTENANCE_START = new Date('2022-02-13T00:00:00.000Z');
-const MAINTENANCE_END = new Date('2022-02-13T04:00:00.000Z');
+const MAINTENANCE_START = new Date('2022-08-13T07:00:00.000Z');
+const MAINTENANCE_END = new Date('2022-08-13T11:00:00.000Z');
 
 interface Team {
   name: string;


### PR DESCRIPTION
Prevent users from creating new competitions during the upcoming maintenance period, which will be on the 13th from 7 to 11 AM UTC.

Taking the server down to backup the database and deploying API v2 beta