### PR TITLE
[v2] Rename Virtual Metrics to Computed Metrics

### DIFF
--- a/server/__tests__/suites/integration/deltas.test.ts
+++ b/server/__tests__/suites/integration/deltas.test.ts
@@ -233,7 +233,7 @@ describe('Deltas API', () => {
       expect(weekResponse.status).toBe(200);
 
       const weekSmithingGains = weekResponse.body.data.skills.smithing;
-      const weekEHPGains = weekResponse.body.data.virtuals.ehp;
+      const weekEHPGains = weekResponse.body.data.computed.ehp;
 
       expect(weekSmithingGains.ehp.gained).toBeGreaterThan(0.1);
       expect(weekEHPGains.value.gained).toBe(weekSmithingGains.ehp.gained);
@@ -245,7 +245,7 @@ describe('Deltas API', () => {
 
       const monthNexGains = monthResponse.body.data.bosses.nex;
       const monthZukGains = monthResponse.body.data.bosses.tzkal_zuk;
-      const monthEhbGains = monthResponse.body.data.virtuals.ehb;
+      const monthEhbGains = monthResponse.body.data.computed.ehb;
       const monthLmsGains = monthResponse.body.data.activities.last_man_standing;
 
       expect(monthNexGains.ehb.gained).toBeGreaterThan(0.1);

--- a/server/__tests__/suites/integration/groups.test.ts
+++ b/server/__tests__/suites/integration/groups.test.ts
@@ -1317,14 +1317,14 @@ describe('Group API', () => {
       expect(activityHiscoresResponse.body[0].data.score).toBeDefined();
       expect(activityHiscoresResponse.body[0].data.rank).toBeDefined();
 
-      const virtualHiscoresResponse = await api
+      const computedMetricsHiscoresResponse = await api
         .get(`/groups/${globalData.testGroupOneLeader.id}/hiscores`)
         .query({ metric: 'ehp' });
 
-      expect(virtualHiscoresResponse.status).toBe(200);
-      expect(virtualHiscoresResponse.body.length).toBe(3);
-      expect(virtualHiscoresResponse.body[0].data.value).toBeDefined();
-      expect(virtualHiscoresResponse.body[0].data.rank).toBeDefined();
+      expect(computedMetricsHiscoresResponse.status).toBe(200);
+      expect(computedMetricsHiscoresResponse.body.length).toBe(3);
+      expect(computedMetricsHiscoresResponse.body[0].data.value).toBeDefined();
+      expect(computedMetricsHiscoresResponse.body[0].data.rank).toBeDefined();
     });
 
     it('should view hiscores (w/ limit & offset)', async () => {

--- a/server/__tests__/suites/integration/players.test.ts
+++ b/server/__tests__/suites/integration/players.test.ts
@@ -133,8 +133,8 @@ describe('Player API', () => {
 
       expect(response.body.latestSnapshot).not.toBeNull();
 
-      expect(response.body.ehp).toBe(response.body.latestSnapshot.data.virtuals.ehp.value);
-      expect(response.body.ehb).toBe(response.body.latestSnapshot.data.virtuals.ehb.value);
+      expect(response.body.ehp).toBe(response.body.latestSnapshot.data.computed.ehp.value);
+      expect(response.body.ehb).toBe(response.body.latestSnapshot.data.computed.ehb.value);
 
       // Track again, stats shouldn't have changed
       await api.post(`/players/ PSIKOI_ `);

--- a/server/__tests__/suites/integration/records.test.ts
+++ b/server/__tests__/suites/integration/records.test.ts
@@ -359,7 +359,7 @@ describe('Records API', () => {
       });
     });
 
-    it('should fetch records (and correctly parse virtual metrics)', async () => {
+    it('should fetch records (and correctly parse computed metrics)', async () => {
       const response = await api
         .get(`/groups/${globalData.testRegularGroupId}/records`)
         .query({ metric: 'ehp', period: 'day' });
@@ -554,7 +554,7 @@ describe('Records API', () => {
       });
     });
 
-    it('should fetch leaderboards (and correctly parse virtual metrics)', async () => {
+    it('should fetch leaderboards (and correctly parse computed metrics)', async () => {
       const response = await api.get(`/records/leaderboard`).query({ period: 'month', metric: 'ehp' });
 
       expect(response.status).toBe(200);

--- a/server/__tests__/suites/unit/metrics.test.ts
+++ b/server/__tests__/suites/unit/metrics.test.ts
@@ -6,13 +6,13 @@ import {
   isSkill,
   isBoss,
   isActivity,
-  isVirtualMetric,
+  isComputedMetric,
   getMetricRankKey,
   getMetricValueKey,
   getMetricMeasure,
   getMetricName,
   getMinimumBossKc,
-  getParentVirtualMetric,
+  getParentEfficiencyMetric,
   parseMetricAbbreviation,
   MetricMeasure
 } from '../../../src/utils';
@@ -53,12 +53,12 @@ describe('Util - Metrics', () => {
     expect(isActivity(findMetric('Soul Wars Zeal') as Metric)).toBe(true);
   });
 
-  test('isVirtualMetric', () => {
-    expect(isVirtualMetric('Other' as Metric)).toBe(false);
-    expect(isVirtualMetric(Metric.WOODCUTTING)).toBe(false);
-    expect(isVirtualMetric(Metric.LAST_MAN_STANDING)).toBe(false);
-    expect(isVirtualMetric(Metric.EHP)).toBe(true);
-    expect(isVirtualMetric(findMetric('EHB') as Metric)).toBe(true);
+  test('isComputedMetric', () => {
+    expect(isComputedMetric('Other' as Metric)).toBe(false);
+    expect(isComputedMetric(Metric.WOODCUTTING)).toBe(false);
+    expect(isComputedMetric(Metric.LAST_MAN_STANDING)).toBe(false);
+    expect(isComputedMetric(Metric.EHP)).toBe(true);
+    expect(isComputedMetric(findMetric('EHB') as Metric)).toBe(true);
   });
 
   test('getMetricRankKey', () => {
@@ -96,11 +96,11 @@ describe('Util - Metrics', () => {
     expect(getMinimumBossKc(Metric.TZKAL_ZUK)).toBe(1);
   });
 
-  test('getParentVirtualMetric', () => {
-    expect(getParentVirtualMetric(Metric.EHP)).toBe(null);
-    expect(getParentVirtualMetric(Metric.ZALCANO)).toBe(Metric.EHB);
-    expect(getParentVirtualMetric(Metric.WOODCUTTING)).toBe(Metric.EHP);
-    expect(getParentVirtualMetric(Metric.SOUL_WARS_ZEAL)).toBe(null);
+  test('getParentEfficiencyMetric', () => {
+    expect(getParentEfficiencyMetric(Metric.EHP)).toBe(null);
+    expect(getParentEfficiencyMetric(Metric.ZALCANO)).toBe(Metric.EHB);
+    expect(getParentEfficiencyMetric(Metric.WOODCUTTING)).toBe(Metric.EHP);
+    expect(getParentEfficiencyMetric(Metric.SOUL_WARS_ZEAL)).toBe(null);
   });
 
   test('parseMetricAbbreviation', () => {

--- a/server/src/api/modules/competitions/services/FetchCompetitionDetailsService.ts
+++ b/server/src/api/modules/competitions/services/FetchCompetitionDetailsService.ts
@@ -1,7 +1,7 @@
 import { omit } from 'lodash';
 import { z } from 'zod';
 import prisma, { modifyPlayer, modifySnapshot } from '../../../../prisma';
-import { getMetricValueKey, isVirtualMetric, Metric } from '../../../../utils';
+import { getMetricValueKey, isComputedMetric, Metric } from '../../../../utils';
 import { NotFoundError } from '../../../errors';
 import { CompetitionDetails } from '../competition.types';
 import * as deltaUtils from '../../deltas/delta.utils';
@@ -39,9 +39,9 @@ async function fetchCompetitionDetails(payload: FetchCompetitionDetailsParams): 
 
   const competitionMetric = params.metric || competition.metric;
   const metricKey = getMetricValueKey(competitionMetric);
-  const isVirtual = isVirtualMetric(competitionMetric);
+  const isComputed = isComputedMetric(competitionMetric);
 
-  const requiredSnapshotFields = isVirtual ? true : { select: { [metricKey]: true } };
+  const requiredSnapshotFields = isComputed ? true : { select: { [metricKey]: true } };
 
   const participations = await prisma.participation.findMany({
     where: { competitionId: params.id },

--- a/server/src/api/modules/deltas/delta.types.ts
+++ b/server/src/api/modules/deltas/delta.types.ts
@@ -1,4 +1,4 @@
-import { Activity, Boss, Player, Skill, Virtual } from '../../../utils';
+import { Activity, Boss, Player, Skill, ComputedMetric } from '../../../utils';
 
 export interface MeasuredDeltaProgress {
   start: number;
@@ -27,8 +27,8 @@ export interface ActivityDelta {
   score: MeasuredDeltaProgress;
 }
 
-export interface VirtualDelta {
-  metric: Virtual;
+export interface ComputedMetricDelta {
+  metric: ComputedMetric;
   rank: MeasuredDeltaProgress;
   value: MeasuredDeltaProgress;
 }
@@ -37,7 +37,7 @@ export interface PlayerDeltasArray {
   skills: Array<SkillDelta>;
   bosses: Array<BossDelta>;
   activities: Array<ActivityDelta>;
-  virtuals: Array<VirtualDelta>;
+  computed: Array<ComputedMetricDelta>;
 }
 
 export interface PlayerDeltasMap {
@@ -50,8 +50,8 @@ export interface PlayerDeltasMap {
   activities: {
     [activity in Activity]?: ActivityDelta;
   };
-  virtuals: {
-    [virtual in Virtual]?: VirtualDelta;
+  computed: {
+    [computedMetric in ComputedMetric]?: ComputedMetricDelta;
   };
 }
 

--- a/server/src/api/modules/deltas/delta.utils.ts
+++ b/server/src/api/modules/deltas/delta.utils.ts
@@ -4,14 +4,14 @@ import {
   SKILLS,
   BOSSES,
   ACTIVITIES,
-  VIRTUALS,
+  COMPUTED_METRICS,
   Metric,
   Skill,
   Boss,
   Activity,
-  Virtual,
+  ComputedMetric,
   isSkill,
-  isVirtualMetric,
+  isComputedMetric,
   getMinimumBossKc,
   getMetricRankKey,
   getMetricValueKey,
@@ -25,7 +25,7 @@ import {
   PlayerDeltasArray,
   PlayerDeltasMap,
   SkillDelta,
-  VirtualDelta
+  ComputedMetricDelta
 } from './delta.types';
 import { EfficiencyMap } from '../efficiency/efficiency.types';
 import { getTotalLevel } from '../snapshots/snapshot.utils';
@@ -33,7 +33,7 @@ import { getTotalLevel } from '../snapshots/snapshot.utils';
 const EMPTY_PROGRESS = Object.freeze({ start: 0, end: 0, gained: 0 });
 
 export function parseNum(metric: Metric, val: string) {
-  return isVirtualMetric(metric) ? parseFloat(val) : parseInt(val);
+  return isComputedMetric(metric) ? parseFloat(val) : parseInt(val);
 }
 
 export function flattenPlayerDeltas(deltas: PlayerDeltasMap): PlayerDeltasArray {
@@ -41,7 +41,7 @@ export function flattenPlayerDeltas(deltas: PlayerDeltasMap): PlayerDeltasArray 
     skills: Object.values(deltas.skills),
     bosses: Object.values(deltas.bosses),
     activities: Object.values(deltas.activities),
-    virtuals: Object.values(deltas.virtuals)
+    computed: Object.values(deltas.computed)
   };
 }
 
@@ -242,16 +242,16 @@ export function calculatePlayerDeltas(startSnapshot: Snapshot, endSnapshot: Snap
     };
   }
 
-  function calculateVirtualDelta(virtual: Virtual): VirtualDelta {
+  function calculateComputedMetricDelta(computedMetric: ComputedMetric): ComputedMetricDelta {
     const valueDiff =
-      virtual === Virtual.EHP
+      computedMetric === Metric.EHP
         ? calculateEHPDiff(startSnapshot, endSnapshot, player)
         : calculateEHBDiff(startSnapshot, endSnapshot, player);
 
     return {
-      metric: virtual,
+      metric: computedMetric,
       value: valueDiff,
-      rank: calculateRankDiff(virtual, startSnapshot, endSnapshot)
+      rank: calculateRankDiff(computedMetric, startSnapshot, endSnapshot)
     };
   }
 
@@ -259,11 +259,11 @@ export function calculatePlayerDeltas(startSnapshot: Snapshot, endSnapshot: Snap
     skills: Object.fromEntries(SKILLS.map(s => [s, calculateSkillDelta(s)])),
     bosses: Object.fromEntries(BOSSES.map(b => [b, calculateBossDelta(b)])),
     activities: Object.fromEntries(ACTIVITIES.map(a => [a, calculateActivityDelta(a)])),
-    virtuals: Object.fromEntries(VIRTUALS.map(v => [v, calculateVirtualDelta(v)]))
+    computed: Object.fromEntries(COMPUTED_METRICS.map(v => [v, calculateComputedMetricDelta(v)]))
   };
 
   // Special Handling for Overall EHP
-  deltas.skills.overall.ehp = deltas.virtuals.ehp.value;
+  deltas.skills.overall.ehp = deltas.computed.ehp.value;
 
   return deltas;
 }
@@ -288,8 +288,8 @@ export function emptyPlayerDelta(): PlayerDeltasArray {
       rank: EMPTY_PROGRESS,
       score: EMPTY_PROGRESS
     })),
-    virtuals: VIRTUALS.map(virtual => ({
-      metric: virtual,
+    computed: COMPUTED_METRICS.map(computedMetric => ({
+      metric: computedMetric,
       rank: EMPTY_PROGRESS,
       value: EMPTY_PROGRESS
     }))

--- a/server/src/api/modules/deltas/services/SyncPlayerDeltasService.ts
+++ b/server/src/api/modules/deltas/services/SyncPlayerDeltasService.ts
@@ -5,7 +5,7 @@ import {
   SKILLS,
   BOSSES,
   ACTIVITIES,
-  VIRTUALS,
+  COMPUTED_METRICS,
   METRICS
 } from '../../../../utils';
 import prisma, { modifyDelta, Player, PrismaDelta, Snapshot } from '../../../../prisma';
@@ -34,8 +34,8 @@ async function syncPlayerDeltas(player: Player, latestSnapshot: Snapshot): Promi
       endedAt: latestSnapshot.createdAt,
       ...Object.fromEntries(SKILLS.map(s => [s, periodDiffs.skills[s].experience.gained])),
       ...Object.fromEntries(BOSSES.map(b => [b, periodDiffs.bosses[b].kills.gained])),
-      ...Object.fromEntries(VIRTUALS.map(v => [v, periodDiffs.virtuals[v].value.gained])),
-      ...Object.fromEntries(ACTIVITIES.map(a => [a, periodDiffs.activities[a].score.gained]))
+      ...Object.fromEntries(ACTIVITIES.map(a => [a, periodDiffs.activities[a].score.gained])),
+      ...Object.fromEntries(COMPUTED_METRICS.map(c => [c, periodDiffs.computed[c].value.gained]))
     };
 
     // Find the existing cached delta for this period

--- a/server/src/api/modules/efficiency/efficiency.services.ts
+++ b/server/src/api/modules/efficiency/efficiency.services.ts
@@ -1,3 +1,3 @@
 export * from './services/ComputeEfficiencyRankService';
-export * from './services/ComputePlayerVirtualsService';
+export * from './services/ComputePlayerMetricsService';
 export * from './services/FindEfficiencyLeaderboardsService';

--- a/server/src/api/modules/efficiency/efficiency.utils.ts
+++ b/server/src/api/modules/efficiency/efficiency.utils.ts
@@ -6,7 +6,7 @@ import {
   BOSSES,
   Skill,
   Boss,
-  Virtual,
+  ComputedMetric,
   Metric,
   getMetricValueKey,
   PlayerType,
@@ -86,7 +86,7 @@ export function buildAlgorithmCache(skillMetas: SkillMetaConfig[], bossMetas: Bo
   };
 }
 
-export function getRates(metric: Virtual, type: EfficiencyAlgorithmType) {
+export function getRates(metric: ComputedMetric, type: EfficiencyAlgorithmType) {
   // Wrong algorithm type
   if (!Object.values(EfficiencyAlgorithmType).includes(type)) return null;
 

--- a/server/src/api/modules/efficiency/services/ComputeEfficiencyRankService.ts
+++ b/server/src/api/modules/efficiency/services/ComputeEfficiencyRankService.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { Virtual, PlayerType } from '../../../../utils';
+import { ComputedMetric, PlayerType } from '../../../../utils';
 import prisma from '../../../../prisma';
 
 const inputSchema = z.object({
@@ -7,7 +7,7 @@ const inputSchema = z.object({
     id: z.number().int().positive(),
     type: z.nativeEnum(PlayerType)
   }),
-  metric: z.nativeEnum(Virtual),
+  metric: z.nativeEnum(ComputedMetric),
   value: z.number().gte(0)
 });
 

--- a/server/src/api/modules/efficiency/services/ComputePlayerMetricsService.ts
+++ b/server/src/api/modules/efficiency/services/ComputePlayerMetricsService.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { Snapshot } from '../../../../prisma';
-import { Virtual, PlayerType, PlayerBuild } from '../../../../utils';
+import { PlayerType, PlayerBuild, Metric } from '../../../../utils';
 import * as efficiencyUtils from '../efficiency.utils';
 import * as efficiencyServices from '../efficiency.services';
 
@@ -12,9 +12,9 @@ const inputSchema = z.object({
   })
 });
 
-type ComputePlayerVirtualsParams = z.infer<typeof inputSchema> & { snapshot: Snapshot };
+type ComputePlayerMetricsParams = z.infer<typeof inputSchema> & { snapshot: Snapshot };
 
-interface ComputePlayerVirtualsResult {
+interface ComputePlayerMetricsResult {
   ttm: number;
   tt200m: number;
   ehpValue: number;
@@ -23,7 +23,7 @@ interface ComputePlayerVirtualsResult {
   ehbRank: number;
 }
 
-async function computePlayerVirtuals(payload: ComputePlayerVirtualsParams) {
+async function computePlayerMetrics(payload: ComputePlayerMetricsParams) {
   const { player, snapshot } = { ...inputSchema.parse(payload), snapshot: payload.snapshot };
 
   const killcountMap = efficiencyUtils.getKillcountMap(snapshot);
@@ -36,17 +36,17 @@ async function computePlayerVirtuals(payload: ComputePlayerVirtualsParams) {
 
   const ehpRank = await efficiencyServices.computeEfficiencyRank({
     player,
-    metric: Virtual.EHP,
+    metric: Metric.EHP,
     value: ehpValue
   });
 
   const ehbRank = await efficiencyServices.computeEfficiencyRank({
     player,
-    metric: Virtual.EHB,
+    metric: Metric.EHB,
     value: ehpValue
   });
 
-  const result: ComputePlayerVirtualsResult = {
+  const result: ComputePlayerMetricsResult = {
     ttm: algorithm.calculateTTM(experienceMap),
     tt200m: algorithm.calculateTT200m(experienceMap),
     ehpValue,
@@ -58,4 +58,4 @@ async function computePlayerVirtuals(payload: ComputePlayerVirtualsParams) {
   return result;
 }
 
-export { computePlayerVirtuals };
+export { computePlayerMetrics };

--- a/server/src/api/modules/efficiency/services/FindEfficiencyLeaderboardsService.ts
+++ b/server/src/api/modules/efficiency/services/FindEfficiencyLeaderboardsService.ts
@@ -1,13 +1,13 @@
 import { z } from 'zod';
 import prisma, { modifyPlayers, Player, PrismaPlayer, PrismaTypes } from '../../../../prisma';
-import { PlayerType, PlayerBuild, Metric, Virtual, Country } from '../../../../utils';
+import { PlayerType, PlayerBuild, Metric, Country } from '../../../../utils';
 import { PAGINATION_SCHEMA } from '../../../util/validation';
 
 const COMBINED_METRIC = 'ehp+ehb';
 
 const inputSchema = z
   .object({
-    metric: z.enum([Virtual.EHP, Virtual.EHB, COMBINED_METRIC]),
+    metric: z.enum([Metric.EHP, Metric.EHB, COMBINED_METRIC]),
     country: z.nativeEnum(Country).optional(),
     playerType: z.nativeEnum(PlayerType).optional().default(PlayerType.REGULAR),
     playerBuild: z.nativeEnum(PlayerBuild).optional()

--- a/server/src/api/modules/groups/group.types.ts
+++ b/server/src/api/modules/groups/group.types.ts
@@ -39,14 +39,14 @@ interface ActivityHiscoresItem {
   score: number;
 }
 
-interface VirtualHiscoresItem {
+interface ComputedMetricHiscoresItem {
   rank: number;
   value: number;
 }
 
 export interface GroupHiscoresEntry {
   player: Player;
-  data: SkillHiscoresItem | BossHiscoresItem | ActivityHiscoresItem | VirtualHiscoresItem;
+  data: SkillHiscoresItem | BossHiscoresItem | ActivityHiscoresItem | ComputedMetricHiscoresItem;
 }
 
 export interface GroupStatistics {

--- a/server/src/api/modules/players/services/UpdatePlayerService.ts
+++ b/server/src/api/modules/players/services/UpdatePlayerService.ts
@@ -64,23 +64,23 @@ async function updatePlayer(payload: UpdatePlayerParams): Promise<UpdatePlayerRe
     updatedPlayerFields.build = getBuild(currentStats);
     updatedPlayerFields.flagged = false;
 
-    const virtuals = await efficiencyServices.computePlayerVirtuals({
+    const computedMetrics = await efficiencyServices.computePlayerMetrics({
       player,
       snapshot: currentStats
     });
 
-    // Set the player's global virtual data
+    // Set the player's global computed data
     updatedPlayerFields.exp = currentStats.overallExperience;
-    updatedPlayerFields.ehp = virtuals.ehpValue;
-    updatedPlayerFields.ehb = virtuals.ehbValue;
-    updatedPlayerFields.ttm = virtuals.ttm;
-    updatedPlayerFields.tt200m = virtuals.tt200m;
+    updatedPlayerFields.ehp = computedMetrics.ehpValue;
+    updatedPlayerFields.ehb = computedMetrics.ehbValue;
+    updatedPlayerFields.ttm = computedMetrics.ttm;
+    updatedPlayerFields.tt200m = computedMetrics.tt200m;
 
-    // Add the virtual data to the snapshot
-    currentStats.ehpValue = virtuals.ehpValue;
-    currentStats.ehpRank = virtuals.ehpRank;
-    currentStats.ehbValue = virtuals.ehbValue;
-    currentStats.ehbRank = virtuals.ehbRank;
+    // Add the computed metrics to the snapshot
+    currentStats.ehpValue = computedMetrics.ehpValue;
+    currentStats.ehpRank = computedMetrics.ehpRank;
+    currentStats.ehbValue = computedMetrics.ehbValue;
+    currentStats.ehbRank = computedMetrics.ehbRank;
 
     // update player with all this new data
     const updatedPlayer = await prisma.player

--- a/server/src/api/modules/records/record.utils.ts
+++ b/server/src/api/modules/records/record.utils.ts
@@ -1,8 +1,8 @@
-import { Metric, isVirtualMetric } from '../../../utils';
+import { Metric, isComputedMetric } from '../../../utils';
 
 // All records' values are stored as an Integer, but EHP/EHB records can have
 // float values, so they're multiplied by 10,000 when saving to the database.
 // Inversely, we need to divide any EHP/EHB records by 10,000 when fetching from the database.
 export function prepareRecordValue(metric: Metric, value: number) {
-  return isVirtualMetric(metric) ? Math.floor(value * 10_000) : value;
+  return isComputedMetric(metric) ? Math.floor(value * 10_000) : value;
 }

--- a/server/src/api/modules/snapshots/snapshot.types.ts
+++ b/server/src/api/modules/snapshots/snapshot.types.ts
@@ -1,4 +1,4 @@
-import { Skill, Boss, Activity, Virtual } from '../../../utils';
+import { Skill, Boss, Activity, ComputedMetric } from '../../../utils';
 import { Snapshot } from '../../../prisma';
 
 export type SnapshotFragment = Omit<Snapshot, 'id'>;
@@ -29,8 +29,8 @@ export interface ActivityValue {
   score: number;
 }
 
-export interface VirtualValue {
-  metric: Virtual;
+export interface ComputedMetricValue {
+  metric: ComputedMetric;
   rank: number;
   value: number;
 }
@@ -50,8 +50,8 @@ export interface FormattedSnapshot {
     activities: {
       [activity in Activity]?: ActivityValue;
     };
-    virtuals: {
-      [virtual in Virtual]?: VirtualValue;
+    computed: {
+      [computed in ComputedMetric]?: ComputedMetric;
     };
   };
 }

--- a/server/src/api/modules/snapshots/snapshot.utils.ts
+++ b/server/src/api/modules/snapshots/snapshot.utils.ts
@@ -4,7 +4,7 @@ import {
   getMetricValueKey,
   Metric,
   METRICS,
-  VIRTUALS,
+  COMPUTED_METRICS,
   ACTIVITIES,
   getLevel,
   SKILLS,
@@ -81,8 +81,8 @@ function format(snapshot: Snapshot, efficiencyMap?: EfficiencyMap): FormattedSna
           ];
         })
       ),
-      virtuals: Object.fromEntries(
-        VIRTUALS.map(v => {
+      computed: Object.fromEntries(
+        COMPUTED_METRICS.map(v => {
           return [
             v,
             {

--- a/server/src/prisma/enum-adapter.ts
+++ b/server/src/prisma/enum-adapter.ts
@@ -137,7 +137,7 @@ export const Boss = {
   ZULRAH: 'zulrah'
 } as const;
 
-export const Virtual = {
+export const ComputedMetric = {
   EHP: 'ehp',
   EHB: 'ehb'
 } as const;
@@ -146,13 +146,13 @@ export const Metric = {
   ...Skill,
   ...Activity,
   ...Boss,
-  ...Virtual
+  ...ComputedMetric
 } as const;
 
 export type Skill = typeof Skill[keyof typeof Skill];
 export type Activity = typeof Activity[keyof typeof Activity];
 export type Boss = typeof Boss[keyof typeof Boss];
-export type Virtual = typeof Virtual[keyof typeof Virtual];
+export type ComputedMetric = typeof ComputedMetric[keyof typeof ComputedMetric];
 export type Metric = typeof Metric[keyof typeof Metric];
 
 export const NameChangeStatus = {

--- a/server/src/prisma/index.ts
+++ b/server/src/prisma/index.ts
@@ -14,7 +14,7 @@ import {
   Prisma,
   Country
 } from '@prisma/client';
-import { isVirtualMetric } from '../utils';
+import { isComputedMetric } from '../utils';
 import { NameChangeStatus } from './enum-adapter';
 import { routeAfterHook } from './hooks';
 import { parseBigInt } from './utils';
@@ -71,8 +71,8 @@ function modifyRecords(records: PrismaRecord[]): Record[] {
     // All records' values are stored as an Integer, but EHP/EHB records can have
     // float values, so they're multiplied by 10,000 when saving to the database.
     // Inversely, we need to divide any EHP/EHB records by 10,000 when fetching from the database.
-    const isVirtual = isVirtualMetric(a.metric);
-    const convertedValue = isVirtual ? parseBigInt(a.value) / 10_000 : parseBigInt(a.value);
+    const isComputed = isComputedMetric(a.metric);
+    const convertedValue = isComputed ? parseBigInt(a.value) / 10_000 : parseBigInt(a.value);
 
     return { ...a, value: convertedValue };
   });

--- a/server/src/utils/metrics.ts
+++ b/server/src/utils/metrics.ts
@@ -1,11 +1,11 @@
 import { capitalize, mapValues } from 'lodash';
-import { Skill, Boss, Activity, Virtual, Metric } from '../prisma/enum-adapter';
+import { Skill, Boss, Activity, ComputedMetric, Metric } from '../prisma/enum-adapter';
 
 enum MetricType {
   SKILL = 'skill',
   BOSS = 'boss',
   ACTIVITY = 'activity',
-  VIRTUAL = 'virtual'
+  COMPUTED = 'computed'
 }
 
 enum MetricMeasure {
@@ -37,7 +37,7 @@ interface ActivityProperties {
   measure: MetricMeasure;
 }
 
-interface VirtualProperties {
+interface ComputedMetricProperties {
   name: string;
   type: MetricType;
   measure: MetricMeasure;
@@ -55,8 +55,8 @@ type ActivityPropsMap = {
   [activity in Activity]: ActivityProperties;
 };
 
-type VirtualPropsMap = {
-  [virtual in Virtual]: VirtualProperties;
+type ComputedMetricPropsMap = {
+  [computedMetric in ComputedMetric]: ComputedMetricProperties;
 };
 
 const SkillProps: SkillPropsMap = mapValues(
@@ -169,26 +169,26 @@ const ActivityProps: ActivityPropsMap = mapValues(
   props => ({ ...props, type: MetricType.ACTIVITY, measure: MetricMeasure.SCORE })
 );
 
-const VirtualProps: VirtualPropsMap = mapValues(
+const ComputedMetricProps: ComputedMetricPropsMap = mapValues(
   {
-    [Virtual.EHP]: { name: 'EHP' },
-    [Virtual.EHB]: { name: 'EHB' }
+    [ComputedMetric.EHP]: { name: 'EHP' },
+    [ComputedMetric.EHB]: { name: 'EHB' }
   },
-  props => ({ ...props, type: MetricType.VIRTUAL, measure: MetricMeasure.VALUE })
+  props => ({ ...props, type: MetricType.COMPUTED, measure: MetricMeasure.VALUE })
 );
 
 const MetricProps = {
   ...SkillProps,
   ...BossProps,
   ...ActivityProps,
-  ...VirtualProps
+  ...ComputedMetricProps
 };
 
 const METRICS = Object.values(Metric);
 const SKILLS = Object.values(Skill);
 const BOSSES = Object.values(Boss);
 const ACTIVITIES = Object.values(Activity);
-const VIRTUALS = Object.values(Virtual);
+const COMPUTED_METRICS = Object.values(ComputedMetric);
 
 const REAL_SKILLS = SKILLS.filter(s => s !== Skill.OVERALL);
 const F2P_BOSSES = BOSSES.filter(b => !MetricProps[b].isMembers);
@@ -215,8 +215,8 @@ function isBoss(metric: Metric) {
   return metric in BossProps;
 }
 
-function isVirtualMetric(metric: Metric) {
-  return metric in VirtualProps;
+function isComputedMetric(metric: Metric) {
+  return metric in ComputedMetricProps;
 }
 
 function getMetricRankKey(metric: Metric) {
@@ -239,7 +239,7 @@ function getMinimumBossKc(metric: Metric) {
   return isBoss(metric) ? MetricProps[metric as Boss].minimumKc : 0;
 }
 
-function getParentVirtualMetric(metric: Metric) {
+function getParentEfficiencyMetric(metric: Metric) {
   if (isBoss(metric)) return Metric.EHB;
   if (isSkill(metric)) return Metric.EHP;
   return null;
@@ -562,7 +562,7 @@ export {
   Skill,
   Boss,
   Activity,
-  Virtual,
+  ComputedMetric,
   MetricType,
   MetricMeasure,
   // Maps
@@ -571,7 +571,7 @@ export {
   SKILLS,
   ACTIVITIES,
   BOSSES,
-  VIRTUALS,
+  COMPUTED_METRICS,
   METRICS,
   F2P_BOSSES,
   REAL_SKILLS,
@@ -585,9 +585,9 @@ export {
   getMetricMeasure,
   getMetricName,
   getMinimumBossKc,
-  getParentVirtualMetric,
+  getParentEfficiencyMetric,
   isSkill,
   isActivity,
   isBoss,
-  isVirtualMetric
+  isComputedMetric
 };


### PR DESCRIPTION
In the near future, combat level will be a computed metric too, that will allow us to have things like combat level achievements (recently removed), competitions, gains, etc.

Same for total level, but those will have to be stored in snapshots as they cannot always be accurately computed (because of unranked skills)

To make this category more generic, efficiency metrics (EHP, EHB) are now a subgenre of computed metrics, maybe I'll add more in future, who knows.