### PR TITLE
Fix Delta Fetching in SyncPlayerDeltas service

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.0.6",
+      "version": "2.0.7",
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^4.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",


### PR DESCRIPTION
Fetching all deltas by `playerId` is more efficient than fetching individually by `playerId, period` with our current indices on `Delta`. 