### PR TITLE
[js-client] Add type guards & export group hiscores items

### DIFF
--- a/client-js/package-lock.json
+++ b/client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wise-old-man/utils",
-      "version": "2.0.0-beta.2",
+      "version": "2.0.0-beta.3",
       "license": "ISC",
       "dependencies": {
         "axios": "^0.27.2",

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/client-js/src/api-types.ts
+++ b/client-js/src/api-types.ts
@@ -1,5 +1,4 @@
 import {
-  Record,
   PlayerDeltasArray,
   PlayerDeltasMap,
   Country,

--- a/client-js/src/clients/EfficiencyClient.ts
+++ b/client-js/src/clients/EfficiencyClient.ts
@@ -4,7 +4,7 @@ import { PaginationOptions, sendGetRequest } from '../utils';
 
 export default class EfficiencyClient {
   /**
-   * Fetches the current efficiency leaderboard for a specific virtual metric, playerType, playerBuild and country.
+   * Fetches the current efficiency leaderboard for a specific efficiency metric, playerType, playerBuild and country.
    * @returns A list of players.
    */
   getEfficiencyLeaderboards(filter: EfficiencyLeaderboardsFilter, pagination?: PaginationOptions) {

--- a/server/__tests__/suites/unit/competitions.test.ts
+++ b/server/__tests__/suites/unit/competitions.test.ts
@@ -1,6 +1,6 @@
 import {
-  findCompetitionType,
-  findCompetitionStatus,
+  isCompetitionStatus,
+  isCompetitionType,
   CompetitionType,
   CompetitionStatus,
   CompetitionTypeProps,
@@ -18,15 +18,16 @@ describe('Util - Competitions', () => {
     expect(Object.keys(CompetitionStatus).length).toBe(Object.keys(CompetitionStatusProps).length);
   });
 
-  test('findCompetitionType', () => {
-    expect(findCompetitionType('Classic')).toBe(CompetitionType.CLASSIC);
-    expect(findCompetitionType('Team')).toBe(CompetitionType.TEAM);
-    expect(findCompetitionType('Other')).toBe(null);
+  test('isCompetitionType', () => {
+    expect(isCompetitionType('classic')).toBe(true);
+    expect(isCompetitionType('team')).toBe(true);
+    expect(isCompetitionType('other')).toBe(false);
   });
 
   test('findCompetitionStatus', () => {
-    expect(findCompetitionStatus('Upcoming')).toBe(CompetitionStatus.UPCOMING);
-    expect(findCompetitionStatus('Ongoing')).toBe(CompetitionStatus.ONGOING);
-    expect(findCompetitionStatus('Other')).toBe(null);
+    expect(isCompetitionStatus('upcoming')).toBe(true);
+    expect(isCompetitionStatus('ongoing')).toBe(true);
+    expect(isCompetitionStatus('finished')).toBe(true);
+    expect(isCompetitionStatus('other')).toBe(false);
   });
 });

--- a/server/src/api/jobs/instances/UpdateGroupScoreJob.ts
+++ b/server/src/api/jobs/instances/UpdateGroupScoreJob.ts
@@ -1,5 +1,5 @@
 import prisma, { Group } from '../../../prisma';
-import { PRIVELEGED_GROUP_ROLES, GroupRole } from '../../../utils';
+import { PRIVELEGED_GROUP_ROLES } from '../../../utils';
 import * as groupServices from '../../modules/groups/group.services';
 import * as competitionServices from '../../modules/competitions/competition.services';
 import { JobType, JobDefinition } from '../job.types';
@@ -46,7 +46,7 @@ async function calculateScore(group: Group): Promise<number> {
   const averageOverallExp = members.reduce((acc: any, cur: any) => acc + cur, 0) / members.length;
 
   // If has atleast one leader
-  if (members.filter(m => PRIVELEGED_GROUP_ROLES.includes(m.role as GroupRole)).length >= 1) {
+  if (members.filter(m => PRIVELEGED_GROUP_ROLES.includes(m.role)).length >= 1) {
     score += 30;
   }
 

--- a/server/src/api/modules/achievements/achievement.utils.ts
+++ b/server/src/api/modules/achievements/achievement.utils.ts
@@ -4,7 +4,7 @@ import {
   getMetricValueKey,
   getLevel,
   SKILL_EXP_AT_99,
-  METRICS
+  isMetric
 } from '../../../utils';
 import { Achievement, Snapshot } from '../../../prisma';
 import { ACHIEVEMENT_TEMPLATES } from './achievement.templates';
@@ -92,7 +92,7 @@ function calculatePastDates(pastSnapshots: Snapshot[], definitions: AchievementD
       // Check if the previous value is > -1, this prevents this calc from setting the first snapshot
       // after May 10th 2020 as the achievement date for any pre-WOM boss achievements
       // (boss tracking was introduced on May 10th 2020)
-      const wasRanked = !METRICS.includes(d.metric) || prev[getMetricValueKey(d.metric)] > -1;
+      const wasRanked = !isMetric(d.metric) || prev[getMetricValueKey(d.metric)] > -1;
       return !d.validate(prev) && d.validate(next) && wasRanked;
     });
 

--- a/server/src/api/modules/groups/group.types.ts
+++ b/server/src/api/modules/groups/group.types.ts
@@ -23,30 +23,34 @@ export interface MemberInput {
   role: string | GroupRole;
 }
 
-interface SkillHiscoresItem {
+export interface GroupHiscoresSkillItem {
   rank: number;
   level: number;
   experience: number;
 }
 
-interface BossHiscoresItem {
+export interface GroupHiscoresBossItem {
   rank: number;
   kills: number;
 }
 
-interface ActivityHiscoresItem {
+export interface GroupHiscoresActivityItem {
   rank: number;
   score: number;
 }
 
-interface ComputedMetricHiscoresItem {
+export interface GroupHiscoresComputedMetricItem {
   rank: number;
   value: number;
 }
 
 export interface GroupHiscoresEntry {
   player: Player;
-  data: SkillHiscoresItem | BossHiscoresItem | ActivityHiscoresItem | ComputedMetricHiscoresItem;
+  data:
+    | GroupHiscoresSkillItem
+    | GroupHiscoresBossItem
+    | GroupHiscoresActivityItem
+    | GroupHiscoresComputedMetricItem;
 }
 
 export interface GroupStatistics {

--- a/server/src/api/util/middlewares.ts
+++ b/server/src/api/util/middlewares.ts
@@ -1,4 +1,4 @@
-import { METRICS, parseMetricAbbreviation } from '../../utils';
+import { isMetric, parseMetricAbbreviation } from '../../utils';
 
 function metricAbbreviation(req, res, next) {
   if (!req) {
@@ -9,7 +9,7 @@ function metricAbbreviation(req, res, next) {
   if (req.body && req.body.metric) {
     const metric = req.body.metric.toLowerCase();
 
-    if (!METRICS.includes(metric)) {
+    if (!isMetric(metric)) {
       req.body.metric = parseMetricAbbreviation(metric);
     }
   }
@@ -18,7 +18,7 @@ function metricAbbreviation(req, res, next) {
   if (req.query && req.query.metric) {
     const metric = req.query.metric.toLowerCase();
 
-    if (!METRICS.includes(metric)) {
+    if (!isMetric(metric)) {
       req.query.metric = parseMetricAbbreviation(metric);
     }
   }

--- a/server/src/utils/competitions.ts
+++ b/server/src/utils/competitions.ts
@@ -28,20 +28,12 @@ const CompetitionStatusProps: CompetitionStatusPropsMap = {
 const COMPETITION_TYPES = Object.values(CompetitionType);
 const COMPETITION_STATUSES = Object.values(CompetitionStatus);
 
-function findCompetitionType(typeName: string): CompetitionType | null {
-  for (const [key, value] of Object.entries(CompetitionTypeProps)) {
-    if (value.name === typeName) return key as CompetitionType;
-  }
-
-  return null;
+function isCompetitionType(typeString: string): typeString is CompetitionType {
+  return typeString in CompetitionTypeProps;
 }
 
-function findCompetitionStatus(statusName: string): CompetitionStatus | null {
-  for (const [key, value] of Object.entries(CompetitionStatusProps)) {
-    if (value.name === statusName) return key as CompetitionStatus;
-  }
-
-  return null;
+function isCompetitionStatus(statusString: string): statusString is CompetitionStatus {
+  return statusString in CompetitionStatusProps;
 }
 
 export {
@@ -54,6 +46,6 @@ export {
   COMPETITION_TYPES,
   COMPETITION_STATUSES,
   // Functions
-  findCompetitionType,
-  findCompetitionStatus
+  isCompetitionType,
+  isCompetitionStatus
 };

--- a/server/src/utils/countries.ts
+++ b/server/src/utils/countries.ts
@@ -268,6 +268,10 @@ const COMMON_ALIASES = [
   { commonIdentifier: 'USA', trueIdentifier: 'US' }
 ];
 
+function isCountry(countryCodeString: string): countryCodeString is Country {
+  return countryCodeString in CountryProps;
+}
+
 function findCountry(countryIdentifier: string): CountryDetails | undefined {
   return findCountryByCode(countryIdentifier) || findCountryByName(countryIdentifier);
 }
@@ -285,4 +289,15 @@ function replaceCommonAliases(countryCode: string) {
   return COMMON_ALIASES.find(ca => ca.commonIdentifier === countryCode)?.trueIdentifier || countryCode;
 }
 
-export { COUNTRY_CODES, CountryProps, Country, findCountry, findCountryByCode, findCountryByName };
+export {
+  // Enums
+  CountryProps,
+  Country,
+  // Lists
+  COUNTRY_CODES,
+  // Functions
+  isCountry,
+  findCountry,
+  findCountryByCode,
+  findCountryByName
+};

--- a/server/src/utils/groups.ts
+++ b/server/src/utils/groups.ts
@@ -292,7 +292,7 @@ const GroupRoleProps: GroupRolePropsMap = mapValues(
   },
   (props, key: GroupRole) => ({
     ...props,
-    isPriveleged: PRIVELEGED_GROUP_ROLES.includes(key as GroupRole)
+    isPriveleged: PRIVELEGED_GROUP_ROLES.includes(key)
   })
 );
 
@@ -306,4 +306,18 @@ function findGroupRole(roleName: string): GroupRole | null {
   return null;
 }
 
-export { GroupRole, GroupRoleProps, GROUP_ROLES, PRIVELEGED_GROUP_ROLES, findGroupRole };
+function isGroupRole(roleString: string): roleString is GroupRole {
+  return roleString in GroupRoleProps;
+}
+
+export {
+  // Enums
+  GroupRole,
+  GroupRoleProps,
+  // Lists
+  GROUP_ROLES,
+  PRIVELEGED_GROUP_ROLES,
+  // Functions
+  isGroupRole,
+  findGroupRole
+};

--- a/server/src/utils/metrics.ts
+++ b/server/src/utils/metrics.ts
@@ -203,19 +203,23 @@ function findMetric(metricName: string): Metric | null {
   return null;
 }
 
-function isSkill(metric: Metric) {
+function isMetric(metricString: string): metricString is Metric {
+  return metricString in MetricProps;
+}
+
+function isSkill(metric: Metric | string): metric is Skill {
   return metric in SkillProps;
 }
 
-function isActivity(metric: Metric) {
+function isActivity(metric: Metric | string): metric is Activity {
   return metric in ActivityProps;
 }
 
-function isBoss(metric: Metric) {
+function isBoss(metric: Metric | string): metric is Boss {
   return metric in BossProps;
 }
 
-function isComputedMetric(metric: Metric) {
+function isComputedMetric(metric: Metric | string): metric is ComputedMetric {
   return metric in ComputedMetricProps;
 }
 
@@ -586,6 +590,7 @@ export {
   getMetricName,
   getMinimumBossKc,
   getParentEfficiencyMetric,
+  isMetric,
   isSkill,
   isActivity,
   isBoss,

--- a/server/src/utils/periods.ts
+++ b/server/src/utils/periods.ts
@@ -1,4 +1,5 @@
 import { Period } from '../prisma/enum-adapter';
+
 const CUSTOM_PERIOD_REGEX = /(\d+y)?(\d+m)?(\d+w)?(\d+d)?(\d+h)?/;
 
 type PeriodPropsMap = {
@@ -26,10 +27,14 @@ function findPeriod(periodName: string): Period | null {
   return null;
 }
 
+function isPeriod(periodString: string): periodString is Period {
+  return periodString in PeriodProps;
+}
+
 function parsePeriodExpression(periodExpression: string) {
   const fixed = periodExpression.toLowerCase();
 
-  if (PERIODS.includes(fixed as Period)) {
+  if (isPeriod(fixed)) {
     return {
       expression: fixed,
       durationMs: PeriodProps[fixed as Period].milliseconds
@@ -60,4 +65,14 @@ function parsePeriodExpression(periodExpression: string) {
   };
 }
 
-export { Period, PeriodProps, PERIODS, findPeriod, parsePeriodExpression };
+export {
+  // Enums
+  Period,
+  PeriodProps,
+  // Lists
+  PERIODS,
+  // Functions
+  isPeriod,
+  findPeriod,
+  parsePeriodExpression
+};

--- a/server/src/utils/players.ts
+++ b/server/src/utils/players.ts
@@ -28,6 +28,14 @@ const PlayerBuildProps: PlayerBuildPropsMap = {
 const PLAYER_TYPES = Object.values(PlayerType);
 const PLAYER_BUILDS = Object.values(PlayerBuild);
 
+function isPlayerType(typeString: string): typeString is PlayerType {
+  return typeString in PlayerTypeProps;
+}
+
+function isPlayerBuild(buildString: string): buildString is PlayerBuild {
+  return buildString in PlayerBuildProps;
+}
+
 function findPlayerType(typeName: string): PlayerType | null {
   for (const [key, value] of Object.entries(PlayerTypeProps)) {
     if (value.name.toUpperCase() === typeName.toUpperCase()) return key as PlayerType;
@@ -54,6 +62,8 @@ export {
   PLAYER_TYPES,
   PLAYER_BUILDS,
   // Functions
+  isPlayerType,
+  isPlayerBuild,
   findPlayerType,
   findPlayerBuild
 };


### PR DESCRIPTION
- Adds type safe guards for enums:
  - `isCompetitionType`
  - `isCompetitionStatus`
  - `isGroupRole`
  - `isCountry` (checks country codes, not names)
  - `isPeriod`
  - `isPlayerType`
  - `isPlayerBuild`
  - `isMetric`
  - `isSkill` (existed already, but type inference improved)
  - `isBoss` (existed already, but type inference improved)
  - `isActivity` (existed already, but type inference improved)
  - `isComputedMetric` (existed already, but type inference improved)

- Exports Group Hiscore Entry items
  - GroupHiscoresSkillItem
  - GroupHiscoresBossItem
  - GroupHiscoresActivityItem
  - GroupHiscoresComputedMetricItem