### PR TITLE
[v2] Fix group editing "duplicate name" and competition top history sorting

### DIFF
--- a/server/__tests__/suites/integration/groups.test.ts
+++ b/server/__tests__/suites/integration/groups.test.ts
@@ -83,8 +83,8 @@ afterAll(async () => {
   axiosMock.reset();
 
   // Sleep for 1s to allow the server to shut down gracefully
-  await apiServer.shutdown().then(() => sleep(1000));
-});
+  await apiServer.shutdown().then(() => sleep(5000));
+}, 10_000);
 
 describe('Group API', () => {
   describe('1 - Create', () => {
@@ -523,6 +523,8 @@ describe('Group API', () => {
 
       expect(onMembersLeftEvent).not.toHaveBeenCalled();
       expect(onMembersJoinedEvent).not.toHaveBeenCalled();
+
+      globalData.testGroupOneLeader.name = response.body.name;
     });
 
     it('should edit clanchat, homeworld & description', async () => {
@@ -541,6 +543,19 @@ describe('Group API', () => {
         memberCount: 5 // shouldn't change
       });
       expect(new Date(response.body.updatedAt).getTime()).toBeGreaterThan(Date.now() - 1000);
+
+      expect(onMembersLeftEvent).not.toHaveBeenCalled();
+      expect(onMembersJoinedEvent).not.toHaveBeenCalled();
+    });
+
+    it('should edit name (capitalization)', async () => {
+      const response = await api.put(`/groups/${globalData.testGroupOneLeader.id}`).send({
+        name: ` ${globalData.testGroupOneLeader.name.toUpperCase()}__`,
+        verificationCode: globalData.testGroupOneLeader.verificationCode
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.body.name).toBe(globalData.testGroupOneLeader.name.toUpperCase());
 
       expect(onMembersLeftEvent).not.toHaveBeenCalled();
       expect(onMembersJoinedEvent).not.toHaveBeenCalled();

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.0.8",
+      "version": "2.0.9",
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^4.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/modules/competitions/services/FetchTop5ProgressService.ts
+++ b/server/src/api/modules/competitions/services/FetchTop5ProgressService.ts
@@ -46,7 +46,7 @@ async function fetchCompetitionTop5Progress(payload: FetchTop5ProgressParams): P
 
     const history = snapshots
       .map(s => ({ value: s[metricKey], date: s.createdAt }))
-      .sort((a, b) => b.value - a.value);
+      .sort((a, b) => b.date.getTime() - a.date.getTime());
 
     return { player, history };
   });

--- a/server/src/api/modules/groups/services/EditGroupService.ts
+++ b/server/src/api/modules/groups/services/EditGroupService.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { omit } from 'lodash';
 import prisma, {
   Group,
   Membership,
@@ -14,7 +15,6 @@ import { GroupDetails } from '../group.types';
 import { isValidUsername, sanitize, standardize } from '../../players/player.utils';
 import * as playerServices from '../../players/player.services';
 import { sanitizeName } from '../group.utils';
-import { omit } from 'lodash';
 
 const MIN_NAME_ERROR = 'Group name must have at least one character.';
 
@@ -81,7 +81,7 @@ async function editGroup(payload: EditGroupParams): Promise<GroupDetails> {
       where: { name: { equals: name, mode: 'insensitive' } }
     });
 
-    if (duplicateGroup) {
+    if (duplicateGroup && duplicateGroup.id !== params.id) {
       throw new BadRequestError(`Group name '${name}' is already taken. (ID: ${duplicateGroup.id})`);
     }
 


### PR DESCRIPTION
- Fixed an issue where if you tried to edit a group and given it the same name as before, it would throw an error saying that name is already being used (well, duh)
- Fixed the sorting on competition top participants' snapshot history to be by date, not by value