### PR TITLE
Improve Client-JS "Map" types [2.0.0-beta.6]

### DIFF
--- a/client-js/package-lock.json
+++ b/client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0-beta.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wise-old-man/utils",
-      "version": "2.0.0-beta.4",
+      "version": "2.0.0-beta.6",
       "license": "ISC",
       "dependencies": {
         "axios": "^0.27.2",

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0-beta.6",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -10,7 +10,7 @@
   "scripts": {
     "prepublish": "npm run build",
     "prebuild": "cd ../server && npm run prisma:generate",
-    "build": "rm -rf ./dist && npx rollup -c && node prisma-transform.js"
+    "build": "rm -rf ./dist && npx rollup -c && node prisma-transform.js && tsc dist/index.d.ts"
   },
   "keywords": [],
   "author": "",

--- a/server/__tests__/data/cml/rspt_group_cml.txt
+++ b/server/__tests__/data/cml/rspt_group_cml.txt
@@ -11,76 +11,6 @@
 .playertooltip { color:black; font-size:125% }
 </style>
 			<title>Statistics - OSRS XP Tracker - Crystal Math Labs</title>
-					<script type='text/javascript' src='assets/scripts/ads.js'></script>
-		<script type='text/javascript' src='assets/scripts/cookies.js'></script>
-		<script type='text/javascript' src='assets/scripts/jquery-1.12.4.js'></script>
-		<script type='text/javascript' src='assets/scripts/custom.js'></script>
-		<script type='text/javascript' src='//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js'></script>
-		<script type='text/javascript' src='assets/scripts/url_parser.js'></script>
-		<script type='text/javascript'>
-
-
-	function capitalize(string) {
-	return string.replace(/^./, capitalize.call.bind("".toUpperCase));
-	}
-
-	function is_a_skill(identifier)
-	{
-	var SKILLS = ['overall','attack','defence','strength','hitpoints','ranged','prayer','magic','cooking','woodcutting','fletching','fishing','firemaking','crafting','smithing','mining','herblore','agility','thieving','slayer','farming','runecrafting','hunter','construction'];
-	var len = SKILLS.length;
-	for(var i = 0; i < len; i++) { if(SKILLS[i]==identifier) { return true; } } return false; } function create_filter() { skill=document.getElementById('filter_skill').value; operator=document.getElementById('filter_operator').value; lvl=document.getElementById('filter_level').value; if(isNaN(lvl) || lvl=='' ) return; add_filter_expression(skill, operator, lvl); } function filter_to_text(skill, operator, lvl) { if(!is_a_skill(skill)) { return capitalize(skill) + " " + (operator==':' ? '=' : operator) + " " + lvl; } if(operator==':' ) { text=lvl + " " + capitalize(skill); if(lvl> 126) { // XP
-		text += ' XP';
-		}
-		} else {
-		text = capitalize(skill);
-		if(lvl > 126) { // XP
-		text += ' XP';
-		} else {
-		text += ' lvl';
-		}
-		text += " " + operator + " " + lvl;
-		}
-		return text;
-		}
-
-		function add_filter_expression(skill, operator, lvl) {
-		add_filter(skill + operator + lvl, filter_to_text(skill, operator, lvl));
-		}
-
-		function add_filter(filter, text) {
-		query = url_to_dict();
-
-		if("filter" in query) {
-		var arr = query["filter"].split(',');
-		arr.push(filter);
-		arr.sort();
-		query["filter"] = arr.join(',');
-		} else {
-		query["filter"] = filter;
-		}
-
-		url = "virtualhiscores.php?" + dict_to_url(query);
-
-		document.getElementById('extrafilters').innerHTML += "<li><a href='" + url + "'>" + text + "</a></li>";
-		}
-	
-</script>
-			<!-- Global site tag (gtag.js) - Google Analytics -->
-			<script async src="https://www.googletagmanager.com/gtag/js?id=UA-130335881-1"></script>
-			<script>
-				window.dataLayer = window.dataLayer || [];
-
-				function gtag() {
-					dataLayer.push(arguments);
-				}
-				gtag('js', new Date());
-
-				gtag('config', 'UA-130335881-1');
-			</script>
-
-
-
-
 		</head>
 
 		<body>
@@ -124,24 +54,6 @@
 							<!--<input type="hidden" name="cookiethis" value="true">-->
 							<input type="submit" value="Track">
 						</form>
-						<script>
-							// get player name from cookie
-							player = "Username";
-							var cookie = get_cookie("player");
-							if (cookie) {
-								player = cookie.replace(/\+/g, " ");
-							}
-							player = player.ucwords()
-
-							var player_name = document.getElementById("player_name");
-							player_name.value = player;
-							player_name.onfocus = function() {
-								if (this.value == player) this.value = '';
-							}
-							player_name.onkeyup = function() {
-								set_cookie('player', this.value, 31);
-							}
-						</script>
 					</li>
 					<li><a href="changenamepending.php">Change Name</a></li>
 						<li><a href="donate.php">Donate</a></li>
@@ -150,16 +62,6 @@
 			</div>
 			<div id="contentwrap">
 				<!-- if page == index.php etc statement -->
-				<script>
-					var captureOutboundLink = function(url) {
-						ga('send', 'event', 'outbound', 'click', url, {
-							'transport': 'beacon',
-							'hitCallback': function() {
-								document.location = url;
-							}
-						});
-					}
-				</script>
 
 				<!--				<div style="text-align: center; padding-top: 25px; margin-right: 20px;"> -->
 				<!--					<a href="https://bit.ly/CrystalMath" onclick="captureOutboundLink('https://bit.ly/CrystalMath'); return false;" target="_blank"> -->
@@ -289,37 +191,6 @@
 			<input type="text" size="2" maxlength="9" id="filter_level" name="filter_level" onchange="create_filter()" />
 		</li>
 		<li id='default_filter_li'><a id='default_filter_a' onclick></a></li>
-		<script>
-			function display_df_li() {
-				var li = document.getElementById('default_filter_li');
-				var a = document.getElementById('default_filter_a');
-				var filterval = 'onhiscores';
-				var cookie = get_cookie('filter');
-				if (filterval == cookie) {
-					li.setAttribute('class', 'highlightedli');
-					if (filterval == 'onhiscores') {
-						a.innerHTML = 'Default';
-					} else {
-						a.innerHTML = 'Remove as default';
-					}
-
-					a.onclick = function() {
-						set_cookie('filter', 'onhiscores', 31);
-						display_df_li();
-					}
-					//document.write("<li class='highlightedli'><a href='cookies.php?action=setfilter&filter=onhiscores'>Remove as default</a></li>");
-				} else {
-					li.removeAttribute('class');
-					a.innerHTML = 'Set as default';
-					a.onclick = function() {
-						set_cookie('filter', filterval, 31);
-						display_df_li();
-					}
-					//document.write("<li><a href='cookies.php?action=setfilter&filter=" + filterval + "'>Set as default</a></li>");
-				}
-			}
-			display_df_li();
-		</script>
 	</ul><h3>Player Group</h3>
 <ul><li><a href='virtualhiscores.php?page=statistics'>None</a></li><li><a href='groups.php'>Select</a></li><li class='highlightedli'><span style='color:white'>Include RSPT MEMBERLIST</span></li></ul><h3>Saved Lists</h3>
 <ul><li><a href='savedlists.php'>Select</a></li><li><a href='savelist.php?page=statistics&amp;group=19740'>Save</a></li></ul>			</div>
@@ -340,24 +211,9 @@
 			</div>
 
 			<div id='footerad'>
-				<script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
-				<!-- footertrackergui -->
-				<ins class="adsbygoogle" style="display:inline-block;width:728px;height:90px" data-ad-client="ca-pub-5699001022866588" data-ad-slot="5418087333"></ins>
-				<script>
 					(adsbygoogle = window.adsbygoogle || []).push({});
 				</script>
 			</div>
-
-			<script>
-				if (window.canRunAds === undefined) {
-					var helpurl = 'https://help.getadblock.com/support/solutions/articles/6000055743-how-do-i-tell-adblock-not-to-run-';
-					var helpheading = 'Always show ads on some sites';
-					document.write("<br/><div style='text-align:center'>");
-					document.write("It seems that you are using an ad blocker. ");
-					document.write("We would appreciate it if you would help support CML by <a href='" + helpurl + "'>whitelisting us in your ad blocker settings</a>. ");
-					document.write("</div>");
-				}
-			</script>
 			</div>
 		</body>
 

--- a/server/__tests__/suites/integration/efficiency.test.ts
+++ b/server/__tests__/suites/integration/efficiency.test.ts
@@ -1,6 +1,13 @@
 import supertest from 'supertest';
 import prisma from '../../../src/prisma';
-import { Boss, SKILLS, MAX_SKILL_EXP, SKILL_EXP_AT_99 } from '../../../src/utils';
+import {
+  Boss,
+  SKILLS,
+  MAX_SKILL_EXP,
+  SKILL_EXP_AT_99,
+  ExperienceMap,
+  KillcountMap
+} from '../../../src/utils';
 import apiServer from '../../../src/api';
 import { ALGORITHMS, buildAlgorithmCache } from '../../../src/api/modules/efficiency/efficiency.utils';
 import * as efficiencyServices from '../../../src/api/modules/efficiency/efficiency.services';
@@ -101,7 +108,7 @@ describe('Efficiency API', () => {
 
   describe('2 - Player EHP calcs', () => {
     test('Maximum EHP calcs (main)', () => {
-      const maximumStats = Object.fromEntries(SKILLS.map(s => [s, MAX_SKILL_EXP]));
+      const maximumStats = Object.fromEntries(SKILLS.map(s => [s, MAX_SKILL_EXP])) as ExperienceMap;
 
       expect(ALGORITHMS.main.calculateEHP(maximumStats)).toBeCloseTo(ALGORITHMS.main.maximumEHP, 4);
       expect(ALGORITHMS.main.calculateTT200m(maximumStats)).toBeCloseTo(0, 4);
@@ -118,7 +125,7 @@ describe('Efficiency API', () => {
     });
 
     test('Maximum EHP calcs (f2p)', () => {
-      const maximumStats = Object.fromEntries(SKILLS.map(s => [s, MAX_SKILL_EXP]));
+      const maximumStats = Object.fromEntries(SKILLS.map(s => [s, MAX_SKILL_EXP])) as ExperienceMap;
 
       expect(ALGORITHMS.f2p.calculateEHP(maximumStats)).toBeCloseTo(ALGORITHMS.f2p.maximumEHP, 4);
       expect(ALGORITHMS.f2p.calculateTT200m(maximumStats)).toBeCloseTo(0, 4);
@@ -140,7 +147,7 @@ describe('Efficiency API', () => {
     });
 
     test('Maxed EHP calcs', () => {
-      const maxedStats = Object.fromEntries(SKILLS.map(s => [s, SKILL_EXP_AT_99]));
+      const maxedStats = Object.fromEntries(SKILLS.map(s => [s, SKILL_EXP_AT_99])) as ExperienceMap;
 
       expect(ALGORITHMS.main.calculateEHP(maxedStats)).toBeCloseTo(ALGORITHMS.main.maxedEHP, 4);
       expect(ALGORITHMS.main.calculateTTM(maxedStats)).toBeCloseTo(0, 4);
@@ -156,7 +163,7 @@ describe('Efficiency API', () => {
     });
 
     test('Skill EHP calcs', () => {
-      const maximumStats = Object.fromEntries(SKILLS.map(s => [s, MAX_SKILL_EXP]));
+      const maximumStats = Object.fromEntries(SKILLS.map(s => [s, MAX_SKILL_EXP])) as ExperienceMap;
 
       expect(
         ALGORITHMS.main.calculateSkillEHP('woodcutting', { ...maximumStats, woodcutting: 0 })
@@ -223,7 +230,7 @@ describe('Efficiency API', () => {
         tzkal_zuk: 100, // 0.8 per hour, 125 EHB
         wintertodt: 100, // no rate, 0 EHB
         zulrah: 100 // 35 per hour, 2.85714 EHB
-      };
+      } as KillcountMap;
 
       expect(ALGORITHMS.main.calculateEHB(killcountMap)).toBeCloseTo(139.82981, 4);
 
@@ -244,7 +251,7 @@ describe('Efficiency API', () => {
         tzkal_zuk: 100, // 0.8 per hour, 125 EHB
         wintertodt: 100, // no rate, 0 EHB
         zulrah: 100 // 32 per hour, 3.125 EHB
-      };
+      } as KillcountMap;
 
       expect(ALGORITHMS.ironman.calculateEHB(killcountMap)).toBeCloseTo(159.25034, 4);
 

--- a/server/src/api/modules/deltas/delta.types.ts
+++ b/server/src/api/modules/deltas/delta.types.ts
@@ -1,4 +1,4 @@
-import { Activity, Boss, Player, Skill, ComputedMetric } from '../../../utils';
+import { Activity, Boss, Player, Skill, ComputedMetric, MapOf } from '../../../utils';
 
 export interface MeasuredDeltaProgress {
   start: number;
@@ -41,10 +41,10 @@ export interface PlayerDeltasArray {
 }
 
 export interface PlayerDeltasMap {
-  skills: Record<Skill, SkillDelta>;
-  bosses: Record<Boss, BossDelta>;
-  activities: Record<Activity, ActivityDelta>;
-  computed: Record<ComputedMetric, ComputedMetricDelta>;
+  skills: MapOf<Skill, SkillDelta>;
+  bosses: MapOf<Boss, BossDelta>;
+  activities: MapOf<Activity, ActivityDelta>;
+  computed: MapOf<ComputedMetric, ComputedMetricDelta>;
 }
 
 export interface DeltaLeaderboardEntry {

--- a/server/src/api/modules/deltas/delta.types.ts
+++ b/server/src/api/modules/deltas/delta.types.ts
@@ -41,18 +41,10 @@ export interface PlayerDeltasArray {
 }
 
 export interface PlayerDeltasMap {
-  skills: {
-    [skill in Skill]?: SkillDelta;
-  };
-  bosses: {
-    [boss in Boss]?: BossDelta;
-  };
-  activities: {
-    [activity in Activity]?: ActivityDelta;
-  };
-  computed: {
-    [computedMetric in ComputedMetric]?: ComputedMetricDelta;
-  };
+  skills: Record<Skill, SkillDelta>;
+  bosses: Record<Boss, BossDelta>;
+  activities: Record<Activity, ActivityDelta>;
+  computed: Record<ComputedMetric, ComputedMetricDelta>;
 }
 
 export interface DeltaLeaderboardEntry {

--- a/server/src/api/modules/deltas/delta.utils.ts
+++ b/server/src/api/modules/deltas/delta.utils.ts
@@ -255,12 +255,12 @@ export function calculatePlayerDeltas(startSnapshot: Snapshot, endSnapshot: Snap
     };
   }
 
-  const deltas: PlayerDeltasMap = {
+  const deltas = {
     skills: Object.fromEntries(SKILLS.map(s => [s, calculateSkillDelta(s)])),
     bosses: Object.fromEntries(BOSSES.map(b => [b, calculateBossDelta(b)])),
     activities: Object.fromEntries(ACTIVITIES.map(a => [a, calculateActivityDelta(a)])),
     computed: Object.fromEntries(COMPUTED_METRICS.map(v => [v, calculateComputedMetricDelta(v)]))
-  };
+  } as PlayerDeltasMap;
 
   // Special Handling for Overall EHP
   deltas.skills.overall.ehp = deltas.computed.ehp.value;

--- a/server/src/api/modules/efficiency/efficiency.types.ts
+++ b/server/src/api/modules/efficiency/efficiency.types.ts
@@ -1,7 +1,7 @@
-import { Skill, Boss } from '../../../utils';
+import { Skill, Boss, MapOf } from '../../../utils';
 
-export type ExperienceMap = Record<Skill, number>;
-export type KillcountMap = Record<Boss, number>;
+export type ExperienceMap = MapOf<Skill, number>;
+export type KillcountMap = MapOf<Boss, number>;
 
 export type EfficiencyMap = ExperienceMap & KillcountMap;
 
@@ -55,4 +55,4 @@ export interface EfficiencyAlgorithm {
   calculateBossEHB(boss: Boss, killcountMap: KillcountMap): number;
 }
 
-export type AlgorithmCache = Record<EfficiencyAlgorithmType, EfficiencyAlgorithm>;
+export type AlgorithmCache = MapOf<EfficiencyAlgorithmType, EfficiencyAlgorithm>;

--- a/server/src/api/modules/efficiency/efficiency.types.ts
+++ b/server/src/api/modules/efficiency/efficiency.types.ts
@@ -1,16 +1,9 @@
 import { Skill, Boss } from '../../../utils';
 
-export type ExperienceMap = {
-  [skill in Skill]?: number;
-};
+export type ExperienceMap = Record<Skill, number>;
+export type KillcountMap = Record<Boss, number>;
 
-export type KillcountMap = {
-  [boss in Boss]?: number;
-};
-
-export type EfficiencyMap = {
-  [m in Skill | Boss]?: number;
-};
+export type EfficiencyMap = ExperienceMap & KillcountMap;
 
 export enum BonusType {
   START,
@@ -62,6 +55,4 @@ export interface EfficiencyAlgorithm {
   calculateBossEHB(boss: Boss, killcountMap: KillcountMap): number;
 }
 
-export type AlgorithmCache = {
-  [a in EfficiencyAlgorithmType]: EfficiencyAlgorithm;
-};
+export type AlgorithmCache = Record<EfficiencyAlgorithmType, EfficiencyAlgorithm>;

--- a/server/src/api/modules/efficiency/efficiency.utils.ts
+++ b/server/src/api/modules/efficiency/efficiency.utils.ts
@@ -136,14 +136,14 @@ function calculateBonuses(experienceMap: ExperienceMap, bonuses: Bonus[]) {
 }
 
 function calculateMaximumEHP(metas: SkillMetaConfig[]) {
-  const zeroStats = Object.fromEntries(SKILLS.map(s => [s, 0]));
+  const zeroStats = Object.fromEntries(SKILLS.map(s => [s, 0])) as ExperienceMap;
 
   return calculateTT200m(zeroStats, metas);
 }
 
 function calculateMaxedEHP(metas: SkillMetaConfig[]) {
-  const zeroStats = Object.fromEntries(SKILLS.map(s => [s, 0]));
-  const maxedStats = Object.fromEntries(SKILLS.map(s => [s, SKILL_EXP_AT_99]));
+  const zeroStats = Object.fromEntries(SKILLS.map(s => [s, 0])) as ExperienceMap;
+  const maxedStats = Object.fromEntries(SKILLS.map(s => [s, SKILL_EXP_AT_99])) as ExperienceMap;
 
   return calculateTT200m(zeroStats, metas) - calculateTT200m(maxedStats, metas);
 }
@@ -215,11 +215,11 @@ function calculateTT200m(experienceMap: ExperienceMap, metas: SkillMetaConfig[])
 }
 
 function getKillcountMap(snapshot: Snapshot): KillcountMap {
-  return Object.fromEntries(BOSSES.map(b => [b, snapshot[getMetricValueKey(b)]]));
+  return Object.fromEntries(BOSSES.map(b => [b, snapshot[getMetricValueKey(b)]])) as KillcountMap;
 }
 
 function getExperienceMap(snapshot: Snapshot): ExperienceMap {
-  return Object.fromEntries(SKILLS.map(s => [s, snapshot[getMetricValueKey(s)]]));
+  return Object.fromEntries(SKILLS.map(s => [s, snapshot[getMetricValueKey(s)]])) as ExperienceMap;
 }
 
 function getPlayerEHB(snapshot: Snapshot, player?: Pick<Player, 'type' | 'build'>) {
@@ -235,12 +235,12 @@ function getPlayerEHP(snapshot: Snapshot, player?: Pick<Player, 'type' | 'build'
 function getPlayerEfficiencyMap(snapshot: Snapshot, player: Pick<Player, 'type' | 'build'>): EfficiencyMap {
   const algorithm = getAlgorithm(player);
 
-  const experienceMap = getExperienceMap(snapshot);
-  const killcountMap = getKillcountMap(snapshot);
+  const expMap = getExperienceMap(snapshot);
+  const kcMap = getKillcountMap(snapshot);
 
   return {
-    ...Object.fromEntries(SKILLS.map(s => [s, algorithm.calculateSkillEHP(s, experienceMap)])),
-    ...Object.fromEntries(BOSSES.map(b => [b, algorithm.calculateBossEHB(b, killcountMap)]))
+    ...(Object.fromEntries(SKILLS.map(s => [s, algorithm.calculateSkillEHP(s, expMap)])) as ExperienceMap),
+    ...(Object.fromEntries(BOSSES.map(b => [b, algorithm.calculateBossEHB(b, kcMap)])) as KillcountMap)
   };
 }
 

--- a/server/src/api/modules/snapshots/snapshot.types.ts
+++ b/server/src/api/modules/snapshots/snapshot.types.ts
@@ -41,18 +41,10 @@ export interface FormattedSnapshot {
   createdAt: Date;
   importedAt: Date | null;
   data: {
-    skills: {
-      [skill in Skill]?: SkillValue;
-    };
-    bosses: {
-      [boss in Boss]?: BossValue;
-    };
-    activities: {
-      [activity in Activity]?: ActivityValue;
-    };
-    computed: {
-      [computed in ComputedMetric]?: ComputedMetric;
-    };
+    skills: Record<Skill, SkillValue>;
+    bosses: Record<Boss, BossValue>;
+    activities: Record<Activity, ActivityValue>;
+    computed: Record<ComputedMetric, ComputedMetricValue>;
   };
 }
 

--- a/server/src/api/modules/snapshots/snapshot.types.ts
+++ b/server/src/api/modules/snapshots/snapshot.types.ts
@@ -1,4 +1,4 @@
-import { Skill, Boss, Activity, ComputedMetric } from '../../../utils';
+import { Skill, Boss, Activity, ComputedMetric, MapOf } from '../../../utils';
 import { Snapshot } from '../../../prisma';
 
 export type SnapshotFragment = Omit<Snapshot, 'id'>;
@@ -41,10 +41,10 @@ export interface FormattedSnapshot {
   createdAt: Date;
   importedAt: Date | null;
   data: {
-    skills: Record<Skill, SkillValue>;
-    bosses: Record<Boss, BossValue>;
-    activities: Record<Activity, ActivityValue>;
-    computed: Record<ComputedMetric, ComputedMetricValue>;
+    skills: MapOf<Skill, SkillValue>;
+    bosses: MapOf<Boss, BossValue>;
+    activities: MapOf<Activity, ActivityValue>;
+    computed: MapOf<ComputedMetric, ComputedMetricValue>;
   };
 }
 

--- a/server/src/api/modules/snapshots/snapshot.utils.ts
+++ b/server/src/api/modules/snapshots/snapshot.utils.ts
@@ -16,7 +16,8 @@ import {
   Skill,
   Boss,
   Activity,
-  ComputedMetric
+  ComputedMetric,
+  MapOf
 } from '../../../utils';
 import { Snapshot } from '../../../prisma';
 import { ServerError } from '../../errors';
@@ -63,7 +64,7 @@ function format(snapshot: Snapshot, efficiencyMap?: EfficiencyMap): FormattedSna
 
           return [s, value];
         })
-      ) as Record<Skill, SkillValue>,
+      ) as MapOf<Skill, SkillValue>,
       bosses: Object.fromEntries(
         BOSSES.map(b => {
           const value: BossValue = {
@@ -78,7 +79,7 @@ function format(snapshot: Snapshot, efficiencyMap?: EfficiencyMap): FormattedSna
 
           return [b, value];
         })
-      ) as Record<Boss, BossValue>,
+      ) as MapOf<Boss, BossValue>,
       activities: Object.fromEntries(
         ACTIVITIES.map(a => {
           return [
@@ -90,7 +91,7 @@ function format(snapshot: Snapshot, efficiencyMap?: EfficiencyMap): FormattedSna
             }
           ];
         })
-      ) as Record<Activity, ActivityValue>,
+      ) as MapOf<Activity, ActivityValue>,
       computed: Object.fromEntries(
         COMPUTED_METRICS.map(v => {
           return [
@@ -102,7 +103,7 @@ function format(snapshot: Snapshot, efficiencyMap?: EfficiencyMap): FormattedSna
             }
           ];
         })
-      ) as Record<ComputedMetric, ComputedMetricValue>
+      ) as MapOf<ComputedMetric, ComputedMetricValue>
     }
   };
 }

--- a/server/src/api/modules/snapshots/snapshot.utils.ts
+++ b/server/src/api/modules/snapshots/snapshot.utils.ts
@@ -12,14 +12,24 @@ import {
   F2P_BOSSES,
   MAX_SKILL_EXP,
   REAL_SKILLS,
-  getCombatLevel
+  getCombatLevel,
+  Skill,
+  Boss,
+  Activity,
+  ComputedMetric
 } from '../../../utils';
 import { Snapshot } from '../../../prisma';
 import { ServerError } from '../../errors';
 import logger from '../../util/logging';
 import * as efficiencyUtils from '../../modules/efficiency/efficiency.utils';
 import { EfficiencyMap } from '../efficiency/efficiency.types';
-import { BossValue, FormattedSnapshot, SkillValue } from './snapshot.types';
+import {
+  ActivityValue,
+  BossValue,
+  ComputedMetricValue,
+  FormattedSnapshot,
+  SkillValue
+} from './snapshot.types';
 
 function format(snapshot: Snapshot, efficiencyMap?: EfficiencyMap): FormattedSnapshot {
   if (!snapshot) return null;
@@ -53,7 +63,7 @@ function format(snapshot: Snapshot, efficiencyMap?: EfficiencyMap): FormattedSna
 
           return [s, value];
         })
-      ),
+      ) as Record<Skill, SkillValue>,
       bosses: Object.fromEntries(
         BOSSES.map(b => {
           const value: BossValue = {
@@ -68,7 +78,7 @@ function format(snapshot: Snapshot, efficiencyMap?: EfficiencyMap): FormattedSna
 
           return [b, value];
         })
-      ),
+      ) as Record<Boss, BossValue>,
       activities: Object.fromEntries(
         ACTIVITIES.map(a => {
           return [
@@ -80,7 +90,7 @@ function format(snapshot: Snapshot, efficiencyMap?: EfficiencyMap): FormattedSna
             }
           ];
         })
-      ),
+      ) as Record<Activity, ActivityValue>,
       computed: Object.fromEntries(
         COMPUTED_METRICS.map(v => {
           return [
@@ -92,7 +102,7 @@ function format(snapshot: Snapshot, efficiencyMap?: EfficiencyMap): FormattedSna
             }
           ];
         })
-      )
+      ) as Record<ComputedMetric, ComputedMetricValue>
     }
   };
 }

--- a/server/src/prisma/enum-adapter.ts
+++ b/server/src/prisma/enum-adapter.ts
@@ -82,7 +82,7 @@ export const Activity = {
   PVP_ARENA: 'pvp_arena',
   SOUL_WARS_ZEAL: 'soul_wars_zeal',
   GUARDIANS_OF_THE_RIFT: 'guardians_of_the_rift'
-};
+} as const;
 
 export const Boss = {
   ABYSSAL_SIRE: 'abyssal_sire',

--- a/server/src/utils/competitions.ts
+++ b/server/src/utils/competitions.ts
@@ -1,4 +1,5 @@
 import { CompetitionType } from '../prisma/enum-adapter';
+import { MapOf } from './types';
 
 enum CompetitionStatus {
   UPCOMING = 'upcoming',
@@ -6,12 +7,12 @@ enum CompetitionStatus {
   FINISHED = 'finished'
 }
 
-const CompetitionTypeProps: Record<CompetitionType, { name: string }> = {
+const CompetitionTypeProps: MapOf<CompetitionType, { name: string }> = {
   [CompetitionType.CLASSIC]: { name: 'Classic' },
   [CompetitionType.TEAM]: { name: 'Team' }
 };
 
-const CompetitionStatusProps: Record<CompetitionStatus, { name: string }> = {
+const CompetitionStatusProps: MapOf<CompetitionStatus, { name: string }> = {
   [CompetitionStatus.UPCOMING]: { name: 'Upcoming' },
   [CompetitionStatus.ONGOING]: { name: 'Ongoing' },
   [CompetitionStatus.FINISHED]: { name: 'Finished' }

--- a/server/src/utils/competitions.ts
+++ b/server/src/utils/competitions.ts
@@ -6,20 +6,12 @@ enum CompetitionStatus {
   FINISHED = 'finished'
 }
 
-type CompetitionStatusPropsMap = {
-  [status in CompetitionStatus]: { name: string };
-};
-
-type CompetitionTypePropsMap = {
-  [type in CompetitionType]: { name: string };
-};
-
-const CompetitionTypeProps: CompetitionTypePropsMap = {
+const CompetitionTypeProps: Record<CompetitionType, { name: string }> = {
   [CompetitionType.CLASSIC]: { name: 'Classic' },
   [CompetitionType.TEAM]: { name: 'Team' }
 };
 
-const CompetitionStatusProps: CompetitionStatusPropsMap = {
+const CompetitionStatusProps: Record<CompetitionStatus, { name: string }> = {
   [CompetitionStatus.UPCOMING]: { name: 'Upcoming' },
   [CompetitionStatus.ONGOING]: { name: 'Ongoing' },
   [CompetitionStatus.FINISHED]: { name: 'Finished' }

--- a/server/src/utils/countries.ts
+++ b/server/src/utils/countries.ts
@@ -5,11 +5,7 @@ export interface CountryDetails {
   name: string;
 }
 
-type CountryPropsMap = {
-  [c in Country]: CountryDetails;
-};
-
-const CountryProps: CountryPropsMap = {
+const CountryProps: Record<Country, CountryDetails> = {
   [Country.AD]: { code: 'AD', name: 'Andorra' },
   [Country.AE]: { code: 'AE', name: 'United Arab Emirates' },
   [Country.AF]: { code: 'AF', name: 'Afghanistan' },

--- a/server/src/utils/countries.ts
+++ b/server/src/utils/countries.ts
@@ -1,11 +1,12 @@
 import { Country } from '../prisma/enum-adapter';
+import { MapOf } from './types';
 
 export interface CountryDetails {
   code: Country;
   name: string;
 }
 
-const CountryProps: Record<Country, CountryDetails> = {
+const CountryProps: MapOf<Country, CountryDetails> = {
   [Country.AD]: { code: 'AD', name: 'Andorra' },
   [Country.AE]: { code: 'AE', name: 'United Arab Emirates' },
   [Country.AF]: { code: 'AF', name: 'Afghanistan' },

--- a/server/src/utils/groups.ts
+++ b/server/src/utils/groups.ts
@@ -11,12 +11,7 @@ const PRIVELEGED_GROUP_ROLES: GroupRole[] = [
   GroupRole.OWNER
 ];
 
-type GroupRolePropsMap = {
-  [role in GroupRole]: {
-    name: string;
-    isPriveleged: boolean;
-  };
-};
+type GroupRolePropsMap = Record<GroupRole, { name: string; isPriveleged: boolean }>;
 
 const GroupRoleProps: GroupRolePropsMap = mapValues(
   {

--- a/server/src/utils/groups.ts
+++ b/server/src/utils/groups.ts
@@ -1,5 +1,6 @@
 import { mapValues } from 'lodash';
 import { GroupRole } from '../prisma/enum-adapter';
+import { MapOf } from './types';
 
 const GROUP_ROLES = Object.values(GroupRole);
 
@@ -11,7 +12,7 @@ const PRIVELEGED_GROUP_ROLES: GroupRole[] = [
   GroupRole.OWNER
 ];
 
-type GroupRolePropsMap = Record<GroupRole, { name: string; isPriveleged: boolean }>;
+type GroupRolePropsMap = MapOf<GroupRole, { name: string; isPriveleged: boolean }>;
 
 const GroupRoleProps: GroupRolePropsMap = mapValues(
   {

--- a/server/src/utils/metrics.ts
+++ b/server/src/utils/metrics.ts
@@ -43,23 +43,7 @@ interface ComputedMetricProperties {
   measure: MetricMeasure;
 }
 
-type SkillPropsMap = {
-  [skill in Skill]: SkillProperties;
-};
-
-type BossPropsMap = {
-  [boss in Boss]: BossProperties;
-};
-
-type ActivityPropsMap = {
-  [activity in Activity]: ActivityProperties;
-};
-
-type ComputedMetricPropsMap = {
-  [computedMetric in ComputedMetric]: ComputedMetricProperties;
-};
-
-const SkillProps: SkillPropsMap = mapValues(
+const SkillProps: Record<Skill, SkillProperties> = mapValues(
   {
     [Skill.OVERALL]: { name: 'Overall', isCombat: false, isMembers: false },
     [Skill.ATTACK]: { name: 'Attack', isCombat: true, isMembers: false },
@@ -89,7 +73,7 @@ const SkillProps: SkillPropsMap = mapValues(
   props => ({ ...props, type: MetricType.SKILL, measure: MetricMeasure.EXPERIENCE })
 );
 
-const BossProps: BossPropsMap = mapValues(
+const BossProps: Record<Boss, BossProperties> = mapValues(
   {
     [Boss.ABYSSAL_SIRE]: { name: 'Abyssal Sire', minimumKc: 50, isMembers: true },
     [Boss.ALCHEMICAL_HYDRA]: { name: 'Alchemical Hydra', minimumKc: 50, isMembers: true },
@@ -149,7 +133,7 @@ const BossProps: BossPropsMap = mapValues(
   props => ({ ...props, type: MetricType.BOSS, measure: MetricMeasure.KILLS })
 );
 
-const ActivityProps: ActivityPropsMap = mapValues(
+const ActivityProps: Record<Activity, ActivityProperties> = mapValues(
   {
     [Activity.LEAGUE_POINTS]: { name: 'League Points' },
     [Activity.BOUNTY_HUNTER_HUNTER]: { name: 'Bounty Hunter (Hunter)' },
@@ -169,7 +153,7 @@ const ActivityProps: ActivityPropsMap = mapValues(
   props => ({ ...props, type: MetricType.ACTIVITY, measure: MetricMeasure.SCORE })
 );
 
-const ComputedMetricProps: ComputedMetricPropsMap = mapValues(
+const ComputedMetricProps: Record<ComputedMetric, ComputedMetricProperties> = mapValues(
   {
     [ComputedMetric.EHP]: { name: 'EHP' },
     [ComputedMetric.EHB]: { name: 'EHB' }
@@ -182,13 +166,13 @@ const MetricProps = {
   ...BossProps,
   ...ActivityProps,
   ...ComputedMetricProps
-};
+} as const;
 
-const METRICS = Object.values(Metric);
-const SKILLS = Object.values(Skill);
-const BOSSES = Object.values(Boss);
-const ACTIVITIES = Object.values(Activity);
-const COMPUTED_METRICS = Object.values(ComputedMetric);
+const METRICS = Object.values(Metric) as Metric[];
+const SKILLS = Object.values(Skill) as Skill[];
+const BOSSES = Object.values(Boss) as Boss[];
+const ACTIVITIES = Object.values(Activity) as Activity[];
+const COMPUTED_METRICS = Object.values(ComputedMetric) as ComputedMetric[];
 
 const REAL_SKILLS = SKILLS.filter(s => s !== Skill.OVERALL);
 const F2P_BOSSES = BOSSES.filter(b => !MetricProps[b].isMembers);

--- a/server/src/utils/metrics.ts
+++ b/server/src/utils/metrics.ts
@@ -1,5 +1,6 @@
 import { capitalize, mapValues } from 'lodash';
 import { Skill, Boss, Activity, ComputedMetric, Metric } from '../prisma/enum-adapter';
+import { MapOf } from './types';
 
 enum MetricType {
   SKILL = 'skill',
@@ -43,7 +44,7 @@ interface ComputedMetricProperties {
   measure: MetricMeasure;
 }
 
-const SkillProps: Record<Skill, SkillProperties> = mapValues(
+const SkillProps: MapOf<Skill, SkillProperties> = mapValues(
   {
     [Skill.OVERALL]: { name: 'Overall', isCombat: false, isMembers: false },
     [Skill.ATTACK]: { name: 'Attack', isCombat: true, isMembers: false },
@@ -73,7 +74,7 @@ const SkillProps: Record<Skill, SkillProperties> = mapValues(
   props => ({ ...props, type: MetricType.SKILL, measure: MetricMeasure.EXPERIENCE })
 );
 
-const BossProps: Record<Boss, BossProperties> = mapValues(
+const BossProps: MapOf<Boss, BossProperties> = mapValues(
   {
     [Boss.ABYSSAL_SIRE]: { name: 'Abyssal Sire', minimumKc: 50, isMembers: true },
     [Boss.ALCHEMICAL_HYDRA]: { name: 'Alchemical Hydra', minimumKc: 50, isMembers: true },
@@ -133,7 +134,7 @@ const BossProps: Record<Boss, BossProperties> = mapValues(
   props => ({ ...props, type: MetricType.BOSS, measure: MetricMeasure.KILLS })
 );
 
-const ActivityProps: Record<Activity, ActivityProperties> = mapValues(
+const ActivityProps: MapOf<Activity, ActivityProperties> = mapValues(
   {
     [Activity.LEAGUE_POINTS]: { name: 'League Points' },
     [Activity.BOUNTY_HUNTER_HUNTER]: { name: 'Bounty Hunter (Hunter)' },
@@ -153,7 +154,7 @@ const ActivityProps: Record<Activity, ActivityProperties> = mapValues(
   props => ({ ...props, type: MetricType.ACTIVITY, measure: MetricMeasure.SCORE })
 );
 
-const ComputedMetricProps: Record<ComputedMetric, ComputedMetricProperties> = mapValues(
+const ComputedMetricProps: MapOf<ComputedMetric, ComputedMetricProperties> = mapValues(
   {
     [ComputedMetric.EHP]: { name: 'EHP' },
     [ComputedMetric.EHB]: { name: 'EHB' }

--- a/server/src/utils/periods.ts
+++ b/server/src/utils/periods.ts
@@ -1,8 +1,9 @@
 import { Period } from '../prisma/enum-adapter';
+import { MapOf } from './types';
 
 const CUSTOM_PERIOD_REGEX = /(\d+y)?(\d+m)?(\d+w)?(\d+d)?(\d+h)?/;
 
-type PeriodPropsMap = Record<Period, { name: string; milliseconds: number }>;
+type PeriodPropsMap = MapOf<Period, { name: string; milliseconds: number }>;
 
 const PeriodProps: PeriodPropsMap = {
   [Period.FIVE_MIN]: { name: '5 Min', milliseconds: 300_000 },

--- a/server/src/utils/periods.ts
+++ b/server/src/utils/periods.ts
@@ -2,12 +2,7 @@ import { Period } from '../prisma/enum-adapter';
 
 const CUSTOM_PERIOD_REGEX = /(\d+y)?(\d+m)?(\d+w)?(\d+d)?(\d+h)?/;
 
-type PeriodPropsMap = {
-  [period in Period]: {
-    name: string;
-    milliseconds: number;
-  };
-};
+type PeriodPropsMap = Record<Period, { name: string; milliseconds: number }>;
 
 const PeriodProps: PeriodPropsMap = {
   [Period.FIVE_MIN]: { name: '5 Min', milliseconds: 300_000 },

--- a/server/src/utils/players.ts
+++ b/server/src/utils/players.ts
@@ -1,14 +1,6 @@
 import { PlayerType, PlayerBuild } from '../prisma/enum-adapter';
 
-type PlayerTypePropsMap = {
-  [playerType in PlayerType]: { name: string };
-};
-
-type PlayerBuildPropsMap = {
-  [playerBuild in PlayerBuild]: { name: string };
-};
-
-const PlayerTypeProps: PlayerTypePropsMap = {
+const PlayerTypeProps: Record<PlayerType, { name: string }> = {
   [PlayerType.UNKNOWN]: { name: 'Unknown' },
   [PlayerType.REGULAR]: { name: 'Regular' },
   [PlayerType.IRONMAN]: { name: 'Ironman' },
@@ -16,7 +8,7 @@ const PlayerTypeProps: PlayerTypePropsMap = {
   [PlayerType.ULTIMATE]: { name: 'Ultimate' }
 };
 
-const PlayerBuildProps: PlayerBuildPropsMap = {
+const PlayerBuildProps: Record<PlayerBuild, { name: string }> = {
   [PlayerBuild.MAIN]: { name: 'Main' },
   [PlayerBuild.F2P]: { name: 'F2P' },
   [PlayerBuild.LVL3]: { name: 'Level 3' },

--- a/server/src/utils/players.ts
+++ b/server/src/utils/players.ts
@@ -1,6 +1,7 @@
 import { PlayerType, PlayerBuild } from '../prisma/enum-adapter';
+import { MapOf } from './types';
 
-const PlayerTypeProps: Record<PlayerType, { name: string }> = {
+const PlayerTypeProps: MapOf<PlayerType, { name: string }> = {
   [PlayerType.UNKNOWN]: { name: 'Unknown' },
   [PlayerType.REGULAR]: { name: 'Regular' },
   [PlayerType.IRONMAN]: { name: 'Ironman' },
@@ -8,7 +9,7 @@ const PlayerTypeProps: Record<PlayerType, { name: string }> = {
   [PlayerType.ULTIMATE]: { name: 'Ultimate' }
 };
 
-const PlayerBuildProps: Record<PlayerBuild, { name: string }> = {
+const PlayerBuildProps: MapOf<PlayerBuild, { name: string }> = {
   [PlayerBuild.MAIN]: { name: 'Main' },
   [PlayerBuild.F2P]: { name: 'F2P' },
   [PlayerBuild.LVL3]: { name: 'Level 3' },

--- a/server/src/utils/types.ts
+++ b/server/src/utils/types.ts
@@ -1,3 +1,10 @@
+// This is an exact copy of the native Typescript type "Record"
+// But since that word is already used for WOM Player Records,
+// the client-js bundle gets confused, so this renames it to MapOf
+export type MapOf<K extends keyof any, T> = {
+  [P in K]: T;
+};
+
 export * from '../api/modules/achievements/achievement.types';
 export * from '../api/modules/competitions/competition.types';
 export * from '../api/modules/deltas/delta.types';


### PR DESCRIPTION
- Replaces Typescript's Native type `Record` for `MapOf` (Record naming conflicts with our own WOM Record types)
- Replaces usages of `{ [x in UnionType]: SomeValue }` for `MapOf<UnionType, SomeValue>`