### PR TITLE
[client-js] Add decimal precision to `formatNumber` and fix `parseMetricAbbreviation` [2.0.0-beta.7]

### DIFF
--- a/client-js/package-lock.json
+++ b/client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "2.0.0-beta.6",
+  "version": "2.0.0-beta.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wise-old-man/utils",
-      "version": "2.0.0-beta.6",
+      "version": "2.0.0-beta.7",
       "license": "ISC",
       "dependencies": {
         "axios": "^0.27.2",

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "2.0.0-beta.6",
+  "version": "2.0.0-beta.7",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/server/__tests__/suites/unit/strings.test.ts
+++ b/server/__tests__/suites/unit/strings.test.ts
@@ -13,9 +13,21 @@ describe('Util - Strings', () => {
 
     expect(formatNumber(-1000, true)).toBe('-1,000');
     expect(formatNumber(10_000, true)).toBe('10k');
+    expect(formatNumber(12_523, true)).toBe('12.52k');
     expect(formatNumber(9_123_000, true)).toBe('9123k');
-    expect(formatNumber(-10_500_000, true)).toBe('-10.5m');
+    expect(formatNumber(10_000_000, true)).toBe('10m');
+    expect(formatNumber(-10_500_000, true)).toBe('-10.50m');
     expect(formatNumber(1_123_456_000, true)).toBe('1.12b');
+    expect(formatNumber(-5_567_175_000, true)).toBe('-5.57b');
+    expect(formatNumber(10_000_000_000, true)).toBe('10b');
+
+    expect(formatNumber(3456, true, 3)).toBe('3,456');
+    expect(formatNumber(10_564, true, 3)).toBe('10.564k');
+    expect(formatNumber(10_000, true, 3)).toBe('10k');
+    expect(formatNumber(200_453, true, 3)).toBe('200.453k');
+    expect(formatNumber(10_000_000, true, 3)).toBe('10m');
+    expect(formatNumber(12_967_712, true, 3)).toBe('12.968m');
+    expect(formatNumber(2_436_267_123, true, 3)).toBe('2.436b');
   });
 
   test('padNumber', () => {

--- a/server/src/api/util/middlewares.ts
+++ b/server/src/api/util/middlewares.ts
@@ -10,7 +10,7 @@ function metricAbbreviation(req, res, next) {
     const metric = req.body.metric.toLowerCase();
 
     if (!isMetric(metric)) {
-      req.body.metric = parseMetricAbbreviation(metric);
+      req.body.metric = parseMetricAbbreviation(metric) || metric;
     }
   }
 
@@ -19,7 +19,7 @@ function metricAbbreviation(req, res, next) {
     const metric = req.query.metric.toLowerCase();
 
     if (!isMetric(metric)) {
-      req.query.metric = parseMetricAbbreviation(metric);
+      req.query.metric = parseMetricAbbreviation(metric) || metric;
     }
   }
 

--- a/server/src/utils/metrics.ts
+++ b/server/src/utils/metrics.ts
@@ -188,8 +188,8 @@ function findMetric(metricName: string): Metric | null {
   return null;
 }
 
-function isMetric(metricString: string): metricString is Metric {
-  return metricString in MetricProps;
+function isMetric(metric: Metric | string): metric is Metric {
+  return metric in MetricProps;
 }
 
 function isSkill(metric: Metric | string): metric is Skill {
@@ -234,12 +234,18 @@ function getParentEfficiencyMetric(metric: Metric) {
   return null;
 }
 
-function parseMetricAbbreviation(abbreviation: string): string | null {
+function parseMetricAbbreviation(abbreviation: string): Metric | null {
   if (!abbreviation || abbreviation.length === 0) {
     return null;
   }
 
-  switch (abbreviation.toLowerCase()) {
+  const fixedAbbreviation = abbreviation.toLowerCase();
+
+  if (isMetric(fixedAbbreviation)) {
+    return fixedAbbreviation;
+  }
+
+  switch (fixedAbbreviation) {
     // Bosses
     case 'sire':
       return Metric.ABYSSAL_SIRE;
@@ -541,7 +547,7 @@ function parseMetricAbbreviation(abbreviation: string): string | null {
       return Metric.CONSTRUCTION;
 
     default:
-      return abbreviation;
+      return null;
   }
 }
 

--- a/server/src/utils/strings.ts
+++ b/server/src/utils/strings.ts
@@ -1,26 +1,35 @@
-function formatNumber(num: number, withLetters = false) {
+function formatNumber(num: number, withLetters = false, decimalPrecision = 2) {
   if (num === undefined || num === null) return -1;
 
   // If number is float
   if (num % 1 !== 0) {
-    return (Math.round(num * 100) / 100).toString().replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1,');
+    return (Math.round(num * 100) / 100).toLocaleString();
   }
 
   if ((num < 10000 && num > -10000) || !withLetters) {
-    return num.toString().replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1,');
+    return num.toLocaleString();
   }
 
   // < 10 million
   if (num < 10_000_000 && num > -10_000_000) {
-    return `${Math.floor(num / 1000)}k`;
+    // If has no decimals, return as whole number instead (10.00k => 10k)
+    if ((num / 1000) % 1 === 0) return `${num / 1000}k`;
+
+    return `${(num / 1000).toFixed(decimalPrecision)}k`;
   }
 
   // < 1 billion
   if (num < 1_000_000_000 && num > -1_000_000_000) {
-    return `${Math.round((num / 1000000 + Number.EPSILON) * 100) / 100}m`;
+    // If has no decimals, return as whole number instead (10.00m => 10m)
+    if ((num / 1_000_000) % 1 === 0) return `${num / 1_000_000}m`;
+
+    return `${(num / 1_000_000).toFixed(decimalPrecision)}m`;
   }
 
-  return `${Math.round((num / 1000000000 + Number.EPSILON) * 100) / 100}b`;
+  // If has no decimals, return as whole number instead (10.00b => 10b)
+  if ((num / 1_000_000_000) % 1 === 0) return `${num / 1_000_000_000}b`;
+
+  return `${(num / 1_000_000_000).toFixed(decimalPrecision)}b`;
 }
 
 function padNumber(value: number): string {


### PR DESCRIPTION
- `formatNumber` now accepts a decimal precision arg
- `parseMetricAbbreviation` now guarantees a return type of Metric or null