### PR TITLE
[v2] Add Activity minimum values

### DIFF
--- a/client-js/package-lock.json
+++ b/client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0-beta.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wise-old-man/utils",
-      "version": "2.0.0-beta.8",
+      "version": "2.0.0-beta.9",
       "license": "ISC",
       "dependencies": {
         "axios": "^0.27.2",

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0-beta.9",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/server/__tests__/suites/integration/deltas.test.ts
+++ b/server/__tests__/suites/integration/deltas.test.ts
@@ -136,7 +136,8 @@ describe('Deltas API', () => {
         { metric: Metric.LAST_MAN_STANDING, value: 450 },
         { metric: Metric.NEX, value: 54 },
         { metric: Metric.TZKAL_ZUK, value: 1 },
-        { metric: Metric.SOUL_WARS_ZEAL, value: 7 }
+        { metric: Metric.SOUL_WARS_ZEAL, value: 203 },
+        { metric: Metric.BOUNTY_HUNTER_HUNTER, value: 5 }
       ]);
 
       registerHiscoresMock(axiosMock, {
@@ -167,7 +168,8 @@ describe('Deltas API', () => {
 
       expect(dayDeltas.nex).toBe(1);
       expect(dayDeltas.tzkal_zuk).toBe(1);
-      expect(dayDeltas.soul_wars_zeal).toBe(7); // soul wars went from -1 (unranked) to 7, make sure it's 7 gained, not 8
+      expect(dayDeltas.bounty_hunter_hunter).toBe(5);
+      expect(dayDeltas.soul_wars_zeal).toBe(4); // soul wars went from -1 (unranked) to 203 (min=200), make sure it's 4 gained, not 204
       expect(dayDeltas.last_man_standing).toBe(0); // LMS went DOWN from 500 to 450, don't show negative gains
       expect(dayDeltas.ehb).toBeLessThan(monthDeltas.ehb); // gained less boss kc, expect ehb gains to be lesser
       expect(parseInt(dayDeltas.overall.toString())).toBe(0); // overall went from -1 to 300m, show 0 gains
@@ -535,7 +537,8 @@ describe('Deltas API', () => {
         { metric: Metric.LAST_MAN_STANDING, value: 450 },
         { metric: Metric.NEX, value: 54 },
         { metric: Metric.TZKAL_ZUK, value: 1 },
-        { metric: Metric.SOUL_WARS_ZEAL, value: 7 }
+        { metric: Metric.SOUL_WARS_ZEAL, value: 203 },
+        { metric: Metric.BOUNTY_HUNTER_HUNTER, value: 5 }
       ]);
 
       // Setup mocks for HCIM for the second test player later on (hydrox6)

--- a/server/__tests__/suites/integration/snapshots.test.ts
+++ b/server/__tests__/suites/integration/snapshots.test.ts
@@ -273,6 +273,14 @@ describe('Snapshots API', () => {
       expect(utils.hasNegativeGains(globalData.snapshots[1], globalData.snapshots[0])).toBe(false);
       // Positive changes between these
       expect(utils.hasNegativeGains(globalData.snapshots[10], globalData.snapshots[0])).toBe(false);
+      // Negative last_man_standing gains
+      const negativeLmsStart = { ...globalData.snapshots[0], last_man_standingScore: 1000 };
+      const negativeLmsEnd = { ...globalData.snapshots[0], last_man_standingScore: 700 };
+      expect(utils.hasNegativeGains(negativeLmsStart, negativeLmsEnd)).toBe(false); // LMS score can decrease, so it shouldn't count as negative gains
+      // Negative pvp_arena gains
+      const negativePvpArenaStart = { ...globalData.snapshots[0], pvp_arenaScore: 1000 };
+      const negativePvpArenaEnd = { ...globalData.snapshots[0], pvp_arenaScore: 700 };
+      expect(utils.hasNegativeGains(negativePvpArenaStart, negativePvpArenaEnd)).toBe(false); // PVP Arena score can decrease, so it shouldn't count as negative gains
       // Negative firemaking gains
       const negativeFiremaking = { ...globalData.snapshots[0], firemakingExperience: 1 };
       expect(utils.hasNegativeGains(globalData.snapshots[10], negativeFiremaking)).toBe(true);

--- a/server/__tests__/suites/unit/metrics.test.ts
+++ b/server/__tests__/suites/unit/metrics.test.ts
@@ -11,7 +11,7 @@ import {
   getMetricValueKey,
   getMetricMeasure,
   getMetricName,
-  getMinimumBossKc,
+  getMinimumValue,
   getParentEfficiencyMetric,
   parseMetricAbbreviation,
   MetricMeasure
@@ -89,11 +89,14 @@ describe('Util - Metrics', () => {
     expect(getMetricName(Metric.SOUL_WARS_ZEAL)).toBe('Soul Wars Zeal');
   });
 
-  test('getMinimumBossKc', () => {
-    expect(getMinimumBossKc(Metric.ATTACK)).toBe(0);
-    expect(getMinimumBossKc(Metric.ZALCANO)).toBe(50);
-    expect(getMinimumBossKc(Metric.TZTOK_JAD)).toBe(5);
-    expect(getMinimumBossKc(Metric.TZKAL_ZUK)).toBe(1);
+  test('getMinimumValue', () => {
+    expect(getMinimumValue(Metric.ATTACK)).toBe(1);
+    expect(getMinimumValue(Metric.ZALCANO)).toBe(50);
+    expect(getMinimumValue(Metric.TZTOK_JAD)).toBe(5);
+    expect(getMinimumValue(Metric.TZKAL_ZUK)).toBe(1);
+    expect(getMinimumValue(Metric.CLUE_SCROLLS_ALL)).toBe(1);
+    expect(getMinimumValue(Metric.SOUL_WARS_ZEAL)).toBe(200);
+    expect(getMinimumValue(Metric.LAST_MAN_STANDING)).toBe(500);
   });
 
   test('getParentEfficiencyMetric', () => {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.0.10",
+      "version": "2.0.11",
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^4.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/modules/deltas/delta.utils.ts
+++ b/server/src/api/modules/deltas/delta.utils.ts
@@ -12,7 +12,7 @@ import {
   ComputedMetric,
   isSkill,
   isComputedMetric,
-  getMinimumBossKc,
+  getMinimumValue,
   getMetricRankKey,
   getMetricValueKey,
   round
@@ -91,7 +91,7 @@ function calculateRankDiff(metric: Metric, startSnapshot: Snapshot, endSnapshot:
  * - Output: { start: -1, end:  5566255, gained: 0 }
  */
 function calculateValueDiff(metric: Metric, startSnapshot: Snapshot, endSnapshot: Snapshot) {
-  const minimumValue = getMinimumBossKc(metric);
+  const minimumValue = getMinimumValue(metric);
   const valueKey = getMetricValueKey(metric);
 
   const startValue = parseNum(

--- a/server/src/api/modules/snapshots/snapshot.utils.ts
+++ b/server/src/api/modules/snapshots/snapshot.utils.ts
@@ -157,25 +157,21 @@ function hasChanged(before: Snapshot, after: Snapshot): boolean {
   if (!after) return false;
 
   // EHP and EHB can fluctuate without the player's envolvement
-  const keysToIgnore = ['ehpValue', 'ehbValue'];
+  const metricsToIgnore = [Metric.EHP, Metric.EHB];
+  const isValidKey = (key: string) => !metricsToIgnore.map(getMetricValueKey).includes(key);
 
-  const isValidKey = key => !keysToIgnore.includes(key);
-  const keys = METRICS.map(m => getMetricValueKey(m));
-
-  return keys.some(k => isValidKey(k) && after[k] > -1 && after[k] > before[k]);
+  return METRICS.map(getMetricValueKey).some(k => isValidKey(k) && after[k] > -1 && after[k] > before[k]);
 }
 
 /**
  * Checks whether two snapshots have negative gains in between.
  */
 function hasNegativeGains(before: Snapshot, after: Snapshot): boolean {
-  // Last man standing scores, ehp and ehb can fluctuate overtime
-  const keysToIgnore = ['last_man_standingScore', 'ehpValue', 'ehbValue'];
+  // LMS scores, PVP ARENA scores, EHP and EHB can fluctuate overtime
+  const metricsToIgnore = [Metric.EHP, Metric.EHB, Metric.LAST_MAN_STANDING, Metric.PVP_ARENA];
+  const isValidKey = (key: string) => !metricsToIgnore.map(getMetricValueKey).includes(key);
 
-  const isValidKey = key => !keysToIgnore.includes(key);
-  const keys = METRICS.map(m => getMetricValueKey(m));
-
-  return keys.some(k => isValidKey(k) && after[k] > -1 && after[k] < before[k]);
+  return METRICS.map(getMetricValueKey).some(k => isValidKey(k) && after[k] > -1 && after[k] < before[k]);
 }
 
 function average(snapshots: Snapshot[]): Snapshot {

--- a/server/src/utils/metrics.ts
+++ b/server/src/utils/metrics.ts
@@ -26,7 +26,7 @@ interface SkillProperties {
 
 interface BossProperties {
   name: string;
-  minimumKc: number;
+  minimumValue: number;
   isMembers: boolean;
   type: MetricType;
   measure: MetricMeasure;
@@ -34,6 +34,7 @@ interface BossProperties {
 
 interface ActivityProperties {
   name: string;
+  minimumValue: number;
   type: MetricType;
   measure: MetricMeasure;
 }
@@ -46,92 +47,100 @@ interface ComputedMetricProperties {
 
 const SkillProps: MapOf<Skill, SkillProperties> = mapValues(
   {
-    [Skill.OVERALL]: { name: 'Overall', isCombat: false, isMembers: false },
-    [Skill.ATTACK]: { name: 'Attack', isCombat: true, isMembers: false },
-    [Skill.DEFENCE]: { name: 'Defence', isCombat: true, isMembers: false },
-    [Skill.STRENGTH]: { name: 'Strength', isCombat: true, isMembers: false },
-    [Skill.HITPOINTS]: { name: 'Hitpoints', isCombat: true, isMembers: false },
-    [Skill.RANGED]: { name: 'Ranged', isCombat: true, isMembers: false },
-    [Skill.PRAYER]: { name: 'Prayer', isCombat: true, isMembers: false },
-    [Skill.MAGIC]: { name: 'Magic', isCombat: true, isMembers: false },
-    [Skill.COOKING]: { name: 'Cooking', isCombat: false, isMembers: false },
-    [Skill.WOODCUTTING]: { name: 'Woodcutting', isCombat: false, isMembers: false },
-    [Skill.FLETCHING]: { name: 'Fletching', isCombat: false, isMembers: true },
-    [Skill.FISHING]: { name: 'Fishing', isCombat: false, isMembers: false },
-    [Skill.FIREMAKING]: { name: 'Firemaking', isCombat: false, isMembers: false },
-    [Skill.CRAFTING]: { name: 'Crafting', isCombat: false, isMembers: false },
-    [Skill.SMITHING]: { name: 'Smithing', isCombat: false, isMembers: false },
-    [Skill.MINING]: { name: 'Mining', isCombat: false, isMembers: false },
-    [Skill.HERBLORE]: { name: 'Herblore', isCombat: false, isMembers: true },
-    [Skill.AGILITY]: { name: 'Agility', isCombat: false, isMembers: true },
-    [Skill.THIEVING]: { name: 'Thieving', isCombat: false, isMembers: true },
-    [Skill.SLAYER]: { name: 'Slayer', isCombat: false, isMembers: true },
-    [Skill.FARMING]: { name: 'Farming', isCombat: false, isMembers: true },
-    [Skill.RUNECRAFTING]: { name: 'Runecrafting', isCombat: false, isMembers: false },
-    [Skill.HUNTER]: { name: 'Hunter', isCombat: false, isMembers: true },
-    [Skill.CONSTRUCTION]: { name: 'Construction', isCombat: false, isMembers: false }
+    [Skill.OVERALL]: { name: 'Overall' },
+    [Skill.ATTACK]: { name: 'Attack', isCombat: true },
+    [Skill.DEFENCE]: { name: 'Defence', isCombat: true },
+    [Skill.STRENGTH]: { name: 'Strength', isCombat: true },
+    [Skill.HITPOINTS]: { name: 'Hitpoints', isCombat: true },
+    [Skill.RANGED]: { name: 'Ranged', isCombat: true },
+    [Skill.PRAYER]: { name: 'Prayer', isCombat: true },
+    [Skill.MAGIC]: { name: 'Magic', isCombat: true },
+    [Skill.COOKING]: { name: 'Cooking' },
+    [Skill.WOODCUTTING]: { name: 'Woodcutting' },
+    [Skill.FLETCHING]: { name: 'Fletching', isMembers: true },
+    [Skill.FISHING]: { name: 'Fishing' },
+    [Skill.FIREMAKING]: { name: 'Firemaking' },
+    [Skill.CRAFTING]: { name: 'Crafting' },
+    [Skill.SMITHING]: { name: 'Smithing' },
+    [Skill.MINING]: { name: 'Mining' },
+    [Skill.HERBLORE]: { name: 'Herblore', isMembers: true },
+    [Skill.AGILITY]: { name: 'Agility', isMembers: true },
+    [Skill.THIEVING]: { name: 'Thieving', isMembers: true },
+    [Skill.SLAYER]: { name: 'Slayer', isMembers: true },
+    [Skill.FARMING]: { name: 'Farming', isMembers: true },
+    [Skill.RUNECRAFTING]: { name: 'Runecrafting' },
+    [Skill.HUNTER]: { name: 'Hunter', isMembers: true },
+    [Skill.CONSTRUCTION]: { name: 'Construction', isMembers: true }
   },
-  props => ({ ...props, type: MetricType.SKILL, measure: MetricMeasure.EXPERIENCE })
+  props => ({
+    ...props,
+    type: MetricType.SKILL,
+    measure: MetricMeasure.EXPERIENCE,
+    isCombat: 'isCombat' in props ? props.isCombat : false,
+    isMembers: 'isMembers' in props ? props.isMembers : false
+  })
 );
 
 const BossProps: MapOf<Boss, BossProperties> = mapValues(
   {
-    [Boss.ABYSSAL_SIRE]: { name: 'Abyssal Sire', minimumKc: 50, isMembers: true },
-    [Boss.ALCHEMICAL_HYDRA]: { name: 'Alchemical Hydra', minimumKc: 50, isMembers: true },
-    [Boss.BARROWS_CHESTS]: { name: 'Barrows Chests', minimumKc: 50, isMembers: true },
-    [Boss.BRYOPHYTA]: { name: 'Bryophyta', minimumKc: 5, isMembers: false },
-    [Boss.CALLISTO]: { name: 'Callisto', minimumKc: 50, isMembers: true },
-    [Boss.CERBERUS]: { name: 'Cerberus', minimumKc: 50, isMembers: true },
-    [Boss.CHAMBERS_OF_XERIC]: { name: 'Chambers Of Xeric', minimumKc: 50, isMembers: true },
-    [Boss.CHAMBERS_OF_XERIC_CM]: { name: 'Chambers Of Xeric (CM)', minimumKc: 5, isMembers: true },
-    [Boss.CHAOS_ELEMENTAL]: { name: 'Chaos Elemental', minimumKc: 50, isMembers: true },
-    [Boss.CHAOS_FANATIC]: { name: 'Chaos Fanatic', minimumKc: 50, isMembers: true },
-    [Boss.COMMANDER_ZILYANA]: { name: 'Commander Zilyana', minimumKc: 50, isMembers: true },
-    [Boss.CORPOREAL_BEAST]: { name: 'Corporeal Beast', minimumKc: 50, isMembers: true },
-    [Boss.CRAZY_ARCHAEOLOGIST]: { name: 'Crazy Archaeologist', minimumKc: 50, isMembers: true },
-    [Boss.DAGANNOTH_PRIME]: { name: 'Dagannoth Prime', minimumKc: 50, isMembers: true },
-    [Boss.DAGANNOTH_REX]: { name: 'Dagannoth Rex', minimumKc: 50, isMembers: true },
-    [Boss.DAGANNOTH_SUPREME]: { name: 'Dagannoth Supreme', minimumKc: 50, isMembers: true },
-    [Boss.DERANGED_ARCHAEOLOGIST]: { name: 'Deranged Archaeologist', minimumKc: 50, isMembers: true },
-    [Boss.GENERAL_GRAARDOR]: { name: 'General Graardor', minimumKc: 50, isMembers: true },
-    [Boss.GIANT_MOLE]: { name: 'Giant Mole', minimumKc: 50, isMembers: true },
-    [Boss.GROTESQUE_GUARDIANS]: { name: 'Grotesque Guardians', minimumKc: 50, isMembers: true },
-    [Boss.HESPORI]: { name: 'Hespori', minimumKc: 5, isMembers: true },
-    [Boss.KALPHITE_QUEEN]: { name: 'Kalphite Queen', minimumKc: 50, isMembers: true },
-    [Boss.KING_BLACK_DRAGON]: { name: 'King Black Dragon', minimumKc: 50, isMembers: true },
-    [Boss.KRAKEN]: { name: 'Kraken', minimumKc: 50, isMembers: true },
-    [Boss.KREEARRA]: { name: "Kree'Arra", minimumKc: 50, isMembers: true },
-    [Boss.KRIL_TSUTSAROTH]: { name: "K'ril Tsutsaroth", minimumKc: 50, isMembers: true },
-    [Boss.MIMIC]: { name: 'Mimic', minimumKc: 1, isMembers: true },
-    [Boss.NEX]: { name: 'Nex', minimumKc: 50, isMembers: true },
-    [Boss.NIGHTMARE]: { name: 'Nightmare', minimumKc: 50, isMembers: true },
-    [Boss.PHOSANIS_NIGHTMARE]: { name: "Phosani's Nightmare", minimumKc: 50, isMembers: true },
-    [Boss.OBOR]: { name: 'Obor', minimumKc: 5, isMembers: false },
-    [Boss.SARACHNIS]: { name: 'Sarachnis', minimumKc: 50, isMembers: true },
-    [Boss.SKOTIZO]: { name: 'Skotizo', minimumKc: 5, isMembers: true },
-    [Boss.SCORPIA]: { name: 'Scorpia', minimumKc: 50, isMembers: true },
-    [Boss.TEMPOROSS]: { name: 'Tempoross', minimumKc: 50, isMembers: true },
-    [Boss.THE_GAUNTLET]: { name: 'The Gauntlet', minimumKc: 50, isMembers: true },
-    [Boss.THE_CORRUPTED_GAUNTLET]: { name: 'The Corrupted Gauntlet', minimumKc: 5, isMembers: true },
-    [Boss.THEATRE_OF_BLOOD]: { name: 'Theatre Of Blood', minimumKc: 50, isMembers: true },
-    [Boss.THEATRE_OF_BLOOD_HARD_MODE]: { name: 'Theatre Of Blood (HM)', minimumKc: 50, isMembers: true },
-    [Boss.THERMONUCLEAR_SMOKE_DEVIL]: { name: 'Thermonuclear Smoke Devil', minimumKc: 50, isMembers: true },
-    [Boss.TOMBS_OF_AMASCUT]: { name: 'Tombs of Amascut', minimumKc: 50, isMembers: true },
-    [Boss.TOMBS_OF_AMASCUT_EXPERT]: {
-      name: 'Tombs of Amascut (Expert Mode)',
-      minimumKc: 50,
-      isMembers: true
-    },
-    [Boss.TZKAL_ZUK]: { name: 'TzKal-Zuk', minimumKc: 1, isMembers: true },
-    [Boss.TZTOK_JAD]: { name: 'TzTok-Jad', minimumKc: 5, isMembers: true },
-    [Boss.VENENATIS]: { name: 'Venenatis', minimumKc: 50, isMembers: true },
-    [Boss.VETION]: { name: "Vet'ion", minimumKc: 50, isMembers: true },
-    [Boss.VORKATH]: { name: 'Vorkath', minimumKc: 50, isMembers: true },
-    [Boss.WINTERTODT]: { name: 'Wintertodt', minimumKc: 50, isMembers: true },
-    [Boss.ZALCANO]: { name: 'Zalcano', minimumKc: 50, isMembers: true },
-    [Boss.ZULRAH]: { name: 'Zulrah', minimumKc: 50, isMembers: true }
+    [Boss.ABYSSAL_SIRE]: { name: 'Abyssal Sire' },
+    [Boss.ALCHEMICAL_HYDRA]: { name: 'Alchemical Hydra' },
+    [Boss.BARROWS_CHESTS]: { name: 'Barrows Chests' },
+    [Boss.BRYOPHYTA]: { name: 'Bryophyta', minimumValue: 5, isMembers: false },
+    [Boss.CALLISTO]: { name: 'Callisto' },
+    [Boss.CERBERUS]: { name: 'Cerberus' },
+    [Boss.CHAMBERS_OF_XERIC]: { name: 'Chambers Of Xeric' },
+    [Boss.CHAMBERS_OF_XERIC_CM]: { name: 'Chambers Of Xeric (CM)', minimumValue: 5 },
+    [Boss.CHAOS_ELEMENTAL]: { name: 'Chaos Elemental' },
+    [Boss.CHAOS_FANATIC]: { name: 'Chaos Fanatic' },
+    [Boss.COMMANDER_ZILYANA]: { name: 'Commander Zilyana' },
+    [Boss.CORPOREAL_BEAST]: { name: 'Corporeal Beast' },
+    [Boss.CRAZY_ARCHAEOLOGIST]: { name: 'Crazy Archaeologist' },
+    [Boss.DAGANNOTH_PRIME]: { name: 'Dagannoth Prime' },
+    [Boss.DAGANNOTH_REX]: { name: 'Dagannoth Rex' },
+    [Boss.DAGANNOTH_SUPREME]: { name: 'Dagannoth Supreme' },
+    [Boss.DERANGED_ARCHAEOLOGIST]: { name: 'Deranged Archaeologist' },
+    [Boss.GENERAL_GRAARDOR]: { name: 'General Graardor' },
+    [Boss.GIANT_MOLE]: { name: 'Giant Mole' },
+    [Boss.GROTESQUE_GUARDIANS]: { name: 'Grotesque Guardians' },
+    [Boss.HESPORI]: { name: 'Hespori', minimumValue: 5 },
+    [Boss.KALPHITE_QUEEN]: { name: 'Kalphite Queen' },
+    [Boss.KING_BLACK_DRAGON]: { name: 'King Black Dragon' },
+    [Boss.KRAKEN]: { name: 'Kraken' },
+    [Boss.KREEARRA]: { name: "Kree'Arra" },
+    [Boss.KRIL_TSUTSAROTH]: { name: "K'ril Tsutsaroth" },
+    [Boss.MIMIC]: { name: 'Mimic', minimumValue: 1 },
+    [Boss.NEX]: { name: 'Nex' },
+    [Boss.NIGHTMARE]: { name: 'Nightmare' },
+    [Boss.PHOSANIS_NIGHTMARE]: { name: "Phosani's Nightmare" },
+    [Boss.OBOR]: { name: 'Obor', minimumValue: 5, isMembers: false },
+    [Boss.SARACHNIS]: { name: 'Sarachnis' },
+    [Boss.SKOTIZO]: { name: 'Skotizo', minimumValue: 5 },
+    [Boss.SCORPIA]: { name: 'Scorpia' },
+    [Boss.TEMPOROSS]: { name: 'Tempoross' },
+    [Boss.THE_GAUNTLET]: { name: 'The Gauntlet' },
+    [Boss.THE_CORRUPTED_GAUNTLET]: { name: 'The Corrupted Gauntlet', minimumValue: 5 },
+    [Boss.THEATRE_OF_BLOOD]: { name: 'Theatre Of Blood' },
+    [Boss.THEATRE_OF_BLOOD_HARD_MODE]: { name: 'Theatre Of Blood (HM)' },
+    [Boss.THERMONUCLEAR_SMOKE_DEVIL]: { name: 'Thermonuclear Smoke Devil' },
+    [Boss.TOMBS_OF_AMASCUT]: { name: 'Tombs of Amascut' },
+    [Boss.TOMBS_OF_AMASCUT_EXPERT]: { name: 'Tombs of Amascut (Expert Mode)' },
+    [Boss.TZKAL_ZUK]: { name: 'TzKal-Zuk', minimumValue: 1 },
+    [Boss.TZTOK_JAD]: { name: 'TzTok-Jad', minimumValue: 5 },
+    [Boss.VENENATIS]: { name: 'Venenatis' },
+    [Boss.VETION]: { name: "Vet'ion" },
+    [Boss.VORKATH]: { name: 'Vorkath' },
+    [Boss.WINTERTODT]: { name: 'Wintertodt' },
+    [Boss.ZALCANO]: { name: 'Zalcano' },
+    [Boss.ZULRAH]: { name: 'Zulrah' }
   },
-  props => ({ ...props, type: MetricType.BOSS, measure: MetricMeasure.KILLS })
+  props => ({
+    ...props,
+    type: MetricType.BOSS,
+    measure: MetricMeasure.KILLS,
+    isMembers: 'isMembers' in props ? props.isMembers : true,
+    minimumValue: 'minimumValue' in props ? props.minimumValue : 50
+  })
 );
 
 const ActivityProps: MapOf<Activity, ActivityProperties> = mapValues(
@@ -146,12 +155,17 @@ const ActivityProps: MapOf<Activity, ActivityProperties> = mapValues(
     [Activity.CLUE_SCROLLS_HARD]: { name: 'Clue Scrolls (Hard)' },
     [Activity.CLUE_SCROLLS_ELITE]: { name: 'Clue Scrolls (Elite)' },
     [Activity.CLUE_SCROLLS_MASTER]: { name: 'Clue Scrolls (Master)' },
-    [Activity.LAST_MAN_STANDING]: { name: 'Last Man Standing' },
-    [Activity.PVP_ARENA]: { name: 'PvP Arena' },
-    [Activity.SOUL_WARS_ZEAL]: { name: 'Soul Wars Zeal' },
-    [Activity.GUARDIANS_OF_THE_RIFT]: { name: 'Guardians of the Rift' }
+    [Activity.LAST_MAN_STANDING]: { name: 'Last Man Standing', minimumValue: 500 },
+    [Activity.PVP_ARENA]: { name: 'PvP Arena', minimumValue: 2525 },
+    [Activity.SOUL_WARS_ZEAL]: { name: 'Soul Wars Zeal', minimumValue: 200 },
+    [Activity.GUARDIANS_OF_THE_RIFT]: { name: 'Guardians of the Rift', minimumValue: 2 }
   },
-  props => ({ ...props, type: MetricType.ACTIVITY, measure: MetricMeasure.SCORE })
+  props => ({
+    ...props,
+    type: MetricType.ACTIVITY,
+    measure: MetricMeasure.SCORE,
+    minimumValue: 'minimumValue' in props ? props.minimumValue : 1
+  })
 );
 
 const ComputedMetricProps: MapOf<ComputedMetric, ComputedMetricProperties> = mapValues(
@@ -224,8 +238,8 @@ function getMetricName(metric: Metric) {
   return MetricProps[metric].name;
 }
 
-function getMinimumBossKc(metric: Metric) {
-  return isBoss(metric) ? MetricProps[metric as Boss].minimumKc : 0;
+function getMinimumValue(metric: Metric) {
+  return isBoss(metric) || isActivity(metric) ? MetricProps[metric].minimumValue : 1;
 }
 
 function getParentEfficiencyMetric(metric: Metric) {
@@ -579,7 +593,7 @@ export {
   getMetricValueKey,
   getMetricMeasure,
   getMetricName,
-  getMinimumBossKc,
+  getMinimumValue,
   getParentEfficiencyMetric,
   isMetric,
   isSkill,


### PR DESCRIPTION
- Adds Activity minimum values:
  - LMS: 500
  - PvP Arena: 2525
  - Soul Wars Zeal: 200
  - Guardians of the Rift: 2
- Adds defaults for Skill/Boss/Activity/Computed props
- Changed `getMinimumBossKc` to `getMinimumValue` (now also accepts activities)
- Adds PvP Arena to the list of possibly decayed metrics (do not flag a player if decreased)
