### PR TITLE
[v2] Add "status" query param to `/players/../competitions` and  `/players/../competitions/standings` 

### DIFF
--- a/client-js/package-lock.json
+++ b/client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wise-old-man/utils",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "ISC",
       "dependencies": {
         "axios": "^0.27.2",

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/client-js/src/api-types.ts
+++ b/client-js/src/api-types.ts
@@ -140,6 +140,14 @@ export interface RecordLeaderboardFilter extends BasePlayerFilter {
  * Player Client Types
  */
 
+export interface PlayerCompetitionsFilter {
+  status?: CompetitionStatus;
+}
+
+export interface PlayerCompetitionStandingsFilter {
+  status: Exclude<CompetitionStatus, CompetitionStatus.UPCOMING>;
+}
+
 export interface PlayerRecordsFilter {
   period: Period | string;
   metric: Metric;

--- a/client-js/src/clients/PlayersClient.ts
+++ b/client-js/src/clients/PlayersClient.ts
@@ -3,7 +3,8 @@ import type {
   PlayerRecordsFilter,
   AssertPlayerTypeResponse,
   GetPlayerGainsResponse,
-  GenericCountMessageResponse
+  GenericCountMessageResponse,
+  PlayerCompetitionsFilter
 } from '../api-types';
 import {
   PlayerResolvable,
@@ -84,20 +85,25 @@ export default class PlayersClient extends BaseAPIClient {
    * Fetches all of the player's competition participations.
    * @returns A list of participations, with the respective competition included.
    */
-  getPlayerCompetitions(player: PlayerResolvable, pagination?: PaginationOptions) {
-    return this.getRequest<ParticipationWithCompetition[]>(
-      `${getPlayerURL(player)}/competitions`,
-      pagination
-    );
+  getPlayerCompetitions(
+    player: PlayerResolvable,
+    filter?: PlayerCompetitionsFilter,
+    pagination?: PaginationOptions
+  ) {
+    return this.getRequest<ParticipationWithCompetition[]>(`${getPlayerURL(player)}/competitions`, {
+      ...filter,
+      ...pagination
+    });
   }
 
   /**
    * Fetches all of the player's competition participations' standings.
    * @returns A list of participations, with the respective competition, rank and progress included.
    */
-  getPlayerCompetitionStandings(player: PlayerResolvable) {
+  getPlayerCompetitionStandings(player: PlayerResolvable, filter: PlayerCompetitionsFilter) {
     return this.getRequest<ParticipationWithCompetitionAndStandings[]>(
-      `${getPlayerURL(player)}/competitions/standings`
+      `${getPlayerURL(player)}/competitions/standings`,
+      filter
     );
   }
 

--- a/server/__tests__/suites/integration/competitions.test.ts
+++ b/server/__tests__/suites/integration/competitions.test.ts
@@ -2813,22 +2813,47 @@ describe('Competition API', () => {
 
   describe('12 - List Player Competition Standings', () => {
     it('should not list player competition standings (player not found)', async () => {
-      const usernameResponse = await api.get(`/players/raaandooom/competitions/standings`);
+      const usernameResponse = await api
+        .get(`/players/raaandooom/competitions/standings`)
+        .query({ status: 'ongoing' });
 
       expect(usernameResponse.status).toBe(404);
       expect(usernameResponse.body.message).toMatch('Player not found.');
 
-      const idResponse = await api.get(`/players/id/100000/competitions/standings`);
+      const idResponse = await api
+        .get(`/players/id/100000/competitions/standings`)
+        .query({ status: 'ongoing' });
 
       expect(idResponse.status).toBe(404);
       expect(idResponse.body.message).toMatch('Player not found.');
     });
 
-    it('should list player competitions standings', async () => {
+    it('should not list player competition standings (undefined competition status)', async () => {
       const response = await api.get(`/players/psikoi/competitions/standings`);
 
+      expect(response.status).toBe(400);
+      expect(response.body.message).toMatch("Invalid enum value for 'status'");
+    });
+
+    it('should not list player competition standings (invalid competition status)', async () => {
+      const response = await api.get(`/players/psikoi/competitions/standings`).query({ status: 'something' });
+
+      expect(response.status).toBe(400);
+      expect(response.body.message).toMatch("Invalid enum value for 'status'");
+    });
+
+    it('should not list player competition standings (upcoming competition status)', async () => {
+      const response = await api.get(`/players/psikoi/competitions/standings`).query({ status: 'upcoming' });
+
+      expect(response.status).toBe(400);
+      expect(response.body.message).toMatch("Invalid enum value for 'status'");
+    });
+
+    it('should list player competitions standings (ongoing competitions)', async () => {
+      const response = await api.get(`/players/psikoi/competitions/standings`).query({ status: 'ongoing' });
+
       expect(response.status).toBe(200);
-      expect(response.body.length).toBe(5);
+      expect(response.body.length).toBe(4);
 
       // Hashes shouldn't be exposed to the API consumer
       expect(response.body.filter(p => !!p.competition.verificationHash).length).toBe(0);
@@ -2859,6 +2884,41 @@ describe('Competition API', () => {
       });
 
       expect(response.body[2]).toMatchObject({
+        teamName: 'Team 1',
+        competitionId: globalData.testCompetitionStartedTeam.id,
+        competition: {
+          id: globalData.testCompetitionStartedTeam.id,
+          participantCount: 4
+        },
+        rank: 3,
+        progress: { end: 1000, gained: 0, start: 1000 }
+      });
+
+      expect(response.body[3]).toMatchObject({
+        teamName: null,
+        competitionId: globalData.testCompetitionStarted.id,
+        competition: {
+          id: globalData.testCompetitionStarted.id,
+          participantCount: 5
+        },
+        rank: 4,
+        progress: { end: 1000, gained: 0, start: 1000 }
+      });
+    });
+
+    it('should list player competitions standings (finished competitions)', async () => {
+      const response = await api.get(`/players/psikoi/competitions/standings`).query({ status: 'finished' });
+
+      expect(response.status).toBe(200);
+      expect(response.body.length).toBe(1);
+
+      // Hashes shouldn't be exposed to the API consumer
+      expect(response.body.filter(p => !!p.competition.verificationHash).length).toBe(0);
+      // Snapshot IDs shouldn't be exposed to the API consumer
+      expect(response.body.filter(p => !!p.startSnapshotId).length).toBe(0);
+      expect(response.body.filter(p => !!p.endSnapshotId).length).toBe(0);
+
+      expect(response.body[0]).toMatchObject({
         teamName: null,
         competitionId: globalData.testCompetitionEnded.id,
         competition: {
@@ -2873,32 +2933,12 @@ describe('Competition API', () => {
         rank: 1,
         progress: { end: -1, gained: 0, start: -1 }
       });
-
-      expect(response.body[3]).toMatchObject({
-        teamName: 'Team 1',
-        competitionId: globalData.testCompetitionStartedTeam.id,
-        competition: {
-          id: globalData.testCompetitionStartedTeam.id,
-          participantCount: 4
-        },
-        rank: 3,
-        progress: { end: 1000, gained: 0, start: 1000 }
-      });
-
-      expect(response.body[4]).toMatchObject({
-        teamName: null,
-        competitionId: globalData.testCompetitionStarted.id,
-        competition: {
-          id: globalData.testCompetitionStarted.id,
-          participantCount: 5
-        },
-        rank: 4,
-        progress: { end: 1000, gained: 0, start: 1000 }
-      });
     });
 
     it('should list player competitions (w/ limit & offset)', async () => {
-      const response = await api.get(`/players/psikoi/competitions`).query({ limit: 1, offset: 1 });
+      const response = await api
+        .get(`/players/psikoi/competitions`)
+        .query({ status: 'ongoing', limit: 1, offset: 1 });
 
       expect(response.status).toBe(200);
       expect(response.body.length).toBe(1);

--- a/server/__tests__/suites/integration/competitions.test.ts
+++ b/server/__tests__/suites/integration/competitions.test.ts
@@ -2706,6 +2706,89 @@ describe('Competition API', () => {
       });
     });
 
+    it('should list player competitions (w/ ongoing status filter)', async () => {
+      const response = await api.get(`/players/psikoi/competitions`).query({ status: 'ongoing' });
+
+      expect(response.status).toBe(200);
+      expect(response.body.length).toBe(4);
+
+      // Hashes shouldn't be exposed to the API consumer
+      expect(response.body.filter(p => !!p.competition.verificationHash).length).toBe(0);
+      // Snapshot IDs shouldn't be exposed to the API consumer
+      expect(response.body.filter(p => !!p.startSnapshotId).length).toBe(0);
+      expect(response.body.filter(p => !!p.endSnapshotId).length).toBe(0);
+
+      expect(response.body[0]).toMatchObject({
+        teamName: 'Contributors',
+        competitionId: globalData.testCompetitionEnding.id,
+        competition: {
+          id: globalData.testCompetitionEnding.id,
+          participantCount: 11
+        }
+      });
+
+      expect(response.body[1]).toMatchObject({
+        teamName: 'Warriors',
+        competitionId: globalData.testCompetitionWithGroup.id,
+        competition: {
+          id: globalData.testCompetitionWithGroup.id,
+          participantCount: 4
+        }
+      });
+
+      expect(response.body[2]).toMatchObject({
+        teamName: 'Team 1',
+        competitionId: globalData.testCompetitionStartedTeam.id,
+        competition: {
+          id: globalData.testCompetitionStartedTeam.id,
+          participantCount: 4
+        }
+      });
+
+      expect(response.body[3]).toMatchObject({
+        teamName: null,
+        competitionId: globalData.testCompetitionStarted.id,
+        competition: {
+          id: globalData.testCompetitionStarted.id,
+          participantCount: 5
+        }
+      });
+    });
+
+    it('should list player competitions (w/ finished status filter)', async () => {
+      const response = await api.get(`/players/psikoi/competitions`).query({ status: 'finished' });
+
+      expect(response.status).toBe(200);
+      expect(response.body.length).toBe(1);
+
+      // Hashes shouldn't be exposed to the API consumer
+      expect(response.body.filter(p => !!p.competition.verificationHash).length).toBe(0);
+      // Snapshot IDs shouldn't be exposed to the API consumer
+      expect(response.body.filter(p => !!p.startSnapshotId).length).toBe(0);
+      expect(response.body.filter(p => !!p.endSnapshotId).length).toBe(0);
+
+      expect(response.body[0]).toMatchObject({
+        teamName: null,
+        competitionId: globalData.testCompetitionEnded.id,
+        competition: {
+          id: globalData.testCompetitionEnded.id,
+          groupId: globalData.testGroup.id,
+          group: {
+            id: globalData.testGroup.id,
+            memberCount: 2
+          },
+          participantCount: 2
+        }
+      });
+    });
+
+    it('should list player competitions (w/ upcoming status filter)', async () => {
+      const response = await api.get(`/players/psikoi/competitions`).query({ status: 'upcoming' });
+
+      expect(response.status).toBe(200);
+      expect(response.body.length).toBe(0);
+    });
+
     it('should list player competitions (w/ limit & offset)', async () => {
       const response = await api.get(`/players/psikoi/competitions`).query({ limit: 1, offset: 1 });
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.1.10",
+  "version": "2.1.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.1.10",
+      "version": "2.1.11",
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^4.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.1.10",
+  "version": "2.1.11",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/modules/competitions/services/FindPlayerParticipationsService.ts
+++ b/server/src/api/modules/competitions/services/FindPlayerParticipationsService.ts
@@ -1,12 +1,14 @@
 import { omit } from 'lodash';
 import { z } from 'zod';
-import prisma from '../../../../prisma';
+import prisma, { PrismaTypes } from '../../../../prisma';
+import { CompetitionStatus } from '../../../../utils';
 import { PAGINATION_SCHEMA } from '../../../util/validation';
 import { ParticipationWithCompetition } from '../competition.types';
 
 const inputSchema = z
   .object({
-    playerId: z.number().int().positive()
+    playerId: z.number().int().positive(),
+    status: z.nativeEnum(CompetitionStatus).optional()
   })
   .merge(PAGINATION_SCHEMA);
 
@@ -17,8 +19,26 @@ async function findPlayerParticipations(
 ): Promise<ParticipationWithCompetition[]> {
   const params = inputSchema.parse(payload);
 
+  const competitionQuery: PrismaTypes.CompetitionWhereInput = {};
+
+  if (params.status) {
+    const now = new Date();
+
+    if (params.status === CompetitionStatus.FINISHED) {
+      competitionQuery.endsAt = { lt: now };
+    } else if (params.status === CompetitionStatus.UPCOMING) {
+      competitionQuery.startsAt = { gt: now };
+    } else if (params.status === CompetitionStatus.ONGOING) {
+      competitionQuery.startsAt = { lt: now };
+      competitionQuery.endsAt = { gt: now };
+    }
+  }
+
   const participations = await prisma.participation.findMany({
-    where: { playerId: params.playerId },
+    where: {
+      playerId: params.playerId,
+      competition: competitionQuery
+    },
     include: {
       competition: {
         include: {

--- a/server/src/api/modules/competitions/services/FindPlayerParticipationsStandingsService.ts
+++ b/server/src/api/modules/competitions/services/FindPlayerParticipationsStandingsService.ts
@@ -1,10 +1,12 @@
 import { z } from 'zod';
+import { CompetitionStatus } from '../../../../utils';
 import { findPlayerParticipations } from './FindPlayerParticipationsService';
 import { ParticipationWithCompetitionAndStandings } from '../competition.types';
 import { calculateParticipantsStandings } from './FetchCompetitionDetailsService';
 
 const inputSchema = z.object({
-  playerId: z.number().int().positive()
+  playerId: z.number().int().positive(),
+  status: z.enum([CompetitionStatus.ONGOING, CompetitionStatus.FINISHED])
 });
 
 type FindPlayerParticipationsParams = z.infer<typeof inputSchema>;
@@ -14,7 +16,10 @@ async function findPlayerParticipationsStandings(
 ): Promise<ParticipationWithCompetitionAndStandings[]> {
   const params = inputSchema.parse(payload);
 
-  const participations = await findPlayerParticipations({ playerId: params.playerId });
+  const participations = await findPlayerParticipations({
+    playerId: params.playerId,
+    status: params.status
+  });
 
   const competitionsStandings = await Promise.all(
     participations.map(async p => {

--- a/server/src/api/modules/players/player.controller.ts
+++ b/server/src/api/modules/players/player.controller.ts
@@ -152,7 +152,8 @@ async function competitionStandings(req: Request): Promise<ControllerResponse> {
   });
 
   const results = await competitionServices.findPlayerParticipationsStandings({
-    playerId
+    playerId,
+    status: getEnum(req.query.status)
   });
 
   if (playerId && results.length === 0) {

--- a/server/src/api/modules/players/player.controller.ts
+++ b/server/src/api/modules/players/player.controller.ts
@@ -130,6 +130,7 @@ async function competitions(req: Request): Promise<ControllerResponse> {
 
   const results = await competitionServices.findPlayerParticipations({
     playerId,
+    status: getEnum(req.query.status),
     limit: getNumber(req.query.limit),
     offset: getNumber(req.query.offset)
   });


### PR DESCRIPTION
- Adds "status" query param to `/players/../competitions` (accepts `upcoming`, `ongoing`, and `finished`)
- Adds "status" query param to `/players/../competitions/standings` (accepts `ongoing`, and `finished`)