### PR TITLE
feat: Add all missing achievements (with unknown dates) on first update

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.1.12",
+  "version": "2.1.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.1.12",
+      "version": "2.1.13",
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^4.2.1",
@@ -53,6 +53,10 @@
         "ts-jest": "^29.0.1",
         "ts-node-dev": "^2.0.0",
         "typescript": "^4.5.5"
+      },
+      "engines": {
+        "node": ">=16.14.0",
+        "npm": ">=8.3.1"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.1.12",
+  "version": "2.1.13",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",


### PR DESCRIPTION
ATM the API skips syncing achievements until a player has 2 at leastsnapshots (so that it can check for new achievements betweent he two).

This changes it so that after the first player update, it checks for missing achievements and adds them with "unknown" dates.

This makes it a bit nicer for users that update for the first time on the website, they'll see their achievements right away.