### PR TITLE
[v2] Add accountHash auto name change submission

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.1.14",
+  "version": "2.1.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.1.14",
+      "version": "2.1.15",
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^4.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.1.14",
+  "version": "2.1.15",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -92,6 +92,12 @@ class API {
 
     // Register each http request for metrics processing
     this.express.use((req, res, next) => {
+      // Browsers block sending a custom user agent, so we're sending a custom header in our webapp
+      const userAgentHeader = req.get('X-User-Agent') || req.get('User-Agent');
+      const userAgent = metricsService.reduceUserAgent(userAgentHeader, req.useragent);
+
+      res.locals.userAgent = userAgent;
+
       const endTimer = metricsService.trackHttpRequestStarted();
 
       res.on('finish', () => {
@@ -102,10 +108,6 @@ class API {
 
         const status = res.statusCode;
         const method = req.method;
-
-        // Browsers block sending a custom user agent, so we're sending a custom header in our webapp
-        const userAgentHeader = req.get('X-User-Agent') || req.get('User-Agent');
-        const userAgent = metricsService.reduceUserAgent(userAgentHeader, req.useragent);
 
         metricsService.trackHttpRequestEnded(endTimer, route, status, method, userAgent);
       });


### PR DESCRIPTION
The API can now receive an `accountHash` query param from RuneLite, and use it to auto detect and submit name changes for players with the plugin installed.

⚠️  Requires Plugin & RL core changes