### PR TITLE
fix: Account hash query param

### DIFF
--- a/server/__tests__/suites/integration/players.test.ts
+++ b/server/__tests__/suites/integration/players.test.ts
@@ -413,14 +413,14 @@ describe('Player API', () => {
     it('should track player (w/ account hash and auto-submit name change)', async () => {
       const response = await api
         .post(`/players/ruben`)
-        .query({ accountHash: '123456' })
+        .send({ accountHash: '123456' })
         .set('User-Agent', 'RuneLite');
 
       expect(response.status).toBe(201);
 
       const secondResponse = await api
         .post(`/players/alan`)
-        .query({ accountHash: '123456' })
+        .send({ accountHash: '123456' })
         .set('User-Agent', 'RuneLite');
 
       expect(secondResponse.status).toBe(201);
@@ -445,14 +445,14 @@ describe('Player API', () => {
 
       const secondTrackResponse = await api
         .post(`/players/will`)
-        .query({ accountHash: '98765' })
+        .send({ accountHash: '98765' })
         .set('User-Agent', 'RuneLite');
 
       expect(secondTrackResponse.status).toBe(200);
 
       const thirdTrackResponse = await api
         .post(`/players/chuckie`)
-        .query({ accountHash: '98765' })
+        .send({ accountHash: '98765' })
         .set('User-Agent', 'RuneLite');
 
       expect(thirdTrackResponse.status).toBe(201);

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.1.15",
+  "version": "2.1.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.1.15",
+      "version": "2.1.16",
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^4.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.1.15",
+  "version": "2.1.16",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",


### PR DESCRIPTION
Moved the `accountHash` to the request body, instead of query param.