### PR TITLE
chore: Remove import-history and player id endpoints

### DIFF
--- a/client-js/package-lock.json
+++ b/client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wise-old-man/utils",
-      "version": "2.0.5",
+      "version": "2.0.6",
       "license": "ISC",
       "dependencies": {
         "axios": "^0.27.2",

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/client-js/src/clients/PlayersClient.ts
+++ b/client-js/src/clients/PlayersClient.ts
@@ -6,7 +6,6 @@ import type {
   PlayerCompetitionsFilter
 } from '../api-types';
 import {
-  PlayerResolvable,
   PlayerDeltasMap,
   PlayerDeltasArray,
   Record,
@@ -36,52 +35,48 @@ export default class PlayersClient extends BaseAPIClient {
    * Updates/tracks a player.
    * @returns The player's new details, including the latest snapshot.
    */
-  updatePlayer(player: PlayerResolvable) {
-    return this.postRequest<PlayerDetails>(getPlayerURL(player));
+  updatePlayer(username: string) {
+    return this.postRequest<PlayerDetails>(`/players/${username}`);
   }
 
   /**
    * Asserts (and attempts to fix, if necessary) a player's game-mode type.
    * @returns The updated player, and an indication of whether the type was changed.
    */
-  assertPlayerType(player: PlayerResolvable) {
-    return this.postRequest<AssertPlayerTypeResponse>(`${getPlayerURL(player)}/assert-type`);
+  assertPlayerType(username: string) {
+    return this.postRequest<AssertPlayerTypeResponse>(`/players/${username}/assert-type`);
   }
 
   /**
    * Fetches a player's details.
    * @returns The player's details, including the latest snapshot.
    */
-  getPlayerDetails(player: PlayerResolvable) {
-    return this.getRequest<PlayerDetails>(getPlayerURL(player));
+  getPlayerDetails(username: string) {
+    return this.getRequest<PlayerDetails>(`/players/${username}`);
   }
 
   /**
    * Fetches a player's current achievements.
    * @returns A list of achievements.
    */
-  getPlayerAchievements(player: PlayerResolvable) {
-    return this.getRequest<ExtendedAchievement[]>(`${getPlayerURL(player)}/achievements`);
+  getPlayerAchievements(username: string) {
+    return this.getRequest<ExtendedAchievement[]>(`/players/${username}/achievements`);
   }
 
   /**
    * Fetches a player's current achievement progress.
    * @returns A list of achievements (completed or otherwise), with their respective relative/absolute progress percentage.
    */
-  getPlayerAchievementProgress(player: PlayerResolvable) {
-    return this.getRequest<AchievementProgress[]>(`${getPlayerURL(player)}/achievements/progress`);
+  getPlayerAchievementProgress(username: string) {
+    return this.getRequest<AchievementProgress[]>(`/players/${username}/achievements/progress`);
   }
 
   /**
    * Fetches all of the player's competition participations.
    * @returns A list of participations, with the respective competition included.
    */
-  getPlayerCompetitions(
-    player: PlayerResolvable,
-    filter?: PlayerCompetitionsFilter,
-    pagination?: PaginationOptions
-  ) {
-    return this.getRequest<ParticipationWithCompetition[]>(`${getPlayerURL(player)}/competitions`, {
+  getPlayerCompetitions(username: string, filter?: PlayerCompetitionsFilter, pagination?: PaginationOptions) {
+    return this.getRequest<ParticipationWithCompetition[]>(`/players/${username}/competitions`, {
       ...filter,
       ...pagination
     });
@@ -91,9 +86,9 @@ export default class PlayersClient extends BaseAPIClient {
    * Fetches all of the player's competition participations' standings.
    * @returns A list of participations, with the respective competition, rank and progress included.
    */
-  getPlayerCompetitionStandings(player: PlayerResolvable, filter: PlayerCompetitionsFilter) {
+  getPlayerCompetitionStandings(username: string, filter: PlayerCompetitionsFilter) {
     return this.getRequest<ParticipationWithCompetitionAndStandings[]>(
-      `${getPlayerURL(player)}/competitions/standings`,
+      `/players/${username}/competitions/standings`,
       filter
     );
   }
@@ -102,27 +97,24 @@ export default class PlayersClient extends BaseAPIClient {
    * Fetches all of the player's group memberships.
    * @returns A list of memberships, with the respective group included.
    */
-  getPlayerGroups(player: PlayerResolvable, pagination?: PaginationOptions) {
-    return this.getRequest<MembershipWithGroup[]>(`${getPlayerURL(player)}/groups`, pagination);
+  getPlayerGroups(username: string, pagination?: PaginationOptions) {
+    return this.getRequest<MembershipWithGroup[]>(`/players/${username}/groups`, pagination);
   }
 
   /**
    * Fetches a player's gains, for a specific period or time range, as a [metric: data] map.
    * @returns A map of each metric's gained data.
    */
-  getPlayerGains(player: PlayerResolvable, options: TimeRangeFilter) {
-    return this.getRequest<GetPlayerGainsResponse<PlayerDeltasMap>>(
-      `${getPlayerURL(player)}/gained`,
-      options
-    );
+  getPlayerGains(username: string, options: TimeRangeFilter) {
+    return this.getRequest<GetPlayerGainsResponse<PlayerDeltasMap>>(`/players/${username}/gained`, options);
   }
 
   /**
    * Fetches a player's gains, for a specific period or time range, as an array.
    * @returns An array of each metric's gained data.
    */
-  getPlayerGainsAsArray(player: PlayerResolvable, options: TimeRangeFilter) {
-    return this.getRequest<GetPlayerGainsResponse<PlayerDeltasArray>>(`${getPlayerURL(player)}/gained`, {
+  getPlayerGainsAsArray(username: string, options: TimeRangeFilter) {
+    return this.getRequest<GetPlayerGainsResponse<PlayerDeltasArray>>(`/players/${username}/gained`, {
       ...options,
       formatting: 'array'
     });
@@ -132,16 +124,16 @@ export default class PlayersClient extends BaseAPIClient {
    * Fetches all of the player's records.
    * @returns A list of records.
    */
-  getPlayerRecords(player: PlayerResolvable, options?: PlayerRecordsFilter) {
-    return this.getRequest<Record[]>(`${getPlayerURL(player)}/records`, options);
+  getPlayerRecords(username: string, options?: PlayerRecordsFilter) {
+    return this.getRequest<Record[]>(`/players/${username}/records`, options);
   }
 
   /**
    * Fetches all of the player's past snapshots.
    * @returns A list of snapshots.
    */
-  getPlayerSnapshots(player: PlayerResolvable, options?: TimeRangeFilter, pagination?: PaginationOptions) {
-    return this.getRequest<FormattedSnapshot[]>(`${getPlayerURL(player)}/snapshots`, {
+  getPlayerSnapshots(username: string, options?: TimeRangeFilter, pagination?: PaginationOptions) {
+    return this.getRequest<FormattedSnapshot[]>(`/players/${username}/snapshots`, {
       ...options,
       ...pagination
     });
@@ -151,19 +143,7 @@ export default class PlayersClient extends BaseAPIClient {
    * Fetches all of the player's approved name changes.
    * @returns A list of name changes.
    */
-  getPlayerNames(player: PlayerResolvable) {
-    return this.getRequest<NameChange[]>(`${getPlayerURL(player)}/names`);
+  getPlayerNames(username: string) {
+    return this.getRequest<NameChange[]>(`/players/${username}/names`);
   }
-}
-
-function getPlayerURL(player: PlayerResolvable) {
-  if (typeof player === 'string') {
-    return `/players/${player}`;
-  }
-
-  if (player.id) {
-    return `/players/id/${player.id}`;
-  }
-
-  return `/players/${player.username}`;
 }

--- a/client-js/src/clients/PlayersClient.ts
+++ b/client-js/src/clients/PlayersClient.ts
@@ -3,7 +3,6 @@ import type {
   PlayerRecordsFilter,
   AssertPlayerTypeResponse,
   GetPlayerGainsResponse,
-  GenericCountMessageResponse,
   PlayerCompetitionsFilter
 } from '../api-types';
 import {
@@ -47,14 +46,6 @@ export default class PlayersClient extends BaseAPIClient {
    */
   assertPlayerType(player: PlayerResolvable) {
     return this.postRequest<AssertPlayerTypeResponse>(`${getPlayerURL(player)}/assert-type`);
-  }
-
-  /**
-   * Attempts to import a player's snapshot history from CrystalMathLabs.
-   * @returns The number of snapshots that were imported.
-   */
-  importPlayer(player: PlayerResolvable) {
-    return this.postRequest<GenericCountMessageResponse>(`${getPlayerURL(player)}/import-history`);
   }
 
   /**

--- a/docs/docs/players-api/player-endpoints.mdx
+++ b/docs/docs/players-api/player-endpoints.mdx
@@ -122,7 +122,7 @@ import { WOMClient } from '@wise-old-man/utils';
 
 const client = new WOMClient();
 
-const playerDetails = await client.players.updatePlayer({ username: 'zezima' });
+const playerDetails = await client.players.updatePlayer('zezima');
 ```
 
 </TabbedCodeBlock>
@@ -227,7 +227,7 @@ import { WOMClient } from '@wise-old-man/utils';
 
 const client = new WOMClient();
 
-const { player, changed } = await client.players.assertPlayerType({ username: 'zezima' });
+const { player, changed } = await client.players.assertPlayerType('zezima');
 ```
 
 </TabbedCodeBlock>
@@ -291,7 +291,7 @@ import { WOMClient } from '@wise-old-man/utils';
 
 const client = new WOMClient();
 
-const playerDetails = await client.players.getPlayerDetails({ username: 'zezima' });
+const playerDetails = await client.players.getPlayerDetails('zezima');
 ```
 
 </TabbedCodeBlock>
@@ -396,7 +396,7 @@ import { WOMClient } from '@wise-old-man/utils';
 
 const client = new WOMClient();
 
-const achievements = await client.players.getPlayerAchievements({ username: 'zezima' });
+const achievements = await client.players.getPlayerAchievements('zezima');
 ```
 
 </TabbedCodeBlock>
@@ -457,7 +457,7 @@ import { WOMClient } from '@wise-old-man/utils';
 
 const client = new WOMClient();
 
-const achievementsProgress = await client.players.getPlayerAchievementProgress({ username: 'zezima' });
+const achievementsProgress = await client.players.getPlayerAchievementProgress('zezima');
 ```
 
 </TabbedCodeBlock>
@@ -556,10 +556,9 @@ import { WOMClient, CompetitionStatus } from '@wise-old-man/utils';
 
 const client = new WOMClient();
 
-const participations = await client.players.getPlayerCompetitions(
-  { username: 'zezima' },
-  { status: CompetitionStatus.ONGOING }
-);
+const participations = await client.players.getPlayerCompetitions('zezima', {
+  status: CompetitionStatus.ONGOING
+});
 ```
 
 </TabbedCodeBlock>
@@ -676,10 +675,9 @@ import { WOMClient, CompetitionStatus } from '@wise-old-man/utils';
 
 const client = new WOMClient();
 
-const standings = await client.players.getPlayerCompetitionStandings(
-  { username: 'zezima' },
-  { status: CompetitionStatus.ONGOING }
-);
+const standings = await client.players.getPlayerCompetitionStandings('zezima', {
+  status: CompetitionStatus.ONGOING
+});
 ```
 
 </TabbedCodeBlock>
@@ -771,7 +769,7 @@ import { WOMClient } from '@wise-old-man/utils';
 
 const client = new WOMClient();
 
-const memberships = await client.players.getPlayerGroups({ username: 'zezima' });
+const memberships = await client.players.getPlayerGroups('zezima');
 ```
 
 </TabbedCodeBlock>
@@ -868,7 +866,7 @@ import { WOMClient, Period } from '@wise-old-man/utils';
 
 const client = new WOMClient();
 
-const gains = await client.players.getPlayerGains({ username: 'zezima' }, { period: Period.WEEK });
+const gains = await client.players.getPlayerGains('zezima', { period: Period.WEEK });
 ```
 
 </TabbedCodeBlock>
@@ -1005,7 +1003,7 @@ import { WOMClient, Metric } from '@wise-old-man/utils';
 
 const client = new WOMClient();
 
-const records = await client.players.getPlayerRecords({ username: 'zezima' }, { metric: Metric.AGILITY });
+const records = await client.players.getPlayerRecords('zezima', { metric: Metric.AGILITY });
 ```
 
 </TabbedCodeBlock>
@@ -1098,7 +1096,7 @@ import { WOMClient, Period } from '@wise-old-man/utils';
 
 const client = new WOMClient();
 
-const snapshots = await client.players.getPlayerSnapshots({ username: 'zezima' }, { period: Period.WEEK });
+const snapshots = await client.players.getPlayerSnapshots('zezima', { period: Period.WEEK });
 ```
 
 </TabbedCodeBlock>
@@ -1184,7 +1182,7 @@ import { WOMClient } from '@wise-old-man/utils';
 
 const client = new WOMClient();
 
-const nameChanges = await client.players.getPlayerNames({ username: 'zezima' });
+const nameChanges = await client.players.getPlayerNames('zezima');
 ```
 
 </TabbedCodeBlock>

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -50,3 +50,7 @@ table {
 .language-curl .token-line {
   filter: brightness(255);
 }
+
+.token.constant {
+  color: inherit !important;
+}

--- a/server/__tests__/suites/integration/competitions.test.ts
+++ b/server/__tests__/suites/integration/competitions.test.ts
@@ -2615,11 +2615,6 @@ describe('Competition API', () => {
 
       expect(usernameResponse.status).toBe(404);
       expect(usernameResponse.body.message).toMatch('Player not found.');
-
-      const idResponse = await api.get(`/players/id/100000/competitions`);
-
-      expect(idResponse.status).toBe(404);
-      expect(idResponse.body.message).toMatch('Player not found.');
     });
 
     it('should not list player competitions (negative offset)', async () => {
@@ -2819,13 +2814,6 @@ describe('Competition API', () => {
 
       expect(usernameResponse.status).toBe(404);
       expect(usernameResponse.body.message).toMatch('Player not found.');
-
-      const idResponse = await api
-        .get(`/players/id/100000/competitions/standings`)
-        .query({ status: 'ongoing' });
-
-      expect(idResponse.status).toBe(404);
-      expect(idResponse.body.message).toMatch('Player not found.');
     });
 
     it('should not list player competition standings (undefined competition status)', async () => {

--- a/server/__tests__/suites/integration/groups.test.ts
+++ b/server/__tests__/suites/integration/groups.test.ts
@@ -929,11 +929,6 @@ describe('Group API', () => {
 
       expect(usernameResponse.status).toBe(404);
       expect(usernameResponse.body.message).toMatch('Player not found.');
-
-      const idResponse = await api.get(`/players/id/100000/groups`);
-
-      expect(idResponse.status).toBe(404);
-      expect(idResponse.body.message).toMatch('Player not found.');
     });
 
     it('should not list player groups (negative offset)', async () => {

--- a/server/__tests__/suites/integration/names.test.ts
+++ b/server/__tests__/suites/integration/names.test.ts
@@ -379,11 +379,6 @@ describe('Names API', () => {
 
       expect(firstResponse.status).toBe(404);
       expect(firstResponse.body.message).toMatch('Player not found.');
-
-      const secondResponse = await api.get(`/players/id/2000000/names`);
-
-      expect(secondResponse.status).toBe(404);
-      expect(secondResponse.body.message).toMatch('Player not found.');
     });
 
     it('should fetch list', async () => {

--- a/server/__tests__/suites/integration/players.test.ts
+++ b/server/__tests__/suites/integration/players.test.ts
@@ -469,8 +469,24 @@ describe('Player API', () => {
   });
 
   describe('2. Importing', () => {
+    it('should not import player (invalid admin password)', async () => {
+      const response = await api.post(`/players/psikoi/import-history`);
+
+      expect(response.status).toBe(400);
+      expect(response.body.message).toBe("Required parameter 'adminPassword' is undefined.");
+    });
+
+    it('should not import player (incorrect admin password)', async () => {
+      const response = await api.post(`/players/psikoi/import-history`).send({ adminPassword: 'abc' });
+
+      expect(response.status).toBe(403);
+      expect(response.body.message).toBe('Incorrect admin password.');
+    });
+
     it('should not import player (player not found)', async () => {
-      const response = await api.post(`/players/zezima/import-history`);
+      const response = await api
+        .post(`/players/zezima/import-history`)
+        .send({ adminPassword: env.ADMIN_PASSWORD });
 
       expect(response.status).toBe(404);
       expect(response.body.message).toMatch('Player not found.');
@@ -482,7 +498,9 @@ describe('Player API', () => {
       // Mock the history fetch from CML
       registerCMLMock(axiosMock, 404);
 
-      const response = await api.post(`/players/psikoi/import-history`);
+      const response = await api
+        .post(`/players/psikoi/import-history`)
+        .send({ adminPassword: env.ADMIN_PASSWORD });
 
       expect(response.status).toBe(500);
       expect(response.body.message).toMatch('Failed to load history from CML.');
@@ -497,7 +515,10 @@ describe('Player API', () => {
       // Setup the CML request to return our mock raw data
       registerCMLMock(axiosMock, 200, globalData.cmlRawData);
 
-      const importResponse = await api.post(`/players/psikoi/import-history`);
+      const importResponse = await api
+        .post(`/players/psikoi/import-history`)
+        .send({ adminPassword: env.ADMIN_PASSWORD });
+
       expect(importResponse.status).toBe(200);
       expect(importResponse.body).toMatchObject({
         count: 219,
@@ -541,7 +562,10 @@ describe('Player API', () => {
       // Setup the CML request to return our mock raw data
       registerCMLMock(axiosMock, 200, globalData.cmlRawData);
 
-      const importResponse = await api.post(`/players/psikoi/import-history`);
+      const importResponse = await api
+        .post(`/players/psikoi/import-history`)
+        .send({ adminPassword: env.ADMIN_PASSWORD });
+
       expect(importResponse.status).toBe(429);
       expect(importResponse.body.message).toMatch('Imported too soon, please wait');
 

--- a/server/__tests__/suites/integration/records.test.ts
+++ b/server/__tests__/suites/integration/records.test.ts
@@ -166,11 +166,6 @@ describe('Records API', () => {
 
       expect(firstResponse.status).toBe(404);
       expect(firstResponse.body.message).toBe('Player not found.');
-
-      const secondResponse = await api.get(`/players/id/2000000/records`);
-
-      expect(secondResponse.status).toBe(404);
-      expect(secondResponse.body.message).toBe('Player not found.');
     });
 
     it('should not fetch records (invalid period)', async () => {

--- a/server/__tests__/suites/integration/snapshots.test.ts
+++ b/server/__tests__/suites/integration/snapshots.test.ts
@@ -367,13 +367,7 @@ describe('Snapshots API', () => {
 
     it('should not fetch all (player not found)', async () => {
       const result = await services.findPlayerSnapshots({ id: 2_000_000 });
-
       expect(result.length).toBe(0);
-
-      const response = await api.get(`/players/id/200000/snapshots`).query({ period: 'week' });
-
-      expect(response.status).toBe(404);
-      expect(response.body.message).toBe('Player not found.');
     });
 
     it('should fetch all snapshots (high limit)', async () => {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.1.17",
+  "version": "2.1.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.1.17",
+      "version": "2.1.18",
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^4.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.1.17",
+  "version": "2.1.18",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/modules/players/player.controller.ts
+++ b/server/src/api/modules/players/player.controller.ts
@@ -61,9 +61,7 @@ async function track(req: Request, res: Response): Promise<ControllerResponse> {
 // POST /players/:username/assert-type
 async function assertType(req: Request): Promise<ControllerResponse> {
   // Find the player using the username param
-  const player = await playerUtils.resolvePlayer({
-    username: getString(req.params.username)
-  });
+  const player = await playerUtils.resolvePlayer(getString(req.params.username));
 
   // (Forcefully) Assert the player's account type
   const [, updatedPlayer, changed] = await playerServices.assertPlayerType(player, true);
@@ -81,9 +79,7 @@ async function importPlayer(req: Request): Promise<ControllerResponse> {
   }
 
   // Find the player using the username param
-  const player = await playerUtils.resolvePlayer({
-    username: getString(req.params.username)
-  });
+  const player = await playerUtils.resolvePlayer(getString(req.params.username));
 
   const { count } = await playerServices.importPlayerHistory(player);
 
@@ -94,13 +90,9 @@ async function importPlayer(req: Request): Promise<ControllerResponse> {
 }
 
 // GET /players/:username
-// GET /players/id/:id
 async function details(req: Request): Promise<ControllerResponse> {
   // Find the player by either the id or the username
-  const player = await playerUtils.resolvePlayer({
-    id: getNumber(req.params.id),
-    username: getString(req.params.username)
-  });
+  const player = await playerUtils.resolvePlayer(getString(req.params.username));
 
   // Fetch the player's details
   const playerDetails = await playerServices.fetchPlayerDetails(player);
@@ -109,50 +101,28 @@ async function details(req: Request): Promise<ControllerResponse> {
 }
 
 // GET /players/:username/achievements
-// GET /players/id/:id/achievements
 async function achievements(req: Request): Promise<ControllerResponse> {
-  const playerId = await playerUtils.resolvePlayerId({
-    id: getNumber(req.params.id),
-    username: getString(req.params.username)
-  });
+  const playerId = await playerUtils.resolvePlayerId(getString(req.params.username));
 
   // Get all player achievements (by player id)
   const achievements = await achievementServices.findPlayerAchievements({ id: playerId });
-
-  if (playerId && achievements.length === 0) {
-    // Ensure this player ID exists (if not, it'll throw a 404 error)
-    await playerUtils.resolvePlayer({ id: playerId });
-  }
 
   return { statusCode: 200, response: achievements };
 }
 
 // GET /players/:username/achievements/progress
-// GET /players/id/:id/achievements/progress
 async function achievementsProgress(req: Request): Promise<ControllerResponse> {
-  const playerId = await playerUtils.resolvePlayerId({
-    id: getNumber(req.params.id),
-    username: getString(req.params.username)
-  });
+  const playerId = await playerUtils.resolvePlayerId(getString(req.params.username));
 
   // Get all player achievements (by player id)
   const result = await achievementServices.findPlayerAchievementProgress({ id: playerId });
-
-  if (playerId && result.filter(a => a.absoluteProgress > 0).length === 0) {
-    // Ensure this player ID exists (if not, it'll throw a 404 error)
-    await playerUtils.resolvePlayer({ id: playerId });
-  }
 
   return { statusCode: 200, response: result };
 }
 
 // GET /players/:username/competitions
-// GET /players/id/:id/competitions
 async function competitions(req: Request): Promise<ControllerResponse> {
-  const playerId = await playerUtils.resolvePlayerId({
-    id: getNumber(req.params.id),
-    username: getString(req.params.username)
-  });
+  const playerId = await playerUtils.resolvePlayerId(getString(req.params.username));
 
   const results = await competitionServices.findPlayerParticipations({
     playerId,
@@ -161,42 +131,24 @@ async function competitions(req: Request): Promise<ControllerResponse> {
     offset: getNumber(req.query.offset)
   });
 
-  if (playerId && results.length === 0) {
-    // Ensure this player ID exists (if not, it'll throw a 404 error)
-    await playerUtils.resolvePlayer({ id: playerId });
-  }
-
   return { statusCode: 200, response: results };
 }
 
 // GET /players/:username/competitions/standings
-// GET /players/id/:id/competitions/standings
 async function competitionStandings(req: Request): Promise<ControllerResponse> {
-  const playerId = await playerUtils.resolvePlayerId({
-    id: getNumber(req.params.id),
-    username: getString(req.params.username)
-  });
+  const playerId = await playerUtils.resolvePlayerId(getString(req.params.username));
 
   const results = await competitionServices.findPlayerParticipationsStandings({
     playerId,
     status: getEnum(req.query.status)
   });
 
-  if (playerId && results.length === 0) {
-    // Ensure this player ID exists (if not, it'll throw a 404 error)
-    await playerUtils.resolvePlayer({ id: playerId });
-  }
-
   return { statusCode: 200, response: results };
 }
 
 // GET /players/:username/groups
-// GET /players/id/:id/groups
 async function groups(req: Request): Promise<ControllerResponse> {
-  const playerId = await playerUtils.resolvePlayerId({
-    id: getNumber(req.params.id),
-    username: getString(req.params.username)
-  });
+  const playerId = await playerUtils.resolvePlayerId(getString(req.params.username));
 
   const results = await groupServices.findPlayerMemberships({
     playerId,
@@ -204,21 +156,12 @@ async function groups(req: Request): Promise<ControllerResponse> {
     offset: getNumber(req.query.offset)
   });
 
-  if (playerId && results.length === 0) {
-    // Ensure this player ID exists (if not, it'll throw a 404 error)
-    await playerUtils.resolvePlayer({ id: playerId });
-  }
-
   return { statusCode: 200, response: results };
 }
 
 // GET /players/:username/gained
-// GET /players/id/:id/gained
 async function gained(req: Request): Promise<ControllerResponse> {
-  const playerId = await playerUtils.resolvePlayerId({
-    id: getNumber(req.params.id),
-    username: getString(req.params.username)
-  });
+  const playerId = await playerUtils.resolvePlayerId(getString(req.params.username));
 
   const results = await deltaServices.findPlayerDeltas({
     id: playerId,
@@ -232,12 +175,8 @@ async function gained(req: Request): Promise<ControllerResponse> {
 }
 
 // GET /players/:username/records
-// GET /players/id/:id/records
 async function records(req: Request): Promise<ControllerResponse> {
-  const playerId = await playerUtils.resolvePlayerId({
-    id: getNumber(req.params.id),
-    username: getString(req.params.username)
-  });
+  const playerId = await playerUtils.resolvePlayerId(getString(req.params.username));
 
   // Fetch all player records for the given period and metric
   const results = await recordServices.findPlayerRecords({
@@ -246,21 +185,12 @@ async function records(req: Request): Promise<ControllerResponse> {
     metric: getEnum(req.query.metric)
   });
 
-  if (playerId && results.length === 0) {
-    // Ensure this player ID exists (if not, it'll throw a 404 error)
-    await playerUtils.resolvePlayer({ id: playerId });
-  }
-
   return { statusCode: 200, response: results };
 }
 
 // GET /players/:username/snapshots
-// GET /players/id/:id/snapshots
 async function snapshots(req: Request): Promise<ControllerResponse> {
-  const playerId = await playerUtils.resolvePlayerId({
-    id: getNumber(req.params.id),
-    username: getString(req.params.username)
-  });
+  const playerId = await playerUtils.resolvePlayerId(getString(req.params.username));
 
   const results = await snapshotServices.findPlayerSnapshots({
     id: playerId,
@@ -271,30 +201,13 @@ async function snapshots(req: Request): Promise<ControllerResponse> {
     limit: req.query.limit ? Math.min(50, getNumber(req.query.limit)) : 20
   });
 
-  const formattedSnapshots = results.map(s => snapshotUtils.format(s));
-
-  if (playerId && formattedSnapshots.length === 0) {
-    // Ensure this player ID exists (if not, it'll throw a 404 error)
-    await playerUtils.resolvePlayer({ id: playerId });
-  }
-
-  return { statusCode: 200, response: formattedSnapshots };
+  return { statusCode: 200, response: results.map(s => snapshotUtils.format(s)) };
 }
 
 // GET /players/:username/names
-// GET /players/id/:id/names
 async function names(req: Request): Promise<ControllerResponse> {
-  const playerId = await playerUtils.resolvePlayerId({
-    id: getNumber(req.params.id),
-    username: getString(req.params.username)
-  });
-
+  const playerId = await playerUtils.resolvePlayerId(getString(req.params.username));
   const result = await nameChangeServices.findPlayerNameChanges({ playerId });
-
-  if (playerId && result.length === 0) {
-    // Ensure this player ID exists (if not, it'll throw a 404 error)
-    await playerUtils.resolvePlayer({ id: playerId });
-  }
 
   return { statusCode: 200, response: result };
 }

--- a/server/src/api/modules/players/player.controller.ts
+++ b/server/src/api/modules/players/player.controller.ts
@@ -76,6 +76,10 @@ async function assertType(req: Request): Promise<ControllerResponse> {
 
 // POST /players/:username/import-history
 async function importPlayer(req: Request): Promise<ControllerResponse> {
+  if (!adminGuard.checkAdminPermissions(req)) {
+    throw new ForbiddenError('Incorrect admin password.');
+  }
+
   // Find the player using the username param
   const player = await playerUtils.resolvePlayer({
     username: getString(req.params.username)

--- a/server/src/api/modules/players/player.routes.ts
+++ b/server/src/api/modules/players/player.routes.ts
@@ -22,15 +22,4 @@ api.get('/:username', setupController(controller.details));
 api.post('/:username', setupController(controller.track));
 api.delete('/:username', setupController(controller.deletePlayer));
 
-api.get('/id/:id/groups', setupController(controller.groups));
-api.get('/id/:id/gained', setupController(controller.gained));
-api.get('/id/:id/records', setupController(controller.records));
-api.get('/id/:id/snapshots', setupController(controller.snapshots));
-api.get('/id/:id/achievements', setupController(controller.achievements));
-api.get('/id/:id/achievements/progress', setupController(controller.achievementsProgress));
-api.get('/id/:id/competitions', setupController(controller.competitions));
-api.get('/id/:id/competitions/standings', setupController(controller.competitionStandings));
-api.get('/id/:id/names', setupController(controller.names));
-api.get('/id/:id', setupController(controller.details));
-
 export default api;

--- a/server/src/api/modules/players/player.types.ts
+++ b/server/src/api/modules/players/player.types.ts
@@ -1,8 +1,6 @@
 import { Player } from '../../../prisma';
 import { FormattedSnapshot } from '../snapshots/snapshot.types';
 
-export type PlayerResolvable = Partial<Pick<Player, 'id' | 'username'>>;
-
 export interface PlayerDetails extends Player {
   combatLevel: number;
   latestSnapshot: FormattedSnapshot;

--- a/server/src/api/modules/players/player.utils.ts
+++ b/server/src/api/modules/players/player.utils.ts
@@ -5,7 +5,6 @@ import { BadRequestError, NotFoundError } from '../../errors';
 import redisService from '../../services/external/redis.service';
 import { isF2p, is10HP, isZerker, isLvl3, is1Def } from '../snapshots/snapshot.utils';
 import { findPlayer } from './services/FindPlayerService';
-import { PlayerResolvable } from './player.types';
 
 let UPDATE_COOLDOWN = isTesting() ? 0 : 60;
 
@@ -13,11 +12,7 @@ const DAY_IN_SECONDS = PeriodProps[Period.DAY].milliseconds / 1000;
 const YEAR_IN_SECONDS = PeriodProps[Period.YEAR].milliseconds / 1000;
 const DECADE_IN_SECONDS = YEAR_IN_SECONDS * 10;
 
-async function resolvePlayerId(playerResolvable: PlayerResolvable): Promise<number | null> {
-  if (playerResolvable.id) return playerResolvable.id;
-
-  const { username } = playerResolvable;
-
+async function resolvePlayerId(username: string): Promise<number | null> {
   if (!username || username.length === 0) {
     throw new BadRequestError(`Parameter 'username' is undefined.`);
   }
@@ -35,12 +30,12 @@ async function resolvePlayerId(playerResolvable: PlayerResolvable): Promise<numb
   return player.id;
 }
 
-async function resolvePlayer(playerResolvable: PlayerResolvable): Promise<Player | null> {
-  if (!playerResolvable.username && !playerResolvable.id) {
-    throw new BadRequestError('Undefined id and username.');
+async function resolvePlayer(username: string): Promise<Player | null> {
+  if (!username || username.length === 0) {
+    throw new BadRequestError('Undefined username.');
   }
 
-  const [player] = await findPlayer(playerResolvable);
+  const [player] = await findPlayer({ username });
 
   if (!player) {
     throw new NotFoundError('Player not found.');


### PR DESCRIPTION
- Removed `POST /players/:username/import-history` as it's unused and unnecessary (imports are already automatically executed when a player updates)
- Removed all "player ID" endpoints, `username` is now the only accepted player identifier.