### PR TITLE
feat: Allow competition dates to be changed anytime

### DIFF
--- a/server/__tests__/suites/integration/competitions.test.ts
+++ b/server/__tests__/suites/integration/competitions.test.ts
@@ -867,19 +867,6 @@ describe('Competition API', () => {
       expect(onParticipantsJoinedEvent).not.toHaveBeenCalled();
     });
 
-    it('should not edit (past dates)', async () => {
-      const response = await api.put(`/competitions/${globalData.testCompetitionStarting.id}`).send({
-        startsAt: new Date(Date.now() - 3_600_000),
-        endsAt: new Date(Date.now() - 1_200_000),
-        verificationCode: globalData.testCompetitionStarting.verificationCode
-      });
-
-      expect(response.status).toBe(400);
-      expect(response.body.message).toBe('Invalid dates: All start and end dates must be in the future.');
-
-      expect(onParticipantsJoinedEvent).not.toHaveBeenCalled();
-    });
-
     it('should not edit (invalid participants list)', async () => {
       const response = await api.put(`/competitions/${globalData.testCompetitionStarting.id}`).send({
         verificationCode: globalData.testCompetitionStarting.verificationCode,
@@ -1058,30 +1045,6 @@ describe('Competition API', () => {
 
       expect(response.status).toBe(403);
       expect(response.body.message).toMatch('Incorrect verification code.');
-
-      expect(onParticipantsJoinedEvent).not.toHaveBeenCalled();
-    });
-
-    it('should not edit start date (already started)', async () => {
-      const response = await api.put(`/competitions/${globalData.testCompetitionOngoing.id}`).send({
-        startsAt: new Date(Date.now() + 3_600_000),
-        verificationCode: globalData.testCompetitionOngoing.verificationCode
-      });
-
-      expect(response.status).toBe(400);
-      expect(response.body.message).toMatch('The competition has started, the start date cannot be changed.');
-
-      expect(onParticipantsJoinedEvent).not.toHaveBeenCalled();
-    });
-
-    it('should not edit metric (already started)', async () => {
-      const response = await api.put(`/competitions/${globalData.testCompetitionOngoing.id}`).send({
-        metric: 'obor',
-        verificationCode: globalData.testCompetitionOngoing.verificationCode
-      });
-
-      expect(response.status).toBe(400);
-      expect(response.body.message).toMatch('The competition has started, the metric cannot be changed.');
 
       expect(onParticipantsJoinedEvent).not.toHaveBeenCalled();
     });

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.1.19",
+  "version": "2.1.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.1.19",
+      "version": "2.1.20",
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^4.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.1.19",
+  "version": "2.1.20",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",


### PR DESCRIPTION
- You can now edit a competition's metric anytime during it's duration (before, during, after)
- You can now edit a competition's start date anytime during it's duration (before, during, after)
- You can now edit a competition's end date anytime during it's duration (before, during, after)

These last two changes require some competition data to be recalculated so it might slow down edits on larger competitions by 500-1500ms.