### PR TITLE
revert: Add pagination to player snapshots endpoint

### DIFF
--- a/client-js/package-lock.json
+++ b/client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wise-old-man/utils",
-      "version": "2.0.9",
+      "version": "2.0.10",
       "license": "ISC",
       "dependencies": {
         "axios": "^0.27.2",

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "description": "A JavaScript/TypeScript client that interfaces and consumes the Wise Old Man API, an API that tracks and measures players' progress in Old School Runescape.",
   "keywords": [
     "wiseoldman",

--- a/client-js/src/clients/PlayersClient.ts
+++ b/client-js/src/clients/PlayersClient.ts
@@ -132,11 +132,8 @@ export default class PlayersClient extends BaseAPIClient {
    * Fetches all of the player's past snapshots.
    * @returns A list of snapshots.
    */
-  getPlayerSnapshots(username: string, options?: TimeRangeFilter, pagination?: PaginationOptions) {
-    return this.getRequest<FormattedSnapshot[]>(`/players/${username}/snapshots`, {
-      ...options,
-      ...pagination
-    });
+  getPlayerSnapshots(username: string, options?: TimeRangeFilter) {
+    return this.getRequest<FormattedSnapshot[]>(`/players/${username}/snapshots`, options);
   }
 
   /**

--- a/docs/docs/players-api/player-endpoints.mdx
+++ b/docs/docs/players-api/player-endpoints.mdx
@@ -1068,13 +1068,11 @@ Fetches all of the player's past snapshots. Returns an array of [Snapshot](/play
 
 **Request Params**
 
-| Field     | Type                                           | Required | Description                                           |
-| --------- | ---------------------------------------------- | -------- | ----------------------------------------------------- |
-| period    | [Period](/global-type-definitions#enum-period) | `false`  | The period to filter the snapshots by.                |
-| startDate | date                                           | `false`  | The minimum date for the snapshots.                   |
-| endDate   | date                                           | `false`  | The maximum date for the snapshots.                   |
-| limit     | integer                                        | `false`  | The pagination limit. See [Pagination](/#pagination)  |
-| offset    | integer                                        | `false`  | The pagination offset. See [Pagination](/#pagination) |
+| Field     | Type                                           | Required | Description                            |
+| --------- | ---------------------------------------------- | -------- | -------------------------------------- |
+| period    | [Period](/global-type-definitions#enum-period) | `false`  | The period to filter the snapshots by. |
+| startDate | date                                           | `false`  | The minimum date for the snapshots.    |
+| endDate   | date                                           | `false`  | The maximum date for the snapshots.    |
 
 :::info
 This endpoint accepts either `period` or `startDate` + `endDate`.

--- a/server/__tests__/suites/integration/players.test.ts
+++ b/server/__tests__/suites/integration/players.test.ts
@@ -531,27 +531,18 @@ describe('Player API', () => {
       expect(detailsResponse.status).toBe(200);
       expect(detailsResponse.body.lastImportedAt).not.toBeNull();
 
-      const allSnapshots = [];
+      const snapshotsResponse = await api.get(`/players/psikoi/snapshots`).query({
+        startDate: new Date('2010-01-01'),
+        endDate: new Date('2030-01-01')
+      });
 
-      for (let i = 0; i < 5; i++) {
-        const snapshotsResponse = await api.get(`/players/psikoi/snapshots`).query({
-          startDate: new Date('2010-01-01'),
-          endDate: new Date('2030-01-01'),
-          offset: i * 50,
-          limit: 50
-        });
-
-        expect(snapshotsResponse.status).toBe(200);
-
-        allSnapshots.push(...snapshotsResponse.body);
-      }
-
-      expect(allSnapshots.length).toBe(222); // 219 imported, 3 tracked (during this test session)
-      expect(allSnapshots.filter(s => s.importedAt !== null).length).toBe(219);
-
+      expect(snapshotsResponse.status).toBe(200);
+      expect(snapshotsResponse.body.length).toBe(222); // 219 imported, 3 tracked (during this test session)
+      expect(snapshotsResponse.body.filter(s => s.importedAt !== null).length).toBe(219);
       expect(
-        allSnapshots.filter(s => s.importedAt !== null && new Date(s.createdAt) > new Date('2020-05-10'))
-          .length
+        snapshotsResponse.body.filter(
+          s => s.importedAt !== null && new Date(s.createdAt) > new Date('2020-05-10')
+        ).length
       ).toBe(0); // there should be no imported snapshots from AFTER May 10th 2020
 
       // Mock the history fetch from CML

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.1.20",
+  "version": "2.1.21",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.1.20",
+      "version": "2.1.21",
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^4.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.1.20",
+  "version": "2.1.21",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/modules/players/player.controller.ts
+++ b/server/src/api/modules/players/player.controller.ts
@@ -196,9 +196,7 @@ async function snapshots(req: Request): Promise<ControllerResponse> {
     id: playerId,
     period: getEnum(req.query.period),
     minDate: getDate(req.query.startDate),
-    maxDate: getDate(req.query.endDate),
-    offset: getNumber(req.query.offset),
-    limit: req.query.limit ? Math.min(50, getNumber(req.query.limit)) : 20
+    maxDate: getDate(req.query.endDate)
   });
 
   return { statusCode: 200, response: results.map(s => snapshotUtils.format(s)) };

--- a/server/src/api/modules/snapshots/services/FindPlayerSnapshotsService.ts
+++ b/server/src/api/modules/snapshots/services/FindPlayerSnapshotsService.ts
@@ -11,9 +11,7 @@ const inputSchema = z
     // or by a time range (min date and max date)
     minDate: z.date().optional(),
     maxDate: z.date().optional(),
-    // Pagination
-    limit: z.number().int().positive("Parameter 'limit' must be > 0.").optional().default(100_000),
-    offset: z.number().int().nonnegative("Parameter 'offset' must be >= 0.").optional().default(0)
+    limit: z.number().int().positive().optional().default(100_000)
   })
   .refine(s => !(s.minDate && s.maxDate && s.minDate >= s.maxDate), {
     message: 'Min date must be before the max date.'
@@ -30,8 +28,7 @@ async function findPlayerSnapshots(payload: FindPlayerSnapshotsParams): Promise<
     .findMany({
       where: { playerId: params.id, ...filterQuery },
       orderBy: { createdAt: 'desc' },
-      take: params.limit,
-      skip: params.offset
+      take: params.limit
     })
     .then(modifySnapshots);
 


### PR DESCRIPTION
Reverts #1037 

I thought I had forgotten to add pagination to that endpoint, so I added it. Turns out there's a reason why it doesn't have pagination. Oops.