### PR TITLE
fix: correctly sort level in HiscoresTable

### DIFF
--- a/app/src/pages/Group/containers/HiscoresTable.jsx
+++ b/app/src/pages/Group/containers/HiscoresTable.jsx
@@ -105,6 +105,7 @@ function getTableConfig(metric) {
   if (isSkill(metric)) {
     TABLE_CONFIG.columns.splice(3, 0, {
       key: 'level',
+      get: row => row.data.level,
       transform: (_, row) => <NumberLabel value={row.data.level} />
     });
   }


### PR DESCRIPTION
### **Problematic Behavior**
Sorting by the `Level` column within a Hiscores table did nothing.

https://user-images.githubusercontent.com/15249821/209405387-2e9498ca-ef7b-4713-8a58-9b2cc852a7dd.mp4

### **New Behavior**
The `Level` column will be correctly sorted.

https://user-images.githubusercontent.com/15249821/209405491-c38c057b-4bea-4704-a1a1-b65021880a65.mp4


