### PR TITLE
fix: Deleting groups doesn't also remove group competitions

### DIFF
--- a/app/src/modals/DeleteGroupModal/DeleteGroupModal.jsx
+++ b/app/src/modals/DeleteGroupModal/DeleteGroupModal.jsx
@@ -37,7 +37,9 @@ function DeleteGroupModal({ group, onCancel }) {
           <img src="/img/icons/clear.svg" alt="X" />
         </button>
         <b className="modal-title">Are you sure you want to delete this group?</b>
-        <span className="modal-warning">This action is permanent and cannot be reversed</span>
+        <span className="modal-warning">
+          This action is permanent and cannot be reversed. All linked competitions will also be deleted.
+        </span>
         <input
           className="verification-input"
           value={verificationCode}

--- a/app/src/redux/groups/reducer.js
+++ b/app/src/redux/groups/reducer.js
@@ -129,11 +129,8 @@ const slice = createSlice({
     onDeleteRequest(state) {
       state.isDeleting = true;
     },
-    onDeleteSuccess(state, action) {
-      const { groupId } = action.payload;
-
+    onDeleteSuccess(state) {
       state.isDeleting = false;
-      state.groups = omit(state.competitions, groupId);
     },
     onDeleteError(state, action) {
       state.isDeleting = false;

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.1.27",
+  "version": "2.1.28",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.1.27",
+      "version": "2.1.28",
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^4.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.1.27",
+  "version": "2.1.28",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/prisma/migrations/20230211213345_add_cascade_delete_actions_to_competitions/migration.sql
+++ b/server/prisma/migrations/20230211213345_add_cascade_delete_actions_to_competitions/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE "competitions" DROP CONSTRAINT "competitions_groupId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "competitions" ADD CONSTRAINT "competitions_groupId_fkey" FOREIGN KEY ("groupId") REFERENCES "groups"("id") ON DELETE CASCADE ON UPDATE NO ACTION;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -46,7 +46,7 @@ model Competition {
   updatedAt        DateTime?       @updatedAt @db.Timestamptz(6)
 
   // Relations
-  group          Group?          @relation(fields: [groupId], references: [id], onUpdate: NoAction)
+  group          Group?          @relation(fields: [groupId], references: [id], onDelete: Cascade, onUpdate: NoAction)
   participations Participation[]
 
   // Indices
@@ -238,8 +238,8 @@ model Participation {
   // Relations
   player        Player      @relation(fields: [playerId], references: [id], onDelete: Cascade, onUpdate: NoAction)
   competition   Competition @relation(fields: [competitionId], references: [id], onDelete: Cascade, onUpdate: NoAction)
-  startSnapshot Snapshot?   @relation("participations_startSnapshotIdTosnapshots", fields: [startSnapshotId], references: [id], onUpdate: NoAction)
-  endSnapshot   Snapshot?   @relation("participations_endSnapshotIdTosnapshots", fields: [endSnapshotId], references: [id], onUpdate: NoAction)
+  startSnapshot Snapshot?   @relation("participations_startSnapshotIdTosnapshots", fields: [startSnapshotId], references: [id], onDelete: SetNull, onUpdate: NoAction)
+  endSnapshot   Snapshot?   @relation("participations_endSnapshotIdTosnapshots", fields: [endSnapshotId], references: [id], onDelete: SetNull, onUpdate: NoAction)
 
   // Constraints
   @@id([playerId, competitionId])


### PR DESCRIPTION
- Drop all linked competitions when a group is deleted
- Fix 404 redirect on the app when deleting a group