### PR TITLE
Dont dispatch name changed discord event for only capitalization

### DIFF
--- a/server/src/api/services/external/discord.service.ts
+++ b/server/src/api/services/external/discord.service.ts
@@ -75,6 +75,9 @@ async function dispatchHardcoreDied(player: Player) {
  * so that it can notify any relevant guilds/servers.
  */
 async function dispatchNameChanged(player: Player, previousDisplayName: string) {
+  // If only capitlization changed, ignore this action
+  if (player.displayName.toLowerCase() === previousDisplayName.toLowerCase()) return;
+
   const memberships = await prisma.membership.findMany({
     where: { playerId: player.id }
   });


### PR DESCRIPTION
Hi,

This PR adds a check to prevent dispatching name changes to discord when only capitalization was changed.

Closes #1053 