### PR TITLE
Fix bug with Get Name Change Details that has invalid new name

### DIFF
--- a/docs/docs/names-api/name-type-definitions.md
+++ b/docs/docs/names-api/name-type-definitions.md
@@ -43,7 +43,11 @@ sidebar_position: 1
 | ehpDiff          | integer                                                          | The difference in efficient hours played (EHP) between the old name's last snapshot, and the new name's first snapshot (or name change submission date, if not tracked.). |
 | ehbDiff          | integer                                                          | The difference in efficient hours bossed (EHB) between the old name's last snapshot, and the new name's first snapshot (or name change submission date, if not tracked.). |
 | oldStats         | [Snapshot](/players-api/player-type-definitions#object-snapshot) | The old name's last snapshot.                                                                                                                                             |
-| newStats         | [Snapshot](/players-api/player-type-definitions#object-snapshot) | The new name's first snapshot. (or current hiscores stats if untracked.)                                                                                                  |
+| newStats         | [Snapshot](/players-api/player-type-definitions#object-snapshot)? | The new name's first snapshot, current hiscores stats if untracked, or null if untracked and not present on hiscores. |
+
+:::caution
+`newStats` may not include `id` or `playerId` if the new username wasn't already tracked on WOM.
+:::
 
 <br />
 

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.1.31",
+  "version": "2.1.32",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/modules/efficiency/services/ComputePlayerMetricsService.ts
+++ b/server/src/api/modules/efficiency/services/ComputePlayerMetricsService.ts
@@ -26,6 +26,8 @@ interface ComputePlayerMetricsResult {
 async function computePlayerMetrics(payload: ComputePlayerMetricsParams) {
   const { player, snapshot } = { ...inputSchema.parse(payload), snapshot: payload.snapshot };
 
+  if (!snapshot) return null;
+
   const killcountMap = efficiencyUtils.getKillcountMap(snapshot);
   const experienceMap = efficiencyUtils.getExperienceMap(snapshot);
 

--- a/server/src/api/modules/name-changes/services/FetchNameChangeDetailsService.ts
+++ b/server/src/api/modules/name-changes/services/FetchNameChangeDetailsService.ts
@@ -97,11 +97,12 @@ async function fetchNameChangeDetails(payload: FetchetailsParams): Promise<NameC
   oldStats.ehbValue = oldPlayerComputedMetrics.ehbValue;
   oldStats.ehbRank = oldPlayerComputedMetrics.ehbRank;
 
-  newStats.ehpValue = newPlayerComputedMetrics.ehpValue;
-  newStats.ehpRank = newPlayerComputedMetrics.ehpRank;
-
-  newStats.ehbValue = newPlayerComputedMetrics.ehbValue;
-  newStats.ehbRank = newPlayerComputedMetrics.ehbRank;
+  if (newPlayerComputedMetrics) {
+    newStats.ehpValue = newPlayerComputedMetrics.ehpValue;
+    newStats.ehpRank = newPlayerComputedMetrics.ehpRank;
+    newStats.ehbValue = newPlayerComputedMetrics.ehbValue;
+    newStats.ehbRank = newPlayerComputedMetrics.ehbRank;
+  }
 
   const ehpDiff = newStats ? newStats.ehpValue - oldStats.ehpValue : 0;
   const ehbDiff = newStats ? newStats.ehbValue - oldStats.ehbValue : 0;
@@ -111,7 +112,7 @@ async function fetchNameChangeDetails(payload: FetchetailsParams): Promise<NameC
   const oldPlayerEfficiencyMap = efficiencyUtils.getPlayerEfficiencyMap(oldStats, oldPlayer);
   const newPlayerEfficiencyMap = efficiencyUtils.getPlayerEfficiencyMap(newStats, newPlayer);
 
-  if (!newPlayer) {
+  if (!newPlayer && newStats) {
     delete newStats.playerId;
   }
 


### PR DESCRIPTION
This PR fixes a bug where we would attempt to read properties of null.
Inside `computePlayerMetrics` when the snapshot was null `getKillCountMap` would fail with:
`Cannot read properties of null (reading 'abyssal_sireKills')`

This occurred in the case when the new username was not tracked by WOM, AND also not on the hiscores, AND the name change request is pending.

In addition to that, make sure we only attempt to delete the `newStats.playerId` if `newStats` is not null.

Added a test to confirm this niche case and updated the documentation to note that `newStats` is now nullable and may not include id/playerid if the new username isn't tracked by WOM.