### PR TITLE
Show actual level for nearest 99s

### DIFF
--- a/.github/workflows/lint-app.yml
+++ b/.github/workflows/lint-app.yml
@@ -29,8 +29,6 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-      - name: Install global dependencies
-        run: npm i
       - name: Install app dependencies
         run: |
           cd app

--- a/app/.eslintrc.json
+++ b/app/.eslintrc.json
@@ -24,6 +24,8 @@
     "jsx-a11y/control-has-associated-label": "off",
     "import/prefer-default-export": "off",
     "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }],
-    "no-param-reassign": "off"
+    "no-param-reassign": "off",
+    "react/jsx-no-bind": [0],
+    "react/jsx-props-no-spreading": [0]
   }
 }

--- a/app/src/components/MembersSelector/MembersSelector.jsx
+++ b/app/src/components/MembersSelector/MembersSelector.jsx
@@ -157,7 +157,7 @@ MembersSelector.defaultProps = {
 
 MembersSelector.propTypes = {
   members: PropTypes.arrayOf(PropTypes.shape()).isRequired,
-  roles: PropTypes.arrayOf(PropTypes.object).isRequired,
+  roles: PropTypes.arrayOf(PropTypes.shape()).isRequired,
   invalidUsernames: PropTypes.arrayOf(PropTypes.string),
   onMemberAdded: PropTypes.func.isRequired,
   onMemberRemoved: PropTypes.func.isRequired,

--- a/app/src/pages/Competition/components/TeamPlayersTable/TeamPlayersTable.jsx
+++ b/app/src/pages/Competition/components/TeamPlayersTable/TeamPlayersTable.jsx
@@ -39,7 +39,7 @@ function TeamPlayersTable({
         get: row => (row.progress ? row.progress.start : 0),
         transform: (val, row) => {
           const lastUpdated = row.updatedAt;
-          const props = MetricProps[metric];
+          const metricProps = MetricProps[metric];
 
           // If competition hasn't started
           if (competition.startsAt >= Date.now())
@@ -58,19 +58,19 @@ function TeamPlayersTable({
             );
 
           // If is unranked on a boss metric
-          if (isBoss(metric) && val < props.minimumValue)
+          if (isBoss(metric) && val < metricProps.minimumValue)
             return (
               <abbr
-                title={`The Hiscores only start tracking ${props.name} kills after ${props.minimumValue} kc.`}
+                title={`The Hiscores only start tracking ${metricProps.name} kills after ${metricProps.minimumValue} kc.`}
               >
-                <span>{`< ${props.minimumValue}`}</span>
+                <span>{`< ${metricProps.minimumValue}`}</span>
               </abbr>
             );
 
           // If unranked or not updated
           if (val === -1)
             return (
-              <abbr title={`This player is currently unranked in ${props.name}.`}>
+              <abbr title={`This player is currently unranked in ${metricProps.name}.`}>
                 <span>--</span>
               </abbr>
             );
@@ -83,7 +83,7 @@ function TeamPlayersTable({
         get: row => (row.progress ? row.progress.end : 0),
         transform: (val, row) => {
           const lastUpdated = row.updatedAt;
-          const props = MetricProps[metric];
+          const metricProps = MetricProps[metric];
 
           // If competition hasn't started
           if (competition.startsAt >= Date.now())
@@ -102,19 +102,19 @@ function TeamPlayersTable({
             );
 
           // If is unranked on a boss metric
-          if (isBoss(metric) && val < props.minimumValue)
+          if (isBoss(metric) && val < metricProps.minimumValue)
             return (
               <abbr
-                title={`The Hiscores only start tracking ${props.name} kills after ${props.minimumValue} kc.`}
+                title={`The Hiscores only start tracking ${metricProps.name} kills after ${metricProps.minimumValue} kc.`}
               >
-                <span>{`< ${props.minimumValue}`}</span>
+                <span>{`< ${metricProps.minimumValue}`}</span>
               </abbr>
             );
 
           // If unranked or not updated
           if (val === -1)
             return (
-              <abbr title={`This player is currently unranked in ${props.name}.`}>
+              <abbr title={`This player is currently unranked in ${metricProps.name}.`}>
                 <span>--</span>
               </abbr>
             );

--- a/app/src/pages/Competition/containers/ParticipantsTable.jsx
+++ b/app/src/pages/Competition/containers/ParticipantsTable.jsx
@@ -225,7 +225,8 @@ ParticipantsTable.propTypes = {
     metric: PropTypes.string,
     status: PropTypes.string,
     startsAt: PropTypes.instanceOf(Date),
-    participants: PropTypes.arrayOf(PropTypes.shape({}))
+    participants: PropTypes.arrayOf(PropTypes.shape({})),
+    participations: PropTypes.arrayOf(PropTypes.shape())
   }).isRequired,
   onUpdateClicked: PropTypes.func.isRequired,
   onExportParticipantsClicked: PropTypes.func.isRequired

--- a/app/src/pages/Competition/containers/Widgets.jsx
+++ b/app/src/pages/Competition/containers/Widgets.jsx
@@ -43,7 +43,8 @@ Widgets.propTypes = {
     totalGained: PropTypes.number,
     startsAt: PropTypes.instanceOf(Date),
     endsAt: PropTypes.instanceOf(Date),
-    participants: PropTypes.arrayOf(PropTypes.shape())
+    participants: PropTypes.arrayOf(PropTypes.shape()),
+    participations: PropTypes.arrayOf(PropTypes.shape())
   })
 };
 

--- a/app/src/pages/CreateGroup/CreateGroup.jsx
+++ b/app/src/pages/CreateGroup/CreateGroup.jsx
@@ -224,9 +224,10 @@ function CreateGroup() {
 
           <MembersSelector
             members={members}
-            roles={Object.entries(GroupRoleProps).map(([groupRole, props]) => {
+            roles={Object.entries(GroupRoleProps).map(([groupRole, groupProps]) => {
               return {
-                label: props.name,
+
+                label: groupProps.name,
                 value: groupRole,
                 icon: getRoleTypeIcon(groupRole)
               };

--- a/app/src/pages/EditGroup/EditGroup.jsx
+++ b/app/src/pages/EditGroup/EditGroup.jsx
@@ -247,9 +247,9 @@ function EditGroup() {
 
           <MembersSelector
             members={members}
-            roles={Object.entries(GroupRoleProps).map(([groupRole, props]) => {
+            roles={Object.entries(GroupRoleProps).map(([groupRole, groupProps]) => {
               return {
-                label: props.name,
+                label: groupProps.name,
                 value: groupRole,
                 icon: getRoleTypeIcon(groupRole)
               };

--- a/app/src/pages/Player/containers/Gained.jsx
+++ b/app/src/pages/Player/containers/Gained.jsx
@@ -41,7 +41,7 @@ function Gained() {
   const [isReducedChart, setReducedChart] = useState(true);
 
   const metric = getSelectedMetric(context.metric, metricType);
-  const measure = MetricProps[metric].measure;
+  const { measure } = MetricProps[metric];
   const periodIndex = PERIOD_OPTIONS.findIndex(o => o.value === period);
   const metricTypeIndex = METRIC_TYPE_OPTIONS.findIndex(o => o.value === metricType);
 

--- a/app/src/pages/Player/containers/Header.jsx
+++ b/app/src/pages/Player/containers/Header.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
 import { getPlayerTypeIcon, getPlayerTooltip, getOfficialHiscoresUrl } from 'utils';
 import { PageHeader, Dropdown, Button, Badge } from 'components';
 
@@ -65,6 +64,7 @@ function Header(props) {
 }
 
 function FlaggedWarning({ displayName }) {
+  // eslint-disable-next-line no-unused-vars
   const nameChangeURL = `/names/submit/${displayName}`;
 
   // return (
@@ -92,10 +92,11 @@ function FlaggedWarning({ displayName }) {
         This player is flagged.
         <br />
         <br />
-        <b>Update:</b> The official OSRS hiscores were down from Wednesday (July 6th) up until July 9th
-        during which time there were numerous rollbacks, which means some people's stats are higher on
+        <b>Update:</b>
+        The official OSRS hiscores were down from Wednesday (July 6th) up until July 9th
+        during which time there were numerous rollbacks, which means some people&apos;s stats are higher on
         WOM than on the current version of the hiscores. This caused a large amount of players to be
-        falsely detected as "flagged".
+        falsely detected as &quot;flagged&quot;.
         <br />
         <br />
         <b>
@@ -104,7 +105,7 @@ function FlaggedWarning({ displayName }) {
         </b>
         <br />
         <br />
-        Didn't work? Join our &nbsp;
+        Didn&apos;t work? Join our &nbsp;
         <a href="https://wiseoldman.net/discord" target="_blank" rel="noopener noreferrer">
           Discord server
         </a>

--- a/app/src/pages/Player/containers/Overview.jsx
+++ b/app/src/pages/Player/containers/Overview.jsx
@@ -120,9 +120,10 @@ function Overview() {
 function ClosestSkills({ player }) {
   const expAt99 = getExperienceAt(99);
   const expLeftTo99 = skill => expAt99 - player.latestSnapshot.data.skills[skill].experience;
+  const getLevel = skill => player.latestSnapshot.data.skills[skill].level;
 
   const diffs = SKILLS.filter(s => s !== 'overall')
-    .map(s => ({ skill: s, expLeft: Math.max(0, expLeftTo99(s)) }))
+    .map(s => ({ skill: s, expLeft: Math.max(0, expLeftTo99(s)), level: getLevel(s) }))
     .filter(s => s.expLeft > 0)
     .sort((a, b) => a.expLeft - b.expLeft)
     .slice(0, 5);
@@ -133,7 +134,7 @@ function ClosestSkills({ player }) {
 
   const diffItems = diffs.map(d => ({
     icon: getMetricIcon(d.skill),
-    title: `99 ${capitalize(d.skill)}`,
+    title: `${d.level} ${capitalize(d.skill)}`,
     subtitle: `${formatNumber(d.expLeft)} exp left`
   }));
 

--- a/app/src/redux/groups/actions.js
+++ b/app/src/redux/groups/actions.js
@@ -10,7 +10,7 @@ const create = (name, description, clanChat, homeworld, members) => async dispat
       name,
       description,
       clanChat,
-      homeworld: homeworld ? parseInt(homeworld) : undefined,
+      homeworld: homeworld ? parseInt(homeworld, 10) : undefined,
       members
     };
     const { data } = await api.post(endpoints.createGroup, body);

--- a/app/src/redux/groups/reducer.js
+++ b/app/src/redux/groups/reducer.js
@@ -1,5 +1,4 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { omit } from 'lodash';
 import { toMap } from '../utils';
 
 const initialState = {


### PR DESCRIPTION
I found myself wondering what the skill levels on nearest 99s were and had to look at the other skill component to see.

This PR shows those levels of the top 5 nearest skills to 99 on the player overview.

Screenshot:
![image](https://user-images.githubusercontent.com/51417989/219547861-275197d7-975a-41d2-b2ad-adcf34ebadc7.png)
