### PR TITLE
Add "latestSnapshotId" field to the "player" table

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.1.33",
+  "version": "2.1.34",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.1.33",
+      "version": "2.1.34",
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^4.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.1.33",
+  "version": "2.1.34",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/prisma/migrations/20230217113624_add_latest_snapshot_id/migration.sql
+++ b/server/prisma/migrations/20230217113624_add_latest_snapshot_id/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "players" ADD COLUMN     "latestSnapshotId" INTEGER;
+
+-- AddForeignKey
+ALTER TABLE "players" ADD CONSTRAINT "players_latestSnapshotId_fkey" FOREIGN KEY ("latestSnapshotId") REFERENCES "snapshots"("id") ON DELETE SET NULL ON UPDATE NO ACTION;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -248,24 +248,26 @@ model Participation {
 }
 
 model Player {
-  id             Int         @id @default(autoincrement())
-  username       String      @unique @db.VarChar(12)
-  displayName    String      @db.VarChar(12)
-  type           PlayerType  @default(unknown)
-  build          PlayerBuild @default(main)
-  country        Country?
-  flagged        Boolean     @default(false)
-  exp            BigInt      @default(0)
-  ehp            Float       @default(0)
-  ehb            Float       @default(0)
-  ttm            Float       @default(0)
-  tt200m         Float       @default(0)
-  registeredAt   DateTime    @default(now()) @db.Timestamptz(6)
-  updatedAt      DateTime?   @updatedAt @db.Timestamptz(6)
-  lastChangedAt  DateTime?   @db.Timestamptz(6)
-  lastImportedAt DateTime?   @db.Timestamptz(6)
+  id               Int         @id @default(autoincrement())
+  username         String      @unique @db.VarChar(12)
+  displayName      String      @db.VarChar(12)
+  type             PlayerType  @default(unknown)
+  build            PlayerBuild @default(main)
+  country          Country?
+  flagged          Boolean     @default(false)
+  exp              BigInt      @default(0)
+  ehp              Float       @default(0)
+  ehb              Float       @default(0)
+  ttm              Float       @default(0)
+  tt200m           Float       @default(0)
+  registeredAt     DateTime    @default(now()) @db.Timestamptz(6)
+  updatedAt        DateTime?   @updatedAt @db.Timestamptz(6)
+  lastChangedAt    DateTime?   @db.Timestamptz(6)
+  lastImportedAt   DateTime?   @db.Timestamptz(6)
+  latestSnapshotId Int?
 
   // Relations
+  latestSnapshot Snapshot?       @relation("player_latest_snapshot", fields: [latestSnapshotId], references: [id], onDelete: SetNull, onUpdate: NoAction)
   achievements   Achievement[]
   deltas         Delta[]
   memberships    Membership[]
@@ -492,6 +494,7 @@ model Snapshot {
   player                     Player          @relation(fields: [playerId], references: [id], onDelete: Cascade, onUpdate: NoAction)
   participationStartPointers Participation[] @relation("participations_endSnapshotIdTosnapshots")
   participationEndPointers   Participation[] @relation("participations_startSnapshotIdTosnapshots")
+  Player                     Player[]        @relation("player_latest_snapshot")
 
   // Indices
   @@index([playerId, createdAt(sort: Desc)], map: "snapshots_player_id_created_at")

--- a/server/src/api/modules/efficiency/services/FindEfficiencyLeaderboardsService.ts
+++ b/server/src/api/modules/efficiency/services/FindEfficiencyLeaderboardsService.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import prisma, { modifyPlayers, Player, PrismaPlayer, PrismaTypes } from '../../../../prisma';
+import prisma, { modifyPlayer, Player, PrismaPlayer, PrismaTypes } from '../../../../prisma';
 import { PlayerType, PlayerBuild, Metric, Country } from '../../../../utils';
 import { PAGINATION_SCHEMA } from '../../../util/validation';
 
@@ -54,7 +54,7 @@ async function fetchPlayersList(params: FindEfficiencyLeaderboardsParams) {
         take: params.limit,
         skip: params.offset
       })
-      .then(modifyPlayers);
+      .then(p => p.map(modifyPlayer));
 
     return players;
   }
@@ -86,7 +86,7 @@ async function fetchPlayersList(params: FindEfficiencyLeaderboardsParams) {
     lastImportedAt: p.lastImportedAt ? new Date(p.lastImportedAt) : null
   }));
 
-  return modifyPlayers(fixedPlayers);
+  return fixedPlayers.map(modifyPlayer);
 }
 
 export { findEfficiencyLeaderboards };

--- a/server/src/api/modules/players/services/FetchPlayerDetailsService.ts
+++ b/server/src/api/modules/players/services/FetchPlayerDetailsService.ts
@@ -4,9 +4,9 @@ import * as snapshotUtils from '../../snapshots/snapshot.utils';
 import * as efficiencyUtils from '../../efficiency/efficiency.utils';
 import { PlayerDetails } from '../player.types';
 
-async function fetchPlayerDetails(player: Player, lastSnapshot?: Snapshot): Promise<PlayerDetails> {
+async function fetchPlayerDetails(player: Player, latestSnapshot?: Snapshot): Promise<PlayerDetails> {
   // Fetch the player's latest snapshot, if not supplied yet
-  const stats = lastSnapshot || (await snapshotServices.findPlayerSnapshot({ id: player.id }));
+  const stats = latestSnapshot || (await snapshotServices.findPlayerSnapshot({ id: player.id }));
 
   const efficiency = stats && efficiencyUtils.getPlayerEfficiencyMap(stats, player);
   const combatLevel = snapshotUtils.getCombatLevelFromSnapshot(stats);

--- a/server/src/api/modules/players/services/FindPlayersService.ts
+++ b/server/src/api/modules/players/services/FindPlayersService.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import prisma, { modifyPlayers, Player } from '../../../../prisma';
+import prisma, { modifyPlayer, Player } from '../../../../prisma';
 import { sanitize, standardize } from '../player.utils';
 
 const inputSchema = z
@@ -42,7 +42,7 @@ async function findPlayersByUsername(usernames: string[]): Promise<Player[]> {
     .findMany({
       where: { username: { in: standardizedUsernames } }
     })
-    .then(modifyPlayers);
+    .then(p => p.map(modifyPlayer));
 
   return players.sort(
     (a, b) => standardizedUsernames.indexOf(a.username) - standardizedUsernames.indexOf(b.username)
@@ -67,7 +67,7 @@ async function findOrCreatePlayersByUsername(usernames: string[]): Promise<Playe
     .findMany({
       where: { username: { in: newPlayerInputs.map(n => n.username) } }
     })
-    .then(modifyPlayers);
+    .then(p => p.map(modifyPlayer));
 
   // Sort the resulting players list by the order of the input usernames
   const standardizedUsernames = usernames.map(standardize);
@@ -82,7 +82,7 @@ async function findPlayersById(ids: number[]): Promise<Player[]> {
     .findMany({
       where: { id: { in: ids } }
     })
-    .then(modifyPlayers);
+    .then(p => p.map(modifyPlayer));
 
   return players;
 }

--- a/server/src/api/modules/players/services/SearchPlayersService.ts
+++ b/server/src/api/modules/players/services/SearchPlayersService.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import prisma, { modifyPlayers, Player } from '../../../../prisma';
+import prisma, { modifyPlayer, Player } from '../../../../prisma';
 import { PAGINATION_SCHEMA } from '../../../util/validation';
 
 const inputSchema = z
@@ -24,7 +24,7 @@ async function searchPlayers(payload: SearchPlayersParams): Promise<Player[]> {
       take: params.limit,
       skip: params.offset
     })
-    .then(modifyPlayers);
+    .then(p => p.map(modifyPlayer));
 
   return players;
 }

--- a/server/src/prisma/index.ts
+++ b/server/src/prisma/index.ts
@@ -53,12 +53,15 @@ function modifyDeltas(deltas: PrismaDelta[]): Delta[] {
   return deltas.map(d => ({ ...d, overall: parseBigInt(d.overall) }));
 }
 
-function modifyPlayers(players: PrismaPlayer[]): Player[] {
-  return players.map(p => ({ ...p, exp: parseBigInt(p.exp) }));
-}
-
 function modifyPlayer(player: PrismaPlayer): Player {
-  return player ? { ...player, exp: parseBigInt(player.exp) } : null;
+  const modifiedPlayer = player ? { ...player, exp: parseBigInt(player.exp) } : null;
+
+  // TODO: Temporary until latestSnapshotId becomes public
+  if (modifiedPlayer) {
+    delete modifiedPlayer.latestSnapshotId;
+  }
+
+  return modifiedPlayer;
 }
 
 function modifySnapshot(snapshot: PrismaSnapshot): Snapshot {
@@ -93,7 +96,7 @@ type Snapshot = Omit<PrismaSnapshot, 'overallExperience'> & {
   overallExperience: number;
 };
 
-type Player = Omit<PrismaPlayer, 'exp'> & {
+type Player = Omit<PrismaPlayer, 'exp' | 'latestSnapshotId'> & {
   exp: number;
 };
 
@@ -123,7 +126,6 @@ export {
   modifyDelta,
   modifyDeltas,
   modifyPlayer,
-  modifyPlayers,
   modifyRecords,
   modifySnapshot,
   modifySnapshots,


### PR DESCRIPTION
This field will be populated on player updates from now on. It isn't used anywhere yet (and it's actually omitted from API responses).

I'm adding this field & its population, months ahead of my plans to use it, to allow some time for the majority of the user base to get updated in the meantime.

Right now, to get a player's latest snapshot (which we do a lot), we have to essentially do
`SELECT * FROM snapshots WHERE "playerId" = X ORDER BY "createdAt" DESC LIMIT 1` on a table with 60M+ rows 👎

This isn't great for large groups (500+) (we do some fancier queries for batch fetches, but still...). Ideally this field would allow for some fast SQL joins, we'll see.