### PR TITLE
Only update competition participants if an array was supplied

### DIFF
--- a/server/__tests__/suites/integration/competitions.test.ts
+++ b/server/__tests__/suites/integration/competitions.test.ts
@@ -1075,6 +1075,34 @@ describe('Competition API', () => {
       expect(onParticipantsJoinedEvent).not.toHaveBeenCalled();
     });
 
+    it('should not edit teams (teams undefined)', async () => {
+      const getResponse = await api.get(`/competitions/${globalData.testCompetitionEnding.id}`);
+      expect(getResponse.status).toBe(200);
+
+      const response = await api.put(`/competitions/${globalData.testCompetitionEnding.id}`).send({
+        verificationCode: globalData.testCompetitionEnding.verificationCode,
+        title: getResponse.body.title,
+        teams: undefined
+      });
+
+      expect(response.status).toBe(200);
+      expect(getResponse.body.participations.count).toEqual(response.body.participations.count);
+    });
+
+    it('should not edit participants (participants undefined)', async () => {
+      const getResponse = await api.get(`/competitions/${globalData.testCompetitionEnding.id}`);
+      expect(getResponse.status).toBe(200);
+
+      const response = await api.put(`/competitions/${globalData.testCompetitionEnding.id}`).send({
+        verificationCode: globalData.testCompetitionEnding.verificationCode,
+        title: getResponse.body.title,
+        participants: undefined
+      });
+
+      expect(response.status).toBe(200);
+      expect(getResponse.body.participations.count).toEqual(response.body.participations.count);
+    });
+
     it('should edit (own fields)', async () => {
       const response = await api.put(`/competitions/${globalData.testCompetitionStarting.id}`).send({
         verificationCode: globalData.testCompetitionStarting.verificationCode,

--- a/server/__tests__/suites/integration/competitions.test.ts
+++ b/server/__tests__/suites/integration/competitions.test.ts
@@ -1086,7 +1086,7 @@ describe('Competition API', () => {
       });
 
       expect(response.status).toBe(200);
-      expect(getResponse.body.participations.count).toEqual(response.body.participations.count);
+      expect(getResponse.body.participations.length).toEqual(response.body.participations.length);
     });
 
     it('should not edit participants (participants undefined)', async () => {
@@ -1100,7 +1100,7 @@ describe('Competition API', () => {
       });
 
       expect(response.status).toBe(200);
-      expect(getResponse.body.participations.count).toEqual(response.body.participations.count);
+      expect(getResponse.body.participations.length).toEqual(response.body.participations.length);
     });
 
     it('should edit (own fields)', async () => {

--- a/server/__tests__/utils.ts
+++ b/server/__tests__/utils.ts
@@ -18,7 +18,10 @@ async function readFile(path: string) {
 
 async function resetDatabase() {
   const modelNames = Object.keys(prisma).filter(k => !k.startsWith('_'));
-  await Promise.all(modelNames.map(model => prisma[model].deleteMany()));
+
+  for (const model of modelNames) {
+    await prisma[model].deleteMany();
+  }
 }
 
 async function resetRedis() {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.1.37",
+  "version": "2.1.38",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.1.37",
+      "version": "2.1.38",
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^4.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.1.37",
+  "version": "2.1.38",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",


### PR DESCRIPTION
This PR fixes a bug where Edit Competition would reset participants even if the consumer did not supply a value for participants.

Closes #1077 