### PR TITLE
Fix discord dispatch altering API response

### DIFF
--- a/server/__tests__/suites/integration/competitions.test.ts
+++ b/server/__tests__/suites/integration/competitions.test.ts
@@ -480,6 +480,7 @@ describe('Competition API', () => {
       expect(response.body.competition.groupId).toBeNull();
       expect(response.body.competition.group).not.toBeDefined();
       expect(response.body.competition.verificationHash).not.toBeDefined();
+      expect(response.body.competition.participations.length).toBe(0);
 
       expect(onCompetitionCreatedEvent).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -524,6 +525,7 @@ describe('Competition API', () => {
       expect(response.body.competition.groupId).toBeNull();
       expect(response.body.competition.group).not.toBeDefined();
       expect(response.body.competition.verificationHash).not.toBeDefined();
+      expect(response.body.competition.participations.length).toBe(4);
 
       expect(onCompetitionCreatedEvent).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/server/src/api/services/external/discord.service.ts
+++ b/server/src/api/services/external/discord.service.ts
@@ -7,6 +7,7 @@ import {
   CompetitionWithParticipations
 } from '../../modules/competitions/competition.types';
 import * as playerServices from '../../modules/players/player.services';
+import { omit } from 'lodash';
 
 export interface EventPeriodDelay {
   hours?: number;
@@ -113,10 +114,11 @@ async function dispatchMembersLeft(groupId: number, playerIds: number[]) {
  * Dispatch a competition created event to our discord bot API.
  */
 function dispatchCompetitionCreated(competition: CompetitionWithParticipations) {
-  // Omit this field when sending to discord, to prevent sending a huge payload unnecessarily
-  delete competition.participations;
-
-  dispatch('COMPETITION_CREATED', { groupId: competition.groupId, competition });
+  // Omit participations field when sending to discord, to decrease payload size
+  dispatch('COMPETITION_CREATED', {
+    groupId: competition.groupId,
+    competition: omit(competition, 'participations')
+  });
 }
 
 /**
@@ -146,10 +148,12 @@ function dispatchCompetitionEnded(competition: CompetitionDetails) {
     .map(p => ({ displayName: p.player.displayName, teamName: p.teamName, gained: p.progress.gained }))
     .slice(0, 10);
 
-  // Omit this field when sending to discord, to prevent sending a huge payload unnecessarily
-  delete competition.participations;
-
-  dispatch('COMPETITION_ENDED', { groupId, competition, standings });
+  // Omit participations field when sending to discord, to decrease payload size
+  dispatch('COMPETITION_ENDED', {
+    competition: omit(competition, 'participations'),
+    standings,
+    groupId
+  });
 }
 
 /**


### PR DESCRIPTION
This PR omits the participations during discord competition created and deleted events instead of deleting the key altogether which was causing no participations to be returned by the API.

I purposely didn't alter the API version to prevent conflicts with the other open PR #1078 

Closes #1080 

![image](https://user-images.githubusercontent.com/51417989/220167751-d472647e-247a-43ee-820f-2d6cfa6c4cc6.png)
