### PR TITLE
Fallback to checking Ironman and FSW hiscores in name change reviews

### DIFF
--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -70,3 +70,18 @@ jobs:
 
       - name: Build & Type Check
         run: cd client-js && npm run build
+  type-check-server:
+    name: Type-check Server package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+
+      - name: Install server dependencies
+        run: cd server && npm ci
+
+      - name: Build & Type Check
+        run: cd server && npm run build

--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Run type-checking
+        run: npm run build
+
       - name: Run Integration Tests
         run: npm run test -
   type-check-client-js:
@@ -70,18 +73,3 @@ jobs:
 
       - name: Build & Type Check
         run: cd client-js && npm run build
-  type-check-server:
-    name: Type-check Server package
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-
-      - name: Install server dependencies
-        run: cd server && npm ci
-
-      - name: Build & Type Check
-        run: cd server && npm run build

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.1.39",
+  "version": "2.1.40",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.1.39",
+      "version": "2.1.40",
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^4.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.1.39",
+  "version": "2.1.40",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,7 @@
     "node": ">=16.14.0"
   },
   "scripts": {
-    "build": "rm -rf ./dist/ && tsc",
+    "build": "rm -rf ./dist/ && prisma generate && tsc",
     "lint": "eslint . --ext .ts",
     "prisma:generate": "prisma generate",
     "dev": "cross-env ./scripts/run-dev.sh",

--- a/server/src/api/modules/name-changes/services/FetchNameChangeDetailsService.ts
+++ b/server/src/api/modules/name-changes/services/FetchNameChangeDetailsService.ts
@@ -36,7 +36,9 @@ async function fetchNameChangeDetails(payload: FetchDetailsParams): Promise<Name
 
   try {
     // Attempt to fetch hiscores data for the new name
-    newHiscores = await jagexService.getHiscoresData(nameChange.newName);
+    // if they can't be found on the regular hiscores, fallback to trying the ironman and FSW hiscores
+    // before asserting that the new name is not on the hiscores at all
+    newHiscores = await fetchHiscoresWithFallback(nameChange.newName);
   } catch (e) {
     // If te hiscores failed to load, abort mission
     if (e instanceof ServerError) throw e;
@@ -130,6 +132,31 @@ async function fetchNameChangeDetails(payload: FetchDetailsParams): Promise<Name
       newStats: snapshotUtils.format(newStats, newPlayerEfficiencyMap)
     }
   };
+}
+
+async function fetchHiscoresWithFallback(username: string) {
+  // Try fetching from the regular hiscores
+  try {
+    return await jagexService.getHiscoresData(username);
+  } catch (error) {
+    if (error instanceof ServerError) throw error;
+  }
+
+  // If the regular hiscores failed, try the ironman hiscores
+  try {
+    return await jagexService.getHiscoresData(username, PlayerType.IRONMAN);
+  } catch (error) {
+    if (error instanceof ServerError) throw error;
+  }
+
+  // If the ironman hiscores failed, finally, try the FSW hiscores
+  try {
+    return await jagexService.getHiscoresData(username, PlayerType.FRESH_START);
+  } catch (error) {
+    if (error instanceof ServerError) throw error;
+  }
+
+  return undefined;
 }
 
 export { fetchNameChangeDetails };

--- a/server/src/api/modules/name-changes/services/FetchNameChangeDetailsService.ts
+++ b/server/src/api/modules/name-changes/services/FetchNameChangeDetailsService.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-// import { PlayerType } from '../../../../utils';
+import { PlayerType } from '../../../../utils';
 import prisma, { NameChangeStatus } from '../../../../prisma';
 import { NotFoundError, ServerError } from '../../../errors';
 import * as jagexService from '../../../services/external/jagex.service';

--- a/server/src/api/modules/name-changes/services/FetchNameChangeDetailsService.ts
+++ b/server/src/api/modules/name-changes/services/FetchNameChangeDetailsService.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { PlayerType } from '../../../../utils';
+// import { PlayerType } from '../../../../utils';
 import prisma, { NameChangeStatus } from '../../../../prisma';
 import { NotFoundError, ServerError } from '../../../errors';
 import * as jagexService from '../../../services/external/jagex.service';

--- a/server/src/api/modules/name-changes/services/FetchNameChangeDetailsService.ts
+++ b/server/src/api/modules/name-changes/services/FetchNameChangeDetailsService.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { PlayerType } from '../../../../utils';
 import prisma, { NameChangeStatus } from '../../../../prisma';
 import { NotFoundError, ServerError } from '../../../errors';
 import * as jagexService from '../../../services/external/jagex.service';


### PR DESCRIPTION
Fixes #1079 

> Name changes get auto-denied when the new stats can't be found on the regular hiscores.
>
>This is a problem for low level ironmen (and possibly FSW/builds?) since they can be unranked in the regular hiscores, despite having WOM histories (fetched from their respective hiscores)
>
>Possible solution:
>
>If fails to fetch current hiscores stats (in FetchNameChangeDetailsService) from regular hiscores, fallback to trying FSW or IM hiscores