### PR TITLE
Add MetricLeaders to group statistics

### DIFF
--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "2.0.15",
+  "version": "2.1.0",
   "description": "A JavaScript/TypeScript client that interfaces and consumes the Wise Old Man API, an API that tracks and measures players' progress in Old School Runescape.",
   "keywords": [
     "wiseoldman",

--- a/docs/docs/groups-api/group-endpoints.mdx
+++ b/docs/docs/groups-api/group-endpoints.mdx
@@ -1671,6 +1671,113 @@ const statistics = await client.groups.getGroupStatistics(123);
         // ... etc for all computed metrics
       }
     }
+  },
+  "best": {
+    skills: {
+      "overall": {
+        "metric": "overall",
+        "experience": 84528862,
+        "rank": 505825,
+        "level": 1939,
+        "player": {
+          "id": 151063,
+          "username": "zezimas bro",
+          "displayName": "Zezimas bro",
+          "type": "regular",
+          "build": "main",
+          "country": null,
+          "flagged": false,
+          "exp": 330940032,
+          "ehp": 1057.05253,
+          "ehb": 126.50192,
+          "ttm": 0,
+          "tt200m": 12467.36769,
+          "registeredAt": "2021-01-29T01:18:41.641Z",
+          "updatedAt": "2022-10-01T17:02:03.360Z",
+          "lastChangedAt": "2022-10-01T17:02:03.129Z",
+          "lastImportedAt": null
+        }
+      }
+      // ... etc for all skills
+    },
+    "bosses": {
+      "abyssal_sire": {
+        "metric": "abyssal_sire",
+        "kills": 58,
+        "rank": 5188,
+        "player": {
+          "id": 322795,
+          "username": "zezimas main",
+          "displayName": "Zezimas Main",
+          "type": "ironman",
+          "build": "main",
+          "country": null,
+          "flagged": false,
+          "exp": 164428785,
+          "ehp": 800.36287,
+          "ehb": 258.43421,
+          "ttm": 963.15034,
+          "tt200m": 21652.44844,
+          "registeredAt": "2021-07-30T20:36:49.447Z",
+          "updatedAt": "2022-09-22T17:47:38.096Z",
+          "lastChangedAt": "2022-09-22T17:47:37.411Z",
+          "lastImportedAt": "2022-09-22T17:47:38.096Z"
+        }
+      }
+      // ... etc for all bosses
+    },
+    "activities": {
+      "bounty_hunter_hunter": {
+        "metric": "bounty_hunter_hunter",
+        "score": 0,
+        "rank": 8371
+        "player": {
+          "id": 322795,
+          "username": "zezimas main",
+          "displayName": "Zezimas Main",
+          "type": "ironman",
+          "build": "main",
+          "country": null,
+          "flagged": false,
+          "exp": 164428785,
+          "ehp": 800.36287,
+          "ehb": 258.43421,
+          "ttm": 963.15034,
+          "tt200m": 21652.44844,
+          "registeredAt": "2021-07-30T20:36:49.447Z",
+          "updatedAt": "2022-09-22T17:47:38.096Z",
+          "lastChangedAt": "2022-09-22T17:47:37.411Z",
+          "lastImportedAt": "2022-09-22T17:47:38.096Z"
+        }
+      }
+      // ... etc for all activities
+    },
+    "computed": {
+      "ehp": {
+        "metric": "ehp",
+        "value": 289,
+        "rank": 111876,
+        "player": {
+          "id": 151063,
+          "username": "zezimas bro",
+          "displayName": "Zezimas bro",
+          "type": "regular",
+          "build": "main",
+          "country": null,
+          "flagged": false,
+          "exp": 330940032,
+          "ehp": 1057.05253,
+          "ehb": 126.50192,
+          "ttm": 0,
+          "tt200m": 12467.36769,
+          "registeredAt": "2021-01-29T01:18:41.641Z",
+          "updatedAt": "2022-10-01T17:02:03.360Z",
+          "lastChangedAt": "2022-10-01T17:02:03.129Z",
+          "lastImportedAt": null
+        }
+      }
+      // ... etc for all computed metrics
+    }
   }
 }
 ```

--- a/docs/docs/groups-api/group-endpoints.mdx
+++ b/docs/docs/groups-api/group-endpoints.mdx
@@ -1672,13 +1672,14 @@ const statistics = await client.groups.getGroupStatistics(123);
       }
     }
   },
-  "best": {
+  "metricLeaders": {
     skills: {
       "overall": {
         "metric": "overall",
         "experience": 84528862,
         "rank": 505825,
         "level": 1939,
+        "playerId": 151063,
         "player": {
           "id": 151063,
           "username": "zezimas bro",
@@ -1705,6 +1706,7 @@ const statistics = await client.groups.getGroupStatistics(123);
         "metric": "abyssal_sire",
         "kills": 58,
         "rank": 5188,
+        "playerId": 322795,
         "player": {
           "id": 322795,
           "username": "zezimas main",
@@ -1731,6 +1733,7 @@ const statistics = await client.groups.getGroupStatistics(123);
         "metric": "bounty_hunter_hunter",
         "score": 0,
         "rank": 8371
+        "playerId": 322795,
         "player": {
           "id": 322795,
           "username": "zezimas main",
@@ -1757,6 +1760,7 @@ const statistics = await client.groups.getGroupStatistics(123);
         "metric": "ehp",
         "value": 289,
         "rank": 111876,
+        "playerId": 151063,
         "player": {
           "id": 151063,
           "username": "zezimas bro",

--- a/docs/docs/groups-api/group-endpoints.mdx
+++ b/docs/docs/groups-api/group-endpoints.mdx
@@ -1679,7 +1679,6 @@ const statistics = await client.groups.getGroupStatistics(123);
         "experience": 84528862,
         "rank": 505825,
         "level": 1939,
-        "playerId": 151063,
         "player": {
           "id": 151063,
           "username": "zezimas bro",
@@ -1706,7 +1705,6 @@ const statistics = await client.groups.getGroupStatistics(123);
         "metric": "abyssal_sire",
         "kills": 58,
         "rank": 5188,
-        "playerId": 322795,
         "player": {
           "id": 322795,
           "username": "zezimas main",
@@ -1733,7 +1731,6 @@ const statistics = await client.groups.getGroupStatistics(123);
         "metric": "bounty_hunter_hunter",
         "score": 0,
         "rank": 8371
-        "playerId": 322795,
         "player": {
           "id": 322795,
           "username": "zezimas main",
@@ -1760,7 +1757,6 @@ const statistics = await client.groups.getGroupStatistics(123);
         "metric": "ehp",
         "value": 289,
         "rank": 111876,
-        "playerId": 151063,
         "player": {
           "id": 151063,
           "username": "zezimas bro",

--- a/docs/docs/groups-api/group-type-definitions.md
+++ b/docs/docs/groups-api/group-type-definitions.md
@@ -143,11 +143,11 @@ Used as an input for group modification endpoints (create, edit, add members, et
 | maxedTotalCount  | integer                                                                                | The total amount of members with 2277 total level (maxed).      |
 | maxed200msCount  | integer                                                                                | The total amount of 200m exp skills between all members.        |
 | averageStats     | [Snapshot](/players-api/player-type-definitions#object-snapshot)                       | The average stats of all group members.                         |
-| best             | [Best Group Snapshot](/players-api/player-type-definitions#object-best-group-snapshot) | The best player in each metric out of all group members.        |
+| metricLeaders    | [Metric Leaders](/players-api/player-type-definitions#object-metric-leaders)           | The best player in each metric out of all group members.        |
 
 <br />
 
-### `(Object)` Best Group Snapshot
+### `(Object)` Metric Leaders
 
 ```typescript
 {
@@ -158,6 +158,7 @@ Used as an input for group modification endpoints (create, edit, add members, et
       rank: number,
       level: number,
       experience: number // (can be a long/bigint)
+      playerId: number,
       player: {
         id: number,
         username: string,
@@ -185,6 +186,7 @@ Used as an input for group modification endpoints (create, edit, add members, et
       ehb: number,
       rank: number,
       kills: number,
+      playerId: number,
       player: {
         id: number,
         username: string,
@@ -211,6 +213,7 @@ Used as an input for group modification endpoints (create, edit, add members, et
       metric: "bounty_hunter_hunter",
       rank: number,
       score: number,
+      playerId: number,
       player: {
         id: number,
         username: string,
@@ -237,6 +240,7 @@ Used as an input for group modification endpoints (create, edit, add members, et
       metric: "ehp",
       rank: number,
       value: number,
+      playerId: number,
       player: {
         id: number,
         username: string,

--- a/docs/docs/groups-api/group-type-definitions.md
+++ b/docs/docs/groups-api/group-type-definitions.md
@@ -143,7 +143,7 @@ Used as an input for group modification endpoints (create, edit, add members, et
 | maxedTotalCount  | integer                                                                                | The total amount of members with 2277 total level (maxed).      |
 | maxed200msCount  | integer                                                                                | The total amount of 200m exp skills between all members.        |
 | averageStats     | [Snapshot](/players-api/player-type-definitions#object-snapshot)                       | The average stats of all group members.                         |
-| metricLeaders    | [Metric Leaders](/players-api/player-type-definitions#object-metric-leaders)           | The best player in each metric out of all group members.        |
+| metricLeaders    | [Metric Leaders](/groups-api/group-type-definitions#object-metric-leaders)             | The best player in each metric out of all group members.        |
 
 <br />
 
@@ -158,7 +158,6 @@ Used as an input for group modification endpoints (create, edit, add members, et
       rank: number,
       level: number,
       experience: number // (can be a long/bigint)
-      playerId: number,
       player: {
         id: number,
         username: string,
@@ -186,7 +185,6 @@ Used as an input for group modification endpoints (create, edit, add members, et
       ehb: number,
       rank: number,
       kills: number,
-      playerId: number,
       player: {
         id: number,
         username: string,
@@ -213,7 +211,6 @@ Used as an input for group modification endpoints (create, edit, add members, et
       metric: "bounty_hunter_hunter",
       rank: number,
       score: number,
-      playerId: number,
       player: {
         id: number,
         username: string,
@@ -240,7 +237,6 @@ Used as an input for group modification endpoints (create, edit, add members, et
       metric: "ehp",
       rank: number,
       value: number,
-      playerId: number,
       player: {
         id: number,
         username: string,

--- a/docs/docs/groups-api/group-type-definitions.md
+++ b/docs/docs/groups-api/group-type-definitions.md
@@ -137,11 +137,128 @@ Used as an input for group modification endpoints (create, edit, add members, et
 
 ### `(Object)` Group Statistics
 
-| Field            | Type                                                             | Description                                                     |
-| :--------------- | :--------------------------------------------------------------- | :-------------------------------------------------------------- |
-| maxedCombatCount | integer                                                          | The total amount of members with 126 combat level (max combat). |
-| maxedTotalCount  | integer                                                          | The total amount of members with 2277 total level (maxed).      |
-| maxed200msCount  | integer                                                          | The total amount of 200m exp skills between all members.        |
-| averageStats     | [Snapshot](/players-api/player-type-definitions#object-snapshot) | The average stats of all group members.                         |
+| Field            | Type                                                                                   | Description                                                     |
+| :--------------- | :------------------------------------------------------------------------------------- | :-------------------------------------------------------------- |
+| maxedCombatCount | integer                                                                                | The total amount of members with 126 combat level (max combat). |
+| maxedTotalCount  | integer                                                                                | The total amount of members with 2277 total level (maxed).      |
+| maxed200msCount  | integer                                                                                | The total amount of 200m exp skills between all members.        |
+| averageStats     | [Snapshot](/players-api/player-type-definitions#object-snapshot)                       | The average stats of all group members.                         |
+| best             | [Best Group Snapshot](/players-api/player-type-definitions#object-best-group-snapshot) | The best player in each metric out of all group members.        |
+
+<br />
+
+### `(Object)` Best Group Snapshot
+
+```typescript
+{
+  skills: {
+    attack: {
+      metric: "attack",
+      ehp: number,
+      rank: number,
+      level: number,
+      experience: number // (can be a long/bigint)
+      player: {
+        id: number,
+        username: string,
+        displayName: string,
+        type: PlayerType,
+        build: PlayerBuild,
+        country: Country?,
+        flagged: boolean,
+        exp: number // (can be a long/bigint),
+        ehp: float,
+        ehb: float,
+        ttm: float,
+        tt200m: float,
+        registeredAt: date,
+        updatedAt: date,
+        lastChangedAt: date?,
+        lastImportedAt: date?
+      }
+    },
+    // ... etc for all skills
+  },
+  bosses: {
+    abyssal_sire: {
+      metric: "abyssal_sire",
+      ehb: number,
+      rank: number,
+      kills: number,
+      player: {
+        id: number,
+        username: string,
+        displayName: string,
+        type: PlayerType,
+        build: PlayerBuild,
+        country: Country?,
+        flagged: boolean,
+        exp: number // (can be a long/bigint),
+        ehp: float,
+        ehb: float,
+        ttm: float,
+        tt200m: float,
+        registeredAt: date,
+        updatedAt: date,
+        lastChangedAt: date?,
+        lastImportedAt: date?
+      }
+    },
+    // ... etc for all bosses
+  },
+  activities: {
+    bounty_hunter_hunter: {
+      metric: "bounty_hunter_hunter",
+      rank: number,
+      score: number,
+      player: {
+        id: number,
+        username: string,
+        displayName: string,
+        type: PlayerType,
+        build: PlayerBuild,
+        country: Country?,
+        flagged: boolean,
+        exp: number // (can be a long/bigint),
+        ehp: float,
+        ehb: float,
+        ttm: float,
+        tt200m: float,
+        registeredAt: date,
+        updatedAt: date,
+        lastChangedAt: date?,
+        lastImportedAt: date?
+      }
+    },
+    // ... etc for all activities
+  },
+  computed: {
+    ehp: {
+      metric: "ehp",
+      rank: number,
+      value: number,
+      player: {
+        id: number,
+        username: string,
+        displayName: string,
+        type: PlayerType,
+        build: PlayerBuild,
+        country: Country?,
+        flagged: boolean,
+        exp: number // (can be a long/bigint),
+        ehp: float,
+        ehb: float,
+        ttm: float,
+        tt200m: float,
+        registeredAt: date,
+        updatedAt: date,
+        lastChangedAt: date?,
+        lastImportedAt: date?
+      }
+    },
+    // ... etc for all computed metrics
+  }
+}
+```
 
 <br />

--- a/server/__tests__/suites/integration/groups.test.ts
+++ b/server/__tests__/suites/integration/groups.test.ts
@@ -1448,7 +1448,7 @@ describe('Group API', () => {
             }
           }
         },
-        best: {
+        metricLeaders: {
           bosses: {
             abyssal_sire: {
               kills: 1049

--- a/server/__tests__/suites/integration/groups.test.ts
+++ b/server/__tests__/suites/integration/groups.test.ts
@@ -1426,6 +1426,7 @@ describe('Group API', () => {
       const response = await api.get(`/groups/${globalData.testGroupOneLeader.id}/statistics`);
 
       expect(response.status).toBe(200);
+      expect(new Date(response.body.averageStats.createdAt).getMonth()).toEqual(new Date().getMonth());
       expect(response.body).toMatchObject({
         maxedCombatCount: 1,
         maxedTotalCount: 1,
@@ -1443,6 +1444,33 @@ describe('Group API', () => {
             skills: {
               magic: {
                 experience: 74929535 // (19288604 + 200000000 + 5500000) / 3
+              }
+            }
+          }
+        },
+        best: {
+          bosses: {
+            abyssal_sire: {
+              kills: 1049
+            },
+            zulrah: {
+              kills: 1646,
+              player: {
+                username: 'psikoi'
+              }
+            }
+          },
+          skills: {
+            agility: {
+              experience: 200000000,
+              player: {
+                username: 'alexsuperfly'
+              }
+            },
+            magic: {
+              experience: 200000000,
+              player: {
+                username: 'alexsuperfly'
               }
             }
           }

--- a/server/__tests__/suites/integration/players.test.ts
+++ b/server/__tests__/suites/integration/players.test.ts
@@ -547,7 +547,7 @@ describe('Player API', () => {
 
       // Mock the history fetch from CML
       registerCMLMock(axiosMock, 404);
-    });
+    }, 10000); // Set the timeout to 10 seconds for this long running test
 
     it('should not import player (too soon)', async () => {
       // Setup the CML request to return our mock raw data

--- a/server/__tests__/suites/unit/snapshots.test.ts
+++ b/server/__tests__/suites/unit/snapshots.test.ts
@@ -1,26 +1,23 @@
-import { Player, Snapshot } from 'src/utils/types';
 import * as snapshotUtils from '../../../src/api/modules/snapshots/snapshot.utils';
 
 describe('Util - Snapshots', () => {
   test('average', () => {
     expect(() => snapshotUtils.average([])).toThrow('Invalid snapshots list. Failed to find average.');
+    expect(() => snapshotUtils.average(null)).toThrow('Invalid snapshots list. Failed to find average.');
+    expect(() => snapshotUtils.average(undefined)).toThrow('Invalid snapshots list. Failed to find average.');
   });
 
   test('getBestInEachMetric', () => {
-    expect(() => snapshotUtils.getBestInEachMetric([], [])).toThrow(
+    expect(() => snapshotUtils.getMetricLeaders([])).toThrow(
       'Invalid snapshots list. Failed to find best players.'
     );
 
-    expect(() => snapshotUtils.getBestInEachMetric([{} as Snapshot], [])).toThrow(
-      'Invalid players list. Failed to find best players.'
-    );
-
-    expect(() => snapshotUtils.getBestInEachMetric([], [{} as Player])).toThrow(
+    expect(() => snapshotUtils.getMetricLeaders(null)).toThrow(
       'Invalid snapshots list. Failed to find best players.'
     );
 
-    expect(() => snapshotUtils.getBestInEachMetric([{} as Snapshot], [{} as Player, {} as Player])).toThrow(
-      'Invalid players list. Failed to find best players.'
+    expect(() => snapshotUtils.getMetricLeaders(undefined)).toThrow(
+      'Invalid snapshots list. Failed to find best players.'
     );
   });
 });

--- a/server/__tests__/suites/unit/snapshots.test.ts
+++ b/server/__tests__/suites/unit/snapshots.test.ts
@@ -1,23 +1,78 @@
-import * as snapshotUtils from '../../../src/api/modules/snapshots/snapshot.utils';
+import { Metric, MetricLeaders, Player } from '../../../src/utils';
+import * as utils from '../../../src/api/modules/snapshots/snapshot.utils';
+
+function buildMockMetricLeaders() {
+  return {
+    skills: {
+      attack: {
+        metric: 'attack'
+      }
+    },
+    bosses: {
+      zulrah: {
+        metric: 'zulrah'
+      }
+    },
+    activities: {
+      bounty_hunter_hunter: {
+        metric: 'bounty_hunter_hunter'
+      }
+    },
+    computed: {
+      ehp: {
+        metric: 'ehp'
+      }
+    }
+  } as unknown as MetricLeaders;
+}
+
+function buildMockPlayers() {
+  return [
+    { id: 1, username: 'jonxslays' },
+    { id: 2, username: 'psikoi' },
+    { id: 3, username: 'alexsuperfly' }
+  ] as unknown as Player[];
+}
+
+function buildMockLeaderIdMap() {
+  const leaderIdMap = new Map<Metric, number>();
+  leaderIdMap.set(Metric.ATTACK, 1);
+  leaderIdMap.set(Metric.ZULRAH, 2);
+  leaderIdMap.set(Metric.BOUNTY_HUNTER_HUNTER, 3);
+  leaderIdMap.set(Metric.EHP, 1);
+  return leaderIdMap;
+}
 
 describe('Util - Snapshots', () => {
   test('average', () => {
-    expect(() => snapshotUtils.average([])).toThrow('Invalid snapshots list. Failed to find average.');
-    expect(() => snapshotUtils.average(null)).toThrow('Invalid snapshots list. Failed to find average.');
-    expect(() => snapshotUtils.average(undefined)).toThrow('Invalid snapshots list. Failed to find average.');
+    expect(() => utils.average([])).toThrow('Invalid snapshots list. Failed to find average.');
+    expect(() => utils.average(null)).toThrow('Invalid snapshots list. Failed to find average.');
+    expect(() => utils.average(undefined)).toThrow('Invalid snapshots list. Failed to find average.');
   });
 
-  test('getBestInEachMetric', () => {
-    expect(() => snapshotUtils.getMetricLeaders([])).toThrow(
-      'Invalid snapshots list. Failed to find best players.'
+  test('getMetricLeaders', () => {
+    expect(() => utils.getMetricLeaders([])).toThrow(
+      'Invalid snapshots list. Failed to find metric leaders.'
     );
 
-    expect(() => snapshotUtils.getMetricLeaders(null)).toThrow(
-      'Invalid snapshots list. Failed to find best players.'
+    expect(() => utils.getMetricLeaders(null)).toThrow(
+      'Invalid snapshots list. Failed to find metric leaders.'
     );
 
-    expect(() => snapshotUtils.getMetricLeaders(undefined)).toThrow(
-      'Invalid snapshots list. Failed to find best players.'
+    expect(() => utils.getMetricLeaders(undefined)).toThrow(
+      'Invalid snapshots list. Failed to find metric leaders.'
     );
+  });
+
+  test('assignPlayersToMetricLeaders', () => {
+    const metricLeaders = buildMockMetricLeaders();
+    const leaderIdMap = buildMockLeaderIdMap();
+    const players = buildMockPlayers();
+    utils.assignPlayersToMetricLeaders(metricLeaders, leaderIdMap, players);
+
+    expect(metricLeaders.skills.attack.player.username).toEqual('jonxslays');
+    expect(metricLeaders.bosses.zulrah.player.username).toEqual('psikoi');
+    expect(metricLeaders.activities.bounty_hunter_hunter.player.username).toEqual('alexsuperfly');
+    expect(metricLeaders.computed.ehp.player.username).toEqual('jonxslays');
   });
 });

--- a/server/__tests__/suites/unit/snapshots.test.ts
+++ b/server/__tests__/suites/unit/snapshots.test.ts
@@ -18,5 +18,9 @@ describe('Util - Snapshots', () => {
     expect(() => snapshotUtils.getBestInEachMetric([], [{} as Player])).toThrow(
       'Invalid snapshots list. Failed to find best players.'
     );
+
+    expect(() => snapshotUtils.getBestInEachMetric([{} as Snapshot], [{} as Player, {} as Player])).toThrow(
+      'Invalid players list. Failed to find best players.'
+    );
   });
 });

--- a/server/__tests__/suites/unit/snapshots.test.ts
+++ b/server/__tests__/suites/unit/snapshots.test.ts
@@ -1,0 +1,22 @@
+import { Player, Snapshot } from 'src/utils/types';
+import * as snapshotUtils from '../../../src/api/modules/snapshots/snapshot.utils';
+
+describe('Util - Snapshots', () => {
+  test('average', () => {
+    expect(() => snapshotUtils.average([])).toThrow('Invalid snapshots list. Failed to find average.');
+  });
+
+  test('getBestInEachMetric', () => {
+    expect(() => snapshotUtils.getBestInEachMetric([], [])).toThrow(
+      'Invalid snapshots list. Failed to find best players.'
+    );
+
+    expect(() => snapshotUtils.getBestInEachMetric([{} as Snapshot], [])).toThrow(
+      'Invalid players list. Failed to find best players.'
+    );
+
+    expect(() => snapshotUtils.getBestInEachMetric([], [{} as Player])).toThrow(
+      'Invalid snapshots list. Failed to find best players.'
+    );
+  });
+});

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.1.42",
+  "version": "2.2.0",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/modules/groups/group.types.ts
+++ b/server/src/api/modules/groups/group.types.ts
@@ -1,6 +1,6 @@
 import { GroupRole } from '../../../utils';
 import { Group, Membership, Player } from '../../../prisma';
-import { FormattedSnapshot } from '../snapshots/snapshot.types';
+import { BestGroupSnapshot, FormattedSnapshot } from '../snapshots/snapshot.types';
 
 export interface GroupListItem extends Omit<Group, 'verificationHash'> {
   memberCount: number;
@@ -58,6 +58,7 @@ export interface GroupStatistics {
   maxedTotalCount: number;
   maxed200msCount: number;
   averageStats: FormattedSnapshot;
+  best: BestGroupSnapshot;
 }
 
 export enum MigrationDataSource {

--- a/server/src/api/modules/groups/group.types.ts
+++ b/server/src/api/modules/groups/group.types.ts
@@ -1,6 +1,6 @@
 import { GroupRole } from '../../../utils';
 import { Group, Membership, Player } from '../../../prisma';
-import { BestGroupSnapshot, FormattedSnapshot } from '../snapshots/snapshot.types';
+import { MetricLeaders, FormattedSnapshot } from '../snapshots/snapshot.types';
 
 export interface GroupListItem extends Omit<Group, 'verificationHash'> {
   memberCount: number;
@@ -58,7 +58,7 @@ export interface GroupStatistics {
   maxedTotalCount: number;
   maxed200msCount: number;
   averageStats: FormattedSnapshot;
-  best: BestGroupSnapshot;
+  metricLeaders: MetricLeaders;
 }
 
 export enum MigrationDataSource {

--- a/server/src/api/modules/groups/services/FetchGroupStatisticsService.ts
+++ b/server/src/api/modules/groups/services/FetchGroupStatisticsService.ts
@@ -11,7 +11,8 @@ import {
   average,
   getCombatLevelFromSnapshot,
   getTotalLevel,
-  getMetricLeaders
+  getMetricLeaders,
+  assignPlayersToMetricLeaders
 } from '../../snapshots/snapshot.utils';
 import { GroupStatistics } from '../group.types';
 
@@ -61,7 +62,11 @@ async function fetchGroupStatistics(payload: FetchGroupStatisticsParams): Promis
   });
 
   const averageStats = format(averageSnapshot, averageEfficiencyMap);
-  const metricLeaders = getMetricLeaders(snapshots);
+
+  const { metricLeaders, leaderIdMap } = getMetricLeaders(snapshots);
+  const leaderIds = [...new Set(leaderIdMap.values())];
+  const players = await playerServices.findPlayers({ ids: leaderIds });
+  assignPlayersToMetricLeaders(metricLeaders, leaderIdMap, players);
 
   return { maxedCombatCount, maxedTotalCount, maxed200msCount, averageStats, metricLeaders };
 }

--- a/server/src/api/modules/groups/services/FetchGroupStatisticsService.ts
+++ b/server/src/api/modules/groups/services/FetchGroupStatisticsService.ts
@@ -11,7 +11,7 @@ import {
   average,
   getCombatLevelFromSnapshot,
   getTotalLevel,
-  getBestInEachMetric
+  getMetricLeaders
 } from '../../snapshots/snapshot.utils';
 import { GroupStatistics } from '../group.types';
 
@@ -61,10 +61,9 @@ async function fetchGroupStatistics(payload: FetchGroupStatisticsParams): Promis
   });
 
   const averageStats = format(averageSnapshot, averageEfficiencyMap);
-  const players = await playerServices.findPlayers({ ids: snapshots.map(s => s.playerId) });
-  const best = getBestInEachMetric(snapshots, players);
+  const metricLeaders = getMetricLeaders(snapshots);
 
-  return { maxedCombatCount, maxedTotalCount, maxed200msCount, averageStats, best };
+  return { maxedCombatCount, maxedTotalCount, maxed200msCount, averageStats, metricLeaders };
 }
 
 export { fetchGroupStatistics };

--- a/server/src/api/modules/groups/services/FetchGroupStatisticsService.ts
+++ b/server/src/api/modules/groups/services/FetchGroupStatisticsService.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import prisma from '../../../../prisma';
 import { PlayerBuild, PlayerType } from '../../../../utils';
 import { NotFoundError, BadRequestError } from '../../../errors';
+import * as playerServices from '../../players/player.services';
 import * as snapshotServices from '../../snapshots/snapshot.services';
 import * as efficiencyUtils from '../../efficiency/efficiency.utils';
 import {
@@ -9,7 +10,8 @@ import {
   format,
   average,
   getCombatLevelFromSnapshot,
-  getTotalLevel
+  getTotalLevel,
+  getBestInEachMetric
 } from '../../snapshots/snapshot.utils';
 import { GroupStatistics } from '../group.types';
 
@@ -59,8 +61,10 @@ async function fetchGroupStatistics(payload: FetchGroupStatisticsParams): Promis
   });
 
   const averageStats = format(averageSnapshot, averageEfficiencyMap);
+  const players = await playerServices.findPlayers({ ids: snapshots.map(s => s.playerId) });
+  const best = getBestInEachMetric(snapshots, players);
 
-  return { maxedCombatCount, maxedTotalCount, maxed200msCount, averageStats };
+  return { maxedCombatCount, maxedTotalCount, maxed200msCount, averageStats, best };
 }
 
 export { fetchGroupStatistics };

--- a/server/src/api/modules/snapshots/snapshot.types.ts
+++ b/server/src/api/modules/snapshots/snapshot.types.ts
@@ -17,6 +17,7 @@ export interface SkillValue {
 }
 
 export interface SkillValueWithPlayer extends SkillValue {
+  playerId: number;
   player: Player;
 }
 
@@ -28,6 +29,7 @@ export interface BossValue {
 }
 
 export interface BossValueWithPlayer extends BossValue {
+  playerId: number;
   player: Player;
 }
 
@@ -38,6 +40,7 @@ export interface ActivityValue {
 }
 
 export interface ActivityValueWithPlayer extends ActivityValue {
+  playerId: number;
   player: Player;
 }
 
@@ -48,10 +51,11 @@ export interface ComputedMetricValue {
 }
 
 export interface ComputedMetricValueWithPlayer extends ComputedMetricValue {
+  playerId: number;
   player: Player;
 }
 
-export interface BestGroupSnapshot {
+export interface MetricLeaders {
   skills: MapOf<Skill, SkillValueWithPlayer>;
   bosses: MapOf<Boss, BossValueWithPlayer>;
   activities: MapOf<Activity, ActivityValueWithPlayer>;

--- a/server/src/api/modules/snapshots/snapshot.types.ts
+++ b/server/src/api/modules/snapshots/snapshot.types.ts
@@ -17,7 +17,6 @@ export interface SkillValue {
 }
 
 export interface SkillValueWithPlayer extends SkillValue {
-  playerId: number;
   player: Player;
 }
 
@@ -29,7 +28,6 @@ export interface BossValue {
 }
 
 export interface BossValueWithPlayer extends BossValue {
-  playerId: number;
   player: Player;
 }
 
@@ -40,7 +38,6 @@ export interface ActivityValue {
 }
 
 export interface ActivityValueWithPlayer extends ActivityValue {
-  playerId: number;
   player: Player;
 }
 
@@ -51,7 +48,6 @@ export interface ComputedMetricValue {
 }
 
 export interface ComputedMetricValueWithPlayer extends ComputedMetricValue {
-  playerId: number;
   player: Player;
 }
 

--- a/server/src/api/modules/snapshots/snapshot.types.ts
+++ b/server/src/api/modules/snapshots/snapshot.types.ts
@@ -1,4 +1,4 @@
-import { Skill, Boss, Activity, ComputedMetric, MapOf } from '../../../utils';
+import { Skill, Boss, Activity, ComputedMetric, MapOf, Player } from '../../../utils';
 import { Snapshot } from '../../../prisma';
 
 export type SnapshotFragment = Omit<Snapshot, 'id'>;
@@ -16,11 +16,19 @@ export interface SkillValue {
   ehp?: number;
 }
 
+export interface SkillValueWithPlayer extends SkillValue {
+  player: Player;
+}
+
 export interface BossValue {
   metric: Boss;
   rank: number;
   kills: number;
   ehb?: number;
+}
+
+export interface BossValueWithPlayer extends BossValue {
+  player: Player;
 }
 
 export interface ActivityValue {
@@ -29,10 +37,25 @@ export interface ActivityValue {
   score: number;
 }
 
+export interface ActivityValueWithPlayer extends ActivityValue {
+  player: Player;
+}
+
 export interface ComputedMetricValue {
   metric: ComputedMetric;
   rank: number;
   value: number;
+}
+
+export interface ComputedMetricValueWithPlayer extends ComputedMetricValue {
+  player: Player;
+}
+
+export interface BestGroupSnapshot {
+  skills: MapOf<Skill, SkillValueWithPlayer>;
+  bosses: MapOf<Boss, BossValueWithPlayer>;
+  activities: MapOf<Activity, ActivityValueWithPlayer>;
+  computed: MapOf<ComputedMetric, ComputedMetricValueWithPlayer>;
 }
 
 export interface FormattedSnapshot {

--- a/server/src/api/modules/snapshots/snapshot.utils.ts
+++ b/server/src/api/modules/snapshots/snapshot.utils.ts
@@ -182,7 +182,7 @@ function hasNegativeGains(before: Snapshot, after: Snapshot): boolean {
 }
 
 function average(snapshots: Snapshot[]): Snapshot {
-  if (!snapshots && snapshots.length === 0) {
+  if (!snapshots || snapshots.length === 0) {
     throw new ServerError('Invalid snapshots list. Failed to find average.');
   }
 


### PR DESCRIPTION
This PR adds a few new things:

- The `createdAt` date for the average stats on the group statistics will now be set to the current date.
- A `MetricLeaders` object. which is basically the same as `SnapshotDataValues`, but with the addition of a `Player` for each metric.
- `GroupStatistics` now have a new field `metricLeaders` which is the metric leaders object.
- Utility functions for building the metric leaders object, and assigning players to it.
- Fixed a bug in the `average` function in snapshot utils where it would fail to throw a server error.
- Added tests.
- Documentation updates.

I'm not 100% sold on the names I went with so definitely let me know if you have better ideas.

I fetch all the players from the db once, to reduce db stress, pass the players and the snapshots into the utility function.
From there it iterates the metrics and find the best one, attaches the player, and done.

Bumped the api version to 2.2 since I would consider this a new feature, let me know if it should just be a patch though and I can update it.

Closes #1086 

EDIT:
Updated above additions for easily adding to the changelog.