### PR TITLE
Trim whitespace from search endpoints name/username param

### DIFF
--- a/server/__tests__/suites/integration/competitions.test.ts
+++ b/server/__tests__/suites/integration/competitions.test.ts
@@ -1440,6 +1440,16 @@ describe('Competition API', () => {
       expect(response.body.filter(c => !!c.verificationHash).length).toBe(0);
     });
 
+    it('should search competitions (w/ title filter, leading/trailing whitespace)', async () => {
+      const response = await api.get('/competitions').query({ title: '  competition  ' });
+
+      expect(response.status).toBe(200);
+      expect(response.body.length).toBe(3);
+
+      // Hashes shouldn't be exposed to the API consumer
+      expect(response.body.filter(c => !!c.verificationHash).length).toBe(0);
+    });
+
     it('should search competitions (w/ title & status filter)', async () => {
       const response = await api.get('/competitions').query({ title: 'competition', status: 'ongoing' });
 

--- a/server/__tests__/suites/integration/groups.test.ts
+++ b/server/__tests__/suites/integration/groups.test.ts
@@ -615,6 +615,17 @@ describe('Group API', () => {
       expect(response.body.filter(g => !!g.verificationHash).length).toBe(0);
     });
 
+    it('should search groups (w/ name query, leading/trailing whitespace)', async () => {
+      const response = await api.get('/groups').query({ name: '  ey  ' });
+
+      expect(response.status).toBe(200);
+      expect(response.body.length).toBe(1);
+      expect(response.body[0].id).toBe(globalData.testGroupNoLeaders.id);
+
+      // Hashes shouldn't be exposed to the API consumer
+      expect(response.body.filter(g => !!g.verificationHash).length).toBe(0);
+    });
+
     it('should search groups (w/ limit)', async () => {
       const response = await api.get('/groups').query({ limit: 1 });
 

--- a/server/__tests__/suites/integration/names.test.ts
+++ b/server/__tests__/suites/integration/names.test.ts
@@ -397,6 +397,14 @@ describe('Names API', () => {
       expect(response.body.filter(n => n.oldName !== 'Zezima').length).toBe(0);
     });
 
+    it('should fetch list (filtered by username, leading/trailing whitespace)', async () => {
+      const response = await api.get(`/names`).query({ username: '  zezi  ' });
+
+      expect(response.status).toBe(200);
+      expect(response.body.length).toBe(1);
+      expect(response.body.filter(n => n.oldName !== 'Zezima').length).toBe(0);
+    });
+
     it('should fetch (empty) list (filtered by username & status)', async () => {
       const response = await api.get(`/names`).query({ username: 'zez', status: 'pending' });
 

--- a/server/__tests__/suites/integration/players.test.ts
+++ b/server/__tests__/suites/integration/players.test.ts
@@ -623,6 +623,23 @@ describe('Player API', () => {
       });
     });
 
+    it('should search players (leading/trailing whitespace)', async () => {
+      const response = await api.get('/players/search').query({ username: '  HYDRO  ' });
+
+      expect(response.status).toBe(200);
+      expect(response.body.length).toBe(2);
+
+      expect(response.body[0]).toMatchObject({
+        username: 'hydrox6',
+        type: 'ironman'
+      });
+
+      expect(response.body[1]).toMatchObject({
+        username: 'hydroman',
+        type: 'unknown'
+      });
+    });
+
     it('should search players (unknown partial username)', async () => {
       const response = await api.get('/players/search').query({ username: 'zez' });
 

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.1.41",
+  "version": "2.1.42",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/scripts/run-tests.sh
+++ b/server/scripts/run-tests.sh
@@ -10,4 +10,4 @@ prisma migrate reset --force
 
 # Run jest on all unit and integration tests tests
 export NODE_ENV=test TZ=UTC
-jest __tests__/suites --detectOpenHandles --verbose --forceExit
+jest __tests__/suites --verbose --runInBand

--- a/server/src/api/modules/competitions/services/SearchCompetitionsService.ts
+++ b/server/src/api/modules/competitions/services/SearchCompetitionsService.ts
@@ -23,7 +23,7 @@ async function searchCompetitions(payload: SearchCompetitionsParams): Promise<Co
 
   if (params.type) query.type = params.type;
   if (params.metric) query.metric = params.metric;
-  if (params.title) query.title = { contains: params.title, mode: 'insensitive' };
+  if (params.title) query.title = { contains: params.title.trim(), mode: 'insensitive' };
 
   if (params.status) {
     const now = new Date();

--- a/server/src/api/modules/groups/services/SearchGroupsService.ts
+++ b/server/src/api/modules/groups/services/SearchGroupsService.ts
@@ -18,7 +18,7 @@ async function searchGroups(payload: SearchGroupsParams): Promise<GroupListItem[
   const groups = await prisma.group.findMany({
     where: {
       name: {
-        contains: params.name.trim(),
+        contains: params.name ? params.name.trim() : params.name,
         mode: 'insensitive'
       }
     },

--- a/server/src/api/modules/groups/services/SearchGroupsService.ts
+++ b/server/src/api/modules/groups/services/SearchGroupsService.ts
@@ -18,7 +18,7 @@ async function searchGroups(payload: SearchGroupsParams): Promise<GroupListItem[
   const groups = await prisma.group.findMany({
     where: {
       name: {
-        contains: params.name,
+        contains: params.name.trim(),
         mode: 'insensitive'
       }
     },

--- a/server/src/api/modules/name-changes/services/SearchNameChangesService.ts
+++ b/server/src/api/modules/name-changes/services/SearchNameChangesService.ts
@@ -21,9 +21,11 @@ async function searchNameChanges(payload: SearchNameChangesParams): Promise<Name
   }
 
   if (params.username && params.username.length > 0) {
+    const startsWith = params.username.trim();
+
     query.OR = [
-      { oldName: { startsWith: params.username, mode: 'insensitive' } },
-      { newName: { startsWith: params.username, mode: 'insensitive' } }
+      { oldName: { startsWith, mode: 'insensitive' } },
+      { newName: { startsWith, mode: 'insensitive' } }
     ];
   }
 

--- a/server/src/api/modules/players/services/ChangePlayerCountryService.ts
+++ b/server/src/api/modules/players/services/ChangePlayerCountryService.ts
@@ -12,7 +12,7 @@ const inputSchema = z
     id: z.number().positive().optional(),
     username: z.string().optional(),
     // This service accepts country codes, and country names (will attempt to parse these into country codes)
-    country: z.string({ required_error: ERROR_MESSAGE }).nonempty({ message: ERROR_MESSAGE })
+    country: z.string({ required_error: ERROR_MESSAGE }).min(1, { message: ERROR_MESSAGE })
   })
   .refine(s => s.id || s.username, {
     message: 'Undefined id and username.'

--- a/server/src/api/modules/players/services/SearchPlayersService.ts
+++ b/server/src/api/modules/players/services/SearchPlayersService.ts
@@ -4,7 +4,7 @@ import { PAGINATION_SCHEMA } from '../../../util/validation';
 
 const inputSchema = z
   .object({
-    username: z.string().nonempty({ message: "Parameter 'username' is undefined." })
+    username: z.string().min(1, { message: "Parameter 'username' is undefined." })
   })
   .merge(PAGINATION_SCHEMA);
 
@@ -16,7 +16,7 @@ async function searchPlayers(payload: SearchPlayersParams): Promise<Player[]> {
   const players = await prisma.player
     .findMany({
       where: {
-        username: { startsWith: params.username, mode: 'insensitive' }
+        username: { startsWith: params.username.trim(), mode: 'insensitive' }
       },
       orderBy: {
         ehp: 'desc'

--- a/server/src/api/modules/snapshots/services/BuildSnapshotService.ts
+++ b/server/src/api/modules/snapshots/services/BuildSnapshotService.ts
@@ -7,7 +7,7 @@ import { SnapshotDataSource } from '../snapshot.types';
 
 const inputSchema = z.object({
   playerId: z.number().int().positive(),
-  rawCSV: z.string().nonempty(),
+  rawCSV: z.string().min(1),
   source: z.nativeEnum(SnapshotDataSource).default(SnapshotDataSource.HISCORES)
 });
 


### PR DESCRIPTION
This PR trims leading and trailing whitespace from name/username params on the search endpoints. 

## Additions

- Tests

## Changes

- The jest test command in `run-tests.sh` to no longer detects open handles
- Replaces usage of deprecated `zod.string().nonempty()` with `zod.string().min(1)`

Closes #1090 