### PR TITLE
Fix ordering of competitions on group page

### DIFF
--- a/app/src/pages/Group/containers/CompetitionsTable.jsx
+++ b/app/src/pages/Group/containers/CompetitionsTable.jsx
@@ -70,24 +70,25 @@ function CompetitionsTable() {
   );
 }
 
+const compareCompetitions = status => (a, b) => {
+  switch (status) {
+    case 'ongoing':
+      return a.endsAt.getTime() - b.endsAt.getTime() || a.startsAt.getTime() - b.startsAt.getTime();
+    case 'finished':
+      return b.endsAt.getTime() - a.endsAt.getTime() || b.startsAt.getTime() - a.startsAt.getTime();
+    default:
+      return a.startsAt.getTime() - b.startsAt.getTime() || a.endsAt.getTime() - b.endsAt.getTime();
+  }
+};
+
 function sortCompetitions(competitions) {
   if (!competitions) return [];
 
-  return competitions.sort((a, b) => {
-    if (a.status === b.status) {
-      if (a.status === 'ongoing') {
-        return a.endsAt.getTime() - b.endsAt.getTime();
-      } else if (a.status === 'finished') {
-        return b.endsAt.getTime() - a.endsAt.getTime();
-      }
-    }
-
-    return (
+  return competitions.sort(
+    (a, b) =>
       STATUS_ORDER.indexOf(a.status) - STATUS_ORDER.indexOf(b.status) ||
-      a.startsAt.getTime() - b.startsAt.getTime() ||
-      a.endsAt.getTime() - b.endsAt.getTime()
-    );
-  });
+      compareCompetitions(a.status)(a, b)
+  );
 }
 
 function convertStatus(status) {

--- a/app/src/pages/Group/containers/CompetitionsTable.jsx
+++ b/app/src/pages/Group/containers/CompetitionsTable.jsx
@@ -74,6 +74,14 @@ function sortCompetitions(competitions) {
   if (!competitions) return [];
 
   return competitions.sort((a, b) => {
+    if (a.status === b.status) {
+      if (a.status === 'ongoing') {
+        return a.endsAt.getTime() - b.endsAt.getTime();
+      } else if (a.status === 'finished') {
+        return b.endsAt.getTime() - a.endsAt.getTime();
+      }
+    }
+
     return (
       STATUS_ORDER.indexOf(a.status) - STATUS_ORDER.indexOf(b.status) ||
       a.startsAt.getTime() - b.startsAt.getTime() ||


### PR DESCRIPTION
Fix #796 

Fix ordering of `ongoing` and `finished` competitions on group page.
- Ongoing competitions that ends first are displayed first
- Finished competitions that ends later are displayed first

**Screenshots**
<img width="480" alt="Screenshot  Finished  Sort" src="https://user-images.githubusercontent.com/79243900/222775375-cd6a3c69-ba27-48c3-9dd5-7c6aba1dab8d.png">

<img width="480" alt="Screenshot  Ongoing  Sort" src="https://user-images.githubusercontent.com/79243900/222775480-d029f5a8-17cc-4f3c-a523-5f2e0638288f.png">
