### PR TITLE
Add 500ms stagger to competition events

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^4.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/jobs/instances/ScheduleCompetitionEventsJob.ts
+++ b/server/src/api/jobs/instances/ScheduleCompetitionEventsJob.ts
@@ -53,7 +53,7 @@ async function scheduleStarting(delayMs: number): Promise<void> {
     }
   });
 
-  competitionsStarting.forEach(c => {
+  competitionsStarting.forEach((c, index) => {
     const eventDelay = Math.max(0, c.startsAt.getTime() - delayMs - Date.now());
 
     setTimeout(() => {
@@ -63,7 +63,8 @@ async function scheduleStarting(delayMs: number): Promise<void> {
       } else {
         competitionEvents.onCompetitionStarting(c, getEventPeriodDelay(delayMs));
       }
-    }, eventDelay);
+      // stagger each event by 500ms to avoid overloading the database
+    }, eventDelay + index * 500);
   });
 }
 
@@ -80,7 +81,7 @@ async function scheduleEnding(delayMs: number): Promise<void> {
     }
   });
 
-  competitionsEnding.forEach(c => {
+  competitionsEnding.forEach((c, index) => {
     const eventDelay = Math.max(0, c.endsAt.getTime() - delayMs - Date.now());
 
     setTimeout(() => {
@@ -90,7 +91,8 @@ async function scheduleEnding(delayMs: number): Promise<void> {
       } else {
         competitionEvents.onCompetitionEnding(c, getEventPeriodDelay(delayMs));
       }
-    }, eventDelay);
+      // stagger each event by 500ms to avoid overloading the database
+    }, eventDelay + index * 500);
   });
 }
 


### PR DESCRIPTION
Some peak times for competition starts and ends (like friday at midnight) could fire dozens of these events within a few milliseconds, which would cause the database connection pool limit to be hit.

This staggers these by 500ms each