### PR TITLE
Fix group achievements types

### DIFF
--- a/client-js/package-lock.json
+++ b/client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wise-old-man/utils",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "ISC",
       "dependencies": {
         "axios": "^0.27.2",

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "A JavaScript/TypeScript client that interfaces and consumes the Wise Old Man API, an API that tracks and measures players' progress in Old School Runescape.",
   "keywords": [
     "wiseoldman",

--- a/client-js/src/clients/GroupsClient.ts
+++ b/client-js/src/clients/GroupsClient.ts
@@ -1,6 +1,5 @@
 import {
   CompetitionListItem,
-  ExtendedAchievement,
   GroupListItem,
   GroupDetails,
   MembershipWithPlayer,
@@ -9,7 +8,8 @@ import {
   NameChange,
   GroupStatistics,
   RecordLeaderboardEntry,
-  DeltaLeaderboardEntry
+  DeltaLeaderboardEntry,
+  ExtendedAchievementWithPlayer
 } from '../../../server/src/utils';
 import type {
   CreateGroupPayload,
@@ -129,7 +129,7 @@ export default class GroupsClient extends BaseAPIClient {
    * @returns A list of achievements.
    */
   getGroupAchievements(id: number, pagination?: PaginationOptions) {
-    return this.getRequest<ExtendedAchievement[]>(`/groups/${id}/achievements`, { ...pagination });
+    return this.getRequest<ExtendedAchievementWithPlayer[]>(`/groups/${id}/achievements`, { ...pagination });
   }
 
   /**

--- a/docs/docs/players-api/player-type-definitions.md
+++ b/docs/docs/players-api/player-type-definitions.md
@@ -147,6 +147,18 @@ Not to be confused with [Player Details](/players-api/player-type-definitions#ob
 
 <br />
 
+### `(Object)` Achievement With Player
+
+Used in endpoints where the resource context is not the player (ex: group achievements).
+
+> extends [Achievement](/players-api/player-type-definitions#object-achievement)
+
+| Field  | Type                                                         | Description              |
+| :----- | :----------------------------------------------------------- | :----------------------- |
+| player | [Player](/players-api/player-type-definitions#object-player) | The membership's player. |
+
+<br />
+
 ### `(Object)` Player Achievement Progress
 
 > extends [Achievement](/players-api/player-type-definitions#object-achievement)

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.2.2",
+      "version": "2.2.3",
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^4.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/modules/achievements/achievement.types.ts
+++ b/server/src/api/modules/achievements/achievement.types.ts
@@ -1,4 +1,4 @@
-import { Metric } from '../../../utils';
+import { Metric, Player } from '../../../utils';
 import { Achievement, Snapshot } from '../../../prisma';
 
 interface AchievementTemplate {
@@ -22,10 +22,21 @@ interface ExtendedAchievement extends Achievement {
   measure: string;
 }
 
+interface ExtendedAchievementWithPlayer extends ExtendedAchievement {
+  player: Player;
+}
+
 interface AchievementProgress extends ExtendedAchievement {
   currentValue: number;
   absoluteProgress: number;
   relativeProgress: number;
 }
 
-export { Achievement, ExtendedAchievement, AchievementProgress, AchievementDefinition, AchievementTemplate };
+export {
+  Achievement,
+  ExtendedAchievement,
+  ExtendedAchievementWithPlayer,
+  AchievementProgress,
+  AchievementDefinition,
+  AchievementTemplate
+};

--- a/server/src/api/modules/achievements/services/FindPlayerAchievementProgressService.ts
+++ b/server/src/api/modules/achievements/services/FindPlayerAchievementProgressService.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { Metric, MetricMeasure, round } from '../../../../utils';
-import prisma, { Achievement, modifyAchievements } from '../../../../prisma';
+import prisma, { Achievement, modifyAchievement } from '../../../../prisma';
 import * as snapshotServices from '../../snapshots/snapshot.services';
 import { AchievementProgress, AchievementDefinition } from '../achievement.types';
 import { getAchievementDefinitions } from '../achievement.utils';
@@ -19,7 +19,7 @@ async function findPlayerAchievementProgress(payload: FindProgressParams): Promi
   // Fetch all the player's achievements
   const achievements = await prisma.achievement
     .findMany({ where: { playerId: params.id } })
-    .then(modifyAchievements);
+    .then(a => a.map(modifyAchievement));
 
   // Map achievement names to achievement objects, for O(1) lookups
   const currentAchievementMap = new Map<string, Achievement>();

--- a/server/src/api/modules/achievements/services/FindPlayerAchievementsService.ts
+++ b/server/src/api/modules/achievements/services/FindPlayerAchievementsService.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import prisma, { modifyAchievements } from '../../../../prisma';
+import prisma, { modifyAchievement } from '../../../../prisma';
 import { ExtendedAchievement } from '../achievement.types';
 import { extend } from '../achievement.utils';
 
@@ -15,7 +15,7 @@ async function findPlayerAchievements(payload: FindPlayerAchievementsParams): Pr
   // Query the database for all achievements of "playerId"
   const achievements = await prisma.achievement
     .findMany({ where: { playerId: params.id } })
-    .then(modifyAchievements);
+    .then(a => a.map(modifyAchievement));
 
   // Extend this database model to include the "measure" field
   return achievements.map(extend);

--- a/server/src/api/modules/achievements/services/ReevaluatePlayerAchievementsService.ts
+++ b/server/src/api/modules/achievements/services/ReevaluatePlayerAchievementsService.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import prisma, { modifyAchievements } from '../../../../prisma';
+import prisma, { modifyAchievement } from '../../../../prisma';
 import * as snapshotServices from '../../snapshots/snapshot.services';
 import { calculatePastDates, getAchievementDefinitions } from '../achievement.utils';
 
@@ -18,7 +18,7 @@ async function reevaluatePlayerAchievements(payload: ReevaluatePlayerAchievement
   // Find all unknown date achievements
   const unknownAchievements = await prisma.achievement
     .findMany({ where: { playerId: params.id, createdAt: UNKNOWN_DATE } })
-    .then(modifyAchievements);
+    .then(a => a.map(modifyAchievement));
 
   const unknownAchievementNames = unknownAchievements.map(u => u.name);
   const unknownDefinitions = ALL_DEFINITIONS.filter(d => unknownAchievementNames.includes(d.name));

--- a/server/src/api/modules/achievements/services/SyncPlayerAchievementsService.ts
+++ b/server/src/api/modules/achievements/services/SyncPlayerAchievementsService.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import prisma, { modifyAchievements } from '../../../../prisma';
+import prisma, { modifyAchievement } from '../../../../prisma';
 import * as snapshotServices from '../../snapshots/snapshot.services';
 import { calculatePastDates, getAchievementDefinitions } from '../achievement.utils';
 
@@ -42,7 +42,7 @@ async function syncPlayerAchievements(payload: SyncPlayerAchievementsParams): Pr
   // Find all achievements the player already has
   const currentAchievements = await prisma.achievement
     .findMany({ where: { playerId: params.id } })
-    .then(modifyAchievements);
+    .then(a => a.map(modifyAchievement));
 
   // Find any missing achievements (by comparing the SHOULD HAVE with the HAS IN DATABASE lists)
   const missingDefinitions = ALL_DEFINITIONS.filter(d => {

--- a/server/src/prisma/hooks.ts
+++ b/server/src/prisma/hooks.ts
@@ -3,7 +3,7 @@ import * as groupEvents from '../api/modules/groups/group.events';
 import * as playerUtils from '../api/modules/players/player.utils';
 import * as competitionEvents from '../api/modules/competitions/competition.events';
 import * as achievementEvents from '../api/modules/achievements/achievement.events';
-import { modifyAchievements } from '.';
+import { modifyAchievement } from '.';
 
 // Some events need to be dispatched on this hook because (some) bulk creates depend
 // on "skipDuplicates" which can't be easily predicted at the service level.
@@ -13,7 +13,7 @@ export function routeAfterHook(params: Prisma.MiddlewareParams, result: any) {
     const achievements = params.args.data;
 
     if (achievements?.length > 0) {
-      achievementEvents.onAchievementsCreated(modifyAchievements(achievements));
+      achievementEvents.onAchievementsCreated(achievements.map(modifyAchievement));
     }
 
     return;

--- a/server/src/prisma/index.ts
+++ b/server/src/prisma/index.ts
@@ -37,12 +37,12 @@ function setHooksEnabled(enabled: boolean) {
   hooksEnabled = enabled;
 }
 
-function modifyAchievements(achievements: PrismaAchievement[]): Achievement[] {
-  return achievements.map(a => ({
-    ...a,
-    threshold: parseBigInt(a.threshold),
-    accuracy: a.accuracy != null ? parseBigInt(a.accuracy) : null
-  }));
+function modifyAchievement(achievement: PrismaAchievement): Achievement {
+  return {
+    ...achievement,
+    threshold: parseBigInt(achievement.threshold),
+    accuracy: achievement.accuracy != null ? parseBigInt(achievement.accuracy) : null
+  };
 }
 
 function modifySnapshots(snapshots: PrismaSnapshot[]): Snapshot[] {
@@ -134,7 +134,7 @@ export {
   modifyRecords,
   modifySnapshot,
   modifySnapshots,
-  modifyAchievements
+  modifyAchievement
 };
 
 export default prisma;


### PR DESCRIPTION
Unblocks https://github.com/wise-old-man/discord-bot/pull/176

The `Achievement` type was missing the `player` field in `/groups/:id/achievements`