### PR TITLE
Improve EHP (TT200m) calcs

### DIFF
--- a/app/src/pages/EhpRates/EhpRates.jsx
+++ b/app/src/pages/EhpRates/EhpRates.jsx
@@ -23,13 +23,14 @@ const RATES_TABLE_CONFIG = {
       transform: (value, row) => {
         if (value === 0) return '---';
 
-        if (row.realRate)
+        if (row.realRate) {
           return (
             <div className="scaled-rate">
-              {formatNumber(value)} per hour
-              <span>(actually {formatNumber(row.realRate)} per hour)</span>
+              {`${formatNumber(value)} per hour`}
+              <span>{`(actually ${formatNumber(row.realRate)} per hour)`}</span>
             </div>
           );
+        }
 
         return `${formatNumber(value)} per hour`;
       }

--- a/app/src/pages/EhpRates/EhpRates.jsx
+++ b/app/src/pages/EhpRates/EhpRates.jsx
@@ -20,7 +20,19 @@ const RATES_TABLE_CONFIG = {
     {
       key: 'rate',
       isSortable: false,
-      transform: value => (value === 0 ? '---' : `${formatNumber(value)} per hour`)
+      transform: (value, row) => {
+        if (value === 0) return '---';
+
+        if (row.realRate)
+          return (
+            <div className="scaled-rate">
+              {formatNumber(value)} per hour
+              <span>(actually {formatNumber(row.realRate)} per hour)</span>
+            </div>
+          );
+
+        return `${formatNumber(value)} per hour`;
+      }
     },
     {
       key: 'description',
@@ -64,8 +76,10 @@ const BONUSES_TABLE_CONFIG = {
       key: 'bonusExp',
       label: 'Bonus Exp.',
       isSortable: false,
-      transform: (val, row) =>
-        formatNumber(Math.min(row.maxBonus || 200000000, (row.endExp - row.startExp) * row.ratio))
+      transform: (_, row) => {
+        if (row.maxBonus) return `${formatNumber(row.maxBonus)} (max)`;
+        return formatNumber(Math.min(200000000, Math.floor((row.endExp - row.startExp) * row.ratio)));
+      }
     }
   ]
 };

--- a/app/src/pages/EhpRates/EhpRates.scss
+++ b/app/src/pages/EhpRates/EhpRates.scss
@@ -37,6 +37,16 @@
           border: 1px solid $gray-00;
           border-bottom: none;
 
+          .scaled-rate {
+            display: flex;
+            flex-direction: column;
+
+            span {
+              padding-top: 8px;
+              color: $gray-60;
+            }
+          }
+
           th {
             background: $gray-00;
           }

--- a/client-js/package-lock.json
+++ b/client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wise-old-man/utils",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "license": "ISC",
       "dependencies": {
         "axios": "^0.27.2",

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "A JavaScript/TypeScript client that interfaces and consumes the Wise Old Man API, an API that tracks and measures players' progress in Old School Runescape.",
   "keywords": [
     "wiseoldman",

--- a/client-js/tsconfig.json
+++ b/client-js/tsconfig.json
@@ -3,7 +3,7 @@
     "rootDir": "../../",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "lib": ["es6", "dom", "es2019"],
+    "lib": ["es6", "dom", "es2019", "es2022"],
     "noImplicitAny": false,
     "moduleResolution": "node",
     "skipLibCheck": true,

--- a/server/__tests__/data/efficiency/configs/ehp/f2p-test.ehp.ts
+++ b/server/__tests__/data/efficiency/configs/ehp/f2p-test.ehp.ts
@@ -6,43 +6,18 @@ export default [
     methods: [
       {
         startExp: 0,
-        rate: 7_200,
-        description: 'Castle wars alt-killing'
+        rate: 12_000,
+        description: 'Vampyre Slayer'
+      },
+      {
+        startExp: 4_825,
+        rate: 30_000,
+        description: 'Castle Wars Alt. Killing'
       },
       {
         startExp: 37_224,
-        rate: 17_000,
-        description: 'Castle wars alt-killing'
-      },
-      {
-        startExp: 100_000,
-        rate: 34_000,
-        description: 'Castle wars alt-killing'
-      },
-      {
-        startExp: 1_000_000,
-        rate: 50_000,
-        description: 'Castle wars alt-killing'
-      },
-      {
-        startExp: 1_986_068,
-        rate: 60_000,
-        description: 'Castle wars alt-killing'
-      },
-      {
-        startExp: 3_000_000,
-        rate: 68_000,
-        description: 'Castle wars alt-killing'
-      },
-      {
-        startExp: 5_346_332,
-        rate: 72_000,
-        description: 'Castle wars alt-killing'
-      },
-      {
-        startExp: 13_034_431,
-        rate: 80_000,
-        description: 'Castle wars alt-killing'
+        rate: 90_000,
+        description: 'Castle Wars Alt. Killing'
       }
     ],
     bonuses: []
@@ -52,8 +27,8 @@ export default [
     methods: [
       {
         startExp: 0,
-        rate: 80_000,
-        description: 'Castle wars alt-killing'
+        rate: 90_000,
+        description: 'Castle Wars Alt. Killing'
       }
     ],
     bonuses: []
@@ -63,54 +38,88 @@ export default [
     methods: [
       {
         startExp: 0,
-        rate: 7_200,
-        description: 'Castle wars alt-killing'
+        rate: 12_000,
+        description: 'Dragon Slayer'
+      },
+      {
+        startExp: 18_650,
+        rate: 25_000,
+        description: 'Castle Wars Alt. Killing'
       },
       {
         startExp: 37_224,
-        rate: 17_000,
-        description: 'Castle wars alt-killing'
+        rate: 40_500,
+        description: 'Castle Wars Alt. Killing'
       },
       {
-        startExp: 100_000,
-        rate: 34_000,
-        description: 'Castle wars alt-killing'
+        startExp: 50_339,
+        rate: 43_500,
+        description: 'Castle Wars Alt. Killing'
       },
       {
-        startExp: 1_000_000,
-        rate: 50_000,
-        description: 'Castle wars alt-killing'
+        startExp: 75_127,
+        rate: 49_000,
+        description: 'Castle Wars Alt. Killing'
+      },
+      {
+        startExp: 123_660,
+        rate: 52_000,
+        description: 'Castle Wars Alt. Killing'
+      },
+      {
+        startExp: 166_636,
+        rate: 55_000,
+        description: 'Castle Wars Alt. Killing'
+      },
+      {
+        startExp: 273_742,
+        rate: 58_000,
+        description: 'Castle Wars Alt. Killing'
+      },
+      {
+        startExp: 407_015,
+        rate: 61_000,
+        description: 'Castle Wars Alt. Killing'
+      },
+      {
+        startExp: 547_953,
+        rate: 66_500,
+        description: 'Castle Wars Alt. Killing'
+      },
+      {
+        startExp: 899_257,
+        rate: 69_500,
+        description: 'Castle Wars Alt. Killing'
+      },
+      {
+        startExp: 1_336_443,
+        rate: 72_500,
+        description: 'Castle Wars Alt. Killing'
       },
       {
         startExp: 1_986_068,
-        rate: 60_000,
-        description: 'Castle wars alt-killing'
+        rate: 75_500,
+        description: 'Castle Wars Alt. Killing'
       },
       {
-        startExp: 3_000_000,
-        rate: 68_000,
-        description: 'Castle wars alt-killing'
+        startExp: 2_951_373,
+        rate: 78_500,
+        description: 'Castle Wars Alt. Killing'
       },
       {
-        startExp: 5_346_332,
-        rate: 72_000,
-        description: 'Castle wars alt-killing'
+        startExp: 4_385_776,
+        rate: 84_000,
+        description: 'Castle Wars Alt. Killing'
       },
       {
-        startExp: 13_034_431,
-        rate: 80_000,
-        description: 'Castle wars alt-killing'
-      }
-    ],
-    bonuses: []
-  },
-  {
-    skill: Skill.HITPOINTS,
-    methods: [
+        startExp: 7_195_629,
+        rate: 87_000,
+        description: 'Castle Wars Alt. Killing'
+      },
       {
-        startExp: 0,
-        rate: 0,
-        description: 'Castle wars alt-killing'
+        startExp: 9_684_577,
+        rate: 90_000,
+        description: 'Castle Wars Alt. Killing'
       }
     ],
     bonuses: []
@@ -120,43 +129,83 @@ export default [
     methods: [
       {
         startExp: 0,
-        rate: 7_000,
-        description: 'Castle wars alt-killing'
+        rate: 8_000,
+        description: 'Castle Wars Alt. Killing'
       },
       {
-        startExp: 37_224,
-        rate: 17_000,
-        description: 'Castle wars alt-killing'
+        startExp: 13_363,
+        rate: 30_000,
+        description: 'Castle Wars Alt. Killing'
       },
       {
-        startExp: 100_000,
+        startExp: 20_224,
         rate: 34_000,
-        description: 'Castle wars alt-killing'
+        description: 'Castle Wars Alt. Killing'
       },
       {
-        startExp: 1_000_000,
-        rate: 50_000,
-        description: 'Castle wars alt-killing'
+        startExp: 33_648,
+        rate: 40_500,
+        description: 'Castle Wars Alt. Killing'
+      },
+      {
+        startExp: 55_649,
+        rate: 44_500,
+        description: 'Castle Wars Alt. Killing'
+      },
+      {
+        startExp: 91_721,
+        rate: 48_500,
+        description: 'Castle Wars Alt. Killing'
+      },
+      {
+        startExp: 150_872,
+        rate: 52_500,
+        description: 'Castle Wars Alt. Killing'
+      },
+      {
+        startExp: 273_742,
+        rate: 56_500,
+        description: 'Castle Wars Alt. Killing'
+      },
+      {
+        startExp: 449_428,
+        rate: 63_000,
+        description: 'Castle Wars Alt. Killing'
+      },
+      {
+        startExp: 737_627,
+        rate: 66_500,
+        description: 'Castle Wars Alt. Killing'
+      },
+      {
+        startExp: 1_210_421,
+        rate: 70_500,
+        description: 'Castle Wars Alt. Killing'
       },
       {
         startExp: 1_986_068,
-        rate: 60_000,
-        description: 'Castle wars alt-killing'
+        rate: 74_500,
+        description: 'Castle Wars Alt. Killing'
       },
       {
-        startExp: 3_000_000,
-        rate: 68_000,
-        description: 'Castle wars alt-killing'
+        startExp: 3_258_594,
+        rate: 78_500,
+        description: 'Castle Wars Alt. Killing'
       },
       {
         startExp: 5_346_332,
-        rate: 72_000,
-        description: 'Castle wars alt-killing'
+        rate: 85_500,
+        description: 'Castle Wars Alt. Killing'
+      },
+      {
+        startExp: 8_771_558,
+        rate: 89_500,
+        description: 'Castle Wars Alt. Killing'
       },
       {
         startExp: 13_034_431,
-        rate: 80_000,
-        description: 'Castle wars alt-killing'
+        rate: 90_000,
+        description: 'Castle Wars Alt. Killing'
       }
     ],
     bonuses: []
@@ -167,7 +216,7 @@ export default [
       {
         startExp: 0,
         rate: 105_000,
-        description: 'Bury big bones'
+        description: 'Bury Big bones & Vile ashes'
       }
     ],
     bonuses: []
@@ -177,8 +226,28 @@ export default [
     methods: [
       {
         startExp: 0,
-        rate: 0,
-        description: 'Bonus xp'
+        rate: 15_000,
+        description: 'Misc. Spells'
+      },
+      {
+        startExp: 5_018,
+        rate: 60_000,
+        description: 'Low Alchemy'
+      },
+      {
+        startExp: 50_339,
+        rate: 100_000,
+        description: 'Superheat Gold'
+      },
+      {
+        startExp: 166_636,
+        rate: 165_000,
+        description: 'Alchemy + Falador Teleport + Fire Blast Splashing'
+      },
+      {
+        startExp: 3_258_594,
+        rate: 180_000,
+        description: 'Alchemy + Teleblock'
       }
     ],
     bonuses: []
@@ -188,23 +257,18 @@ export default [
     methods: [
       {
         startExp: 0,
-        rate: 40_000,
-        description: 'Best fish'
+        rate: 100_000,
+        description: '1t Beef'
       },
       {
-        startExp: 7_842,
-        rate: 130_000,
-        description: 'Best fish'
+        startExp: 22_406,
+        rate: 450_000,
+        description: 'Wines (Incl. Avg. Rate of Failure)'
       },
       {
-        startExp: 37_224,
-        rate: 175_000,
+        startExp: 605_032,
+        rate: 500_000,
         description: 'Wines'
-      },
-      {
-        startExp: 224_466,
-        rate: 2_052_000,
-        description: '3t fish-cook method'
       }
     ],
     bonuses: []
@@ -214,57 +278,90 @@ export default [
     methods: [
       {
         startExp: 0,
-        rate: 7_000,
-        description: 'Trees'
+        rate: 29_500,
+        description: '4t Trees'
       },
       {
         startExp: 2_411,
-        rate: 15_000,
-        description: '3t Oak trees'
+        rate: 30_000,
+        description: '2t Oaks (steel axe)'
       },
       {
-        startExp: 13_363,
-        rate: 28_000,
-        description: '2.66t, 2x snow Willows'
+        startExp: 5_018,
+        rate: 40_000,
+        description: '2t oaks (mith axe)'
+      },
+      {
+        startExp: 14_833,
+        rate: 55_000,
+        description: '2t oaks (addy axe)'
       },
       {
         startExp: 41_171,
-        rate: 45_000,
-        description: '2.66t, 2x snow Willows'
+        rate: 73_500,
+        description: '2t oaks (rune axe)'
+      },
+      {
+        startExp: 101_333,
+        rate: 81_500,
+        description: '2t oaks (rune axe)'
       },
       {
         startExp: 302_288,
-        rate: 58_500,
-        description: '2.66t, 2x snow Willows'
-      },
-      {
-        startExp: 1_986_068,
-        rate: 70_000,
-        description: '2.66t, 2x snow Willows'
-      },
-      {
-        startExp: 5_346_332,
-        rate: 81_000,
-        description: '2.66t, 2x snow Willows'
-      },
-      {
-        startExp: 13_034_431,
         rate: 90_000,
-        description: '2.66t, 2x snow Willows'
+        description: '2t oaks (100% success)'
       }
     ],
-    bonuses: []
-  },
-  {
-    skill: Skill.FLETCHING,
-    methods: [
+    bonuses: [
       {
-        startExp: 0,
-        rate: 0,
-        description: '-'
+        originSkill: Skill.WOODCUTTING,
+        bonusSkill: Skill.MAGIC,
+        startExp: 2_411,
+        endExp: 5_018,
+        end: false,
+        ratio: 1.8
+      },
+      {
+        originSkill: Skill.WOODCUTTING,
+        bonusSkill: Skill.MAGIC,
+        startExp: 5_018,
+        endExp: 14_833,
+        end: false,
+        ratio: 1.35
+      },
+      {
+        originSkill: Skill.WOODCUTTING,
+        bonusSkill: Skill.MAGIC,
+        startExp: 14_833,
+        endExp: 41_171,
+        end: false,
+        ratio: 0.97
+      },
+      {
+        originSkill: Skill.WOODCUTTING,
+        bonusSkill: Skill.MAGIC,
+        startExp: 41_171,
+        endExp: 101_333,
+        end: false,
+        ratio: 0.73
+      },
+      {
+        originSkill: Skill.WOODCUTTING,
+        bonusSkill: Skill.MAGIC,
+        startExp: 101_333,
+        endExp: 302_288,
+        end: false,
+        ratio: 0.66
+      },
+      {
+        originSkill: Skill.WOODCUTTING,
+        bonusSkill: Skill.MAGIC,
+        startExp: 302_288,
+        endExp: 200_000_000,
+        end: false,
+        ratio: 0.6
       }
-    ],
-    bonuses: []
+    ]
   },
   {
     skill: Skill.FISHING,
@@ -281,36 +378,111 @@ export default [
       },
       {
         startExp: 13_363,
-        rate: 35_250,
-        description: '3t fish-cook method'
+        rate: 37_500,
+        description: '3t Cake Scatter'
+      },
+      {
+        startExp: 101_333,
+        rate: 52_000,
+        description: '3t Cake Scatter'
       },
       {
         startExp: 273_742,
-        rate: 60_350,
-        description: '3t fish-cook method'
+        rate: 58_000,
+        description: '3t Cake Scatter'
       },
       {
         startExp: 737_627,
-        rate: 71_000,
-        description: '3t fish-cook method'
+        rate: 64_000,
+        description: '3t Cake Scatter'
       },
       {
-        startExp: 2_500_000,
-        rate: 76_250,
-        description: '3t fish-cook method'
+        startExp: 1_986_068,
+        rate: 70_000,
+        description: '3t Cake Scatter'
       },
       {
-        startExp: 6_000_000,
-        rate: 81_000,
-        description: '3t fish-cook method'
+        startExp: 5_902_831,
+        rate: 75_000,
+        description: '3t Cake Scatter'
+      },
+      {
+        startExp: 8_771_558,
+        rate: 77_500,
+        description: '3t Cake Scatter'
       },
       {
         startExp: 13_034_431,
-        rate: 90_000,
-        description: '3t fish-cook method'
+        rate: 80_000,
+        description: '3t Cake Scatter'
       }
     ],
-    bonuses: []
+    bonuses: [
+      {
+        originSkill: Skill.FISHING,
+        bonusSkill: Skill.PRAYER,
+        startExp: 13_363,
+        endExp: 101_333,
+        end: false,
+        ratio: 0.667
+      },
+      {
+        originSkill: Skill.FISHING,
+        bonusSkill: Skill.PRAYER,
+        startExp: 101_333,
+        endExp: 273_742,
+        end: false,
+        ratio: 0.48
+      },
+      {
+        originSkill: Skill.FISHING,
+        bonusSkill: Skill.PRAYER,
+        startExp: 273_742,
+        endExp: 737_627,
+        end: false,
+        ratio: 0.43
+      },
+      {
+        originSkill: Skill.FISHING,
+        bonusSkill: Skill.PRAYER,
+        startExp: 737_627,
+        endExp: 1_986_068,
+        end: false,
+        ratio: 0.39
+      },
+      {
+        originSkill: Skill.FISHING,
+        bonusSkill: Skill.PRAYER,
+        startExp: 1_986_068,
+        endExp: 5_902_831,
+        end: false,
+        ratio: 0.356
+      },
+      {
+        originSkill: Skill.FISHING,
+        bonusSkill: Skill.PRAYER,
+        startExp: 5_902_831,
+        endExp: 8_771_558,
+        end: false,
+        ratio: 0.333
+      },
+      {
+        originSkill: Skill.FISHING,
+        bonusSkill: Skill.PRAYER,
+        startExp: 8_771_558,
+        endExp: 13_034_431,
+        end: false,
+        ratio: 0.323
+      },
+      {
+        originSkill: Skill.FISHING,
+        bonusSkill: Skill.PRAYER,
+        startExp: 13_034_431,
+        endExp: 200_000_000,
+        end: false,
+        ratio: 0.313
+      }
+    ]
   },
   {
     skill: Skill.FIREMAKING,
@@ -318,22 +490,22 @@ export default [
       {
         startExp: 0,
         rate: 45_000,
-        description: 'Best logs @ GE w/ vile ashes'
+        description: 'Best logs @ GE w/ Vile ashes'
       },
       {
         startExp: 13_363,
         rate: 130_500,
-        description: 'Best logs @ GE w/ vile ashes'
+        description: 'Best logs @ GE w/ Vile ashes'
       },
       {
         startExp: 61_512,
         rate: 195_750,
-        description: 'Best logs @ GE w/ vile ashes'
+        description: 'Best logs @ GE w/ Vile ashes'
       },
       {
         startExp: 273_742,
         rate: 293_625,
-        description: 'Best logs @ GE w/ vile ashes'
+        description: 'Best logs @ GE w/ Vile ashes'
       }
     ],
     bonuses: [
@@ -343,7 +515,7 @@ export default [
         startExp: 13_363,
         endExp: 61_512,
         end: false,
-        ratio: 0.2666
+        ratio: 0.267
       },
       {
         originSkill: Skill.FIREMAKING,
@@ -351,7 +523,7 @@ export default [
         startExp: 61_512,
         endExp: 273_742,
         end: false,
-        ratio: 0.1777
+        ratio: 0.178
       },
       {
         originSkill: Skill.FIREMAKING,
@@ -368,18 +540,28 @@ export default [
     methods: [
       {
         startExp: 0,
-        rate: 57_000,
-        description: 'Best gems'
+        rate: 37_000,
+        description: 'Leather'
       },
       {
         startExp: 4_470,
-        rate: 135_000,
-        description: 'Best gems'
+        rate: 137_200,
+        description: 'Sapphires'
+      },
+      {
+        startExp: 9_730,
+        rate: 185_220,
+        description: 'Emeralds'
+      },
+      {
+        startExp: 20_224,
+        rate: 233_240,
+        description: 'Rubies'
       },
       {
         startExp: 50_339,
         rate: 295_000,
-        description: 'Best gems'
+        description: 'Diamonds'
       }
     ],
     bonuses: []
@@ -389,13 +571,33 @@ export default [
     methods: [
       {
         startExp: 0,
-        rate: 4_385_776,
-        description: "Knight's sword -> superheat"
+        rate: 38_175,
+        description: "Knight's Sword"
+      },
+      {
+        startExp: 12_725,
+        rate: 58_000,
+        description: 'Bronze Platebodies w/ alt'
+      },
+      {
+        startExp: 18_247,
+        rate: 116_000,
+        description: 'Iron Platebodies w/ alt'
+      },
+      {
+        startExp: 83_014,
+        rate: 174_000,
+        description: 'Steel Platebodies w/ alt'
+      },
+      {
+        startExp: 605_032,
+        rate: 232_000,
+        description: 'Mithril Platebodies w/ alt'
       },
       {
         startExp: 4_385_776,
-        rate: 275_000,
-        description: 'Addy bodies w/ alt'
+        rate: 290_000,
+        description: 'Adamant Platebodies w/ alt'
       }
     ],
     bonuses: []
@@ -409,91 +611,46 @@ export default [
         description: 'Tin/copper'
       },
       {
-        startExp: 14_833,
-        rate: 12_000,
-        description: '3t iron with alt'
+        startExp: 2_411,
+        rate: 40_500,
+        description: '4t leather double roll at hobgoblin mine'
       },
       {
-        startExp: 41_171,
-        rate: 25_000,
-        description: '3t iron with alt'
+        startExp: 13_363,
+        rate: 45_500,
+        description: '4t leather double roll at hobgoblin mine'
       },
       {
-        startExp: 111_945,
+        startExp: 37_224,
+        rate: 48_000,
+        description: '3.33t snow mining at al kharid'
+      },
+      {
+        startExp: 101_333,
+        rate: 54_000,
+        description: '3.33t snow mining at al kharid'
+      },
+      {
+        startExp: 247_886,
+        rate: 56_000,
+        description: '3t cake scatter iron at mining guild'
+      },
+      {
+        startExp: 302_288,
         rate: 57_000,
-        description: '3t iron with alt'
-      },
-      {
-        startExp: 737_627,
-        rate: 65_000,
-        description: '3t iron with alt'
+        description: '3t cake scatter iron at mining guild'
       }
     ],
     bonuses: [
       {
         originSkill: Skill.MINING,
-        bonusSkill: Skill.SMITHING,
-        startExp: 0,
+        bonusSkill: Skill.PRAYER,
+        startExp: 247_886,
         endExp: 200_000_000,
         end: false,
-        ratio: 0.25
+        ratio: 0.54
       }
     ]
-  },
-  {
-    skill: Skill.HERBLORE,
-    methods: [
-      {
-        startExp: 0,
-        rate: 0,
-        description: '-'
-      }
-    ],
-    bonuses: []
-  },
-  {
-    skill: Skill.AGILITY,
-    methods: [
-      {
-        startExp: 0,
-        rate: 0,
-        description: '-'
-      }
-    ],
-    bonuses: []
-  },
-  {
-    skill: Skill.THIEVING,
-    methods: [
-      {
-        startExp: 0,
-        rate: 0,
-        description: '-'
-      }
-    ],
-    bonuses: []
-  },
-  {
-    skill: Skill.SLAYER,
-    methods: [
-      {
-        startExp: 0,
-        rate: 0,
-        description: '-'
-      }
-    ],
-    bonuses: []
-  },
-  {
-    skill: Skill.FARMING,
-    methods: [
-      {
-        startExp: 0,
-        rate: 0,
-        description: '-'
-      }
-    ],
-    bonuses: []
   },
   {
     skill: Skill.RUNECRAFTING,
@@ -501,31 +658,18 @@ export default [
       {
         startExp: 0,
         rate: 55_000,
-        description: 'Pvp world body tiaras'
+        description: 'Solo Body talismans'
       }
     ],
-    bonuses: []
-  },
-  {
-    skill: Skill.HUNTER,
-    methods: [
+    bonuses: [
       {
+        originSkill: Skill.RUNECRAFTING,
+        bonusSkill: Skill.MAGIC,
         startExp: 0,
-        rate: 0,
-        description: '-'
+        endExp: 200_000_000,
+        end: false,
+        ratio: 0.4
       }
-    ],
-    bonuses: []
-  },
-  {
-    skill: Skill.CONSTRUCTION,
-    methods: [
-      {
-        startExp: 0,
-        rate: 0,
-        description: '-'
-      }
-    ],
-    bonuses: []
+    ]
   }
 ];

--- a/server/__tests__/data/efficiency/configs/ehp/ironman-test.ehp.ts
+++ b/server/__tests__/data/efficiency/configs/ehp/ironman-test.ehp.ts
@@ -6,8 +6,8 @@ export default [
     methods: [
       {
         startExp: 0,
-        rate: 193_300,
-        description: 'Chally greater nechs'
+        rate: 192_400,
+        description: 'Chally 2 alt tzhaar'
       }
     ],
     bonuses: []
@@ -17,8 +17,8 @@ export default [
     methods: [
       {
         startExp: 0,
-        rate: 669_100,
-        description: 'Def chin+bonus pray xp'
+        rate: 679_800,
+        description: 'Def chin+bonus pray'
       }
     ],
     bonuses: []
@@ -29,18 +29,7 @@ export default [
       {
         startExp: 0,
         rate: 300_000,
-        description: 'Chally greater nechs'
-      }
-    ],
-    bonuses: []
-  },
-  {
-    skill: Skill.HITPOINTS,
-    methods: [
-      {
-        startExp: 0,
-        rate: 0,
-        description: 'Bonus xp from slayer'
+        description: 'Chally 2 alt tzhaar'
       }
     ],
     bonuses: []
@@ -50,38 +39,38 @@ export default [
     methods: [
       {
         startExp: 0,
-        rate: 15_000,
-        description: 'Quest/pc'
+        rate: 17_000,
+        description: 'Quest + void'
       },
       {
-        startExp: 203_354,
-        rate: 609_900,
-        description: 'Red chins+bonus pray'
+        startExp: 224_466,
+        rate: 527_700,
+        description: 'Red chins + pray (456k rate)'
       },
       {
         startExp: 449_428,
-        rate: 752_400,
-        description: 'Black chins+bonus pray'
+        rate: 786_200,
+        description: 'Black chins + pray (638k rate)'
       },
       {
         startExp: 737_627,
-        rate: 839_800,
-        description: 'Black chins+bonus pray'
+        rate: 886_400,
+        description: 'Black chins + pray (702k rate)'
       },
       {
         startExp: 1_986_068,
-        rate: 962_600,
-        description: 'Black chins+bonus pray'
+        rate: 1_016_600,
+        description: 'Black chins + pray (781k rate)'
       },
       {
         startExp: 5_346_332,
-        rate: 1_110_500,
-        description: 'Black chins+bonus pray'
+        rate: 1_148_400,
+        description: 'Black chins + pray (857k rate)'
       },
       {
         startExp: 13_034_431,
-        rate: 1_276_600,
-        description: 'Black chins+bonus pray'
+        rate: 1_308_400,
+        description: 'Black chins + pray (943k rate)'
       }
     ],
     bonuses: []
@@ -91,19 +80,8 @@ export default [
     methods: [
       {
         startExp: 0,
-        rate: 218_000,
-        description: 'Lance green dragons'
-      }
-    ],
-    bonuses: []
-  },
-  {
-    skill: Skill.MAGIC,
-    methods: [
-      {
-        startExp: 0,
-        rate: 0,
-        description: 'Bonus xp from slayer'
+        rate: 209_000,
+        description: 'Green dragons (340/hr) including melee'
       }
     ],
     bonuses: []
@@ -114,47 +92,47 @@ export default [
       {
         startExp: 0,
         rate: 100_000,
-        description: 'Buying + cooking karambwans with alt'
+        description: 'Buying and cooking karams with alt'
       },
       {
         startExp: 13_363,
         rate: 211_200,
-        description: 'Buying + cooking karambwans with alt'
+        description: 'Buying and cooking karams with alt'
       },
       {
         startExp: 41_171,
         rate: 240_800,
-        description: 'Buying + cooking karambwans with alt'
+        description: 'Buying and cooking karams with alt'
       },
       {
         startExp: 101_333,
         rate: 270_400,
-        description: 'Buying + cooking karambwans with alt'
+        description: 'Buying and cooking karams with alt'
       },
       {
         startExp: 273_742,
         rate: 300_100,
-        description: 'Buying + cooking karambwans with alt'
+        description: 'Buying and cooking karams with alt'
       },
       {
         startExp: 737_627,
         rate: 329_700,
-        description: 'Buying + cooking karambwans with alt'
+        description: 'Buying and cooking karams with alt'
       },
       {
         startExp: 1_986_068,
         rate: 359_300,
-        description: 'Buying + cooking karambwans with alt'
+        description: 'Buying and cooking karams with alt'
       },
       {
         startExp: 5_346_332,
         rate: 385_900,
-        description: 'Buying + cooking karambwans with alt'
+        description: 'Buying and cooking karams with alt'
       },
       {
         startExp: 13_034_431,
         rate: 400_000,
-        description: 'Buying + cooking karambwans with alt'
+        description: 'Buying and cooking karams with alt'
       }
     ],
     bonuses: []
@@ -169,18 +147,18 @@ export default [
       },
       {
         startExp: 2_411,
-        rate: 16_000,
+        rate: 25_000,
         description: 'Oak trees'
       },
       {
-        startExp: 13_363,
-        rate: 35_000,
-        description: 'Willow trees'
+        startExp: 22_406,
+        rate: 45_000,
+        description: 'Teak trees'
       },
       {
-        startExp: 41_171,
-        rate: 49_000,
-        description: 'Teak trees'
+        startExp: 67_983,
+        rate: 115_500,
+        description: '1.5t teaks (for proper wt scaling)'
       },
       {
         startExp: 302_288,
@@ -204,8 +182,8 @@ export default [
       },
       {
         startExp: 13_034_431,
-        rate: 200_000,
-        description: '1.5t teaks'
+        rate: 228_000,
+        description: '1.5t redwood (161k wc 145k fm rate) + tool seed time'
       }
     ],
     bonuses: []
@@ -215,13 +193,13 @@ export default [
     methods: [
       {
         startExp: 0,
-        rate: 200_000,
-        description: 'Bows & arrows'
+        rate: 300_000,
+        description: 'Headless arrows'
       },
       {
         startExp: 123_660,
-        rate: 1_100_000,
-        description: 'Broad arrows'
+        rate: 825_000,
+        description: 'Broads at sep, bh & zmi - gp adjusted'
       }
     ],
     bonuses: []
@@ -231,60 +209,55 @@ export default [
     methods: [
       {
         startExp: 0,
-        rate: 20_000,
-        description: 'Quest'
+        rate: 15_000,
+        description: 'Quests'
       },
       {
-        startExp: 9_612,
+        startExp: 15_612,
         rate: 30_000,
         description: 'Fly fishing'
       },
       {
-        startExp: 13_363,
-        rate: 40_000,
-        description: 'Fly fishing'
+        startExp: 22_406,
+        rate: 32_000,
+        description: 'Tempoross barrel'
       },
       {
-        startExp: 83_014,
-        rate: 43_711,
-        description: 'Cut-eat barb'
-      },
-      {
-        startExp: 224_466,
-        rate: 72_629,
-        description: 'Cut-eat barb'
+        startExp: 302_288,
+        rate: 67_260,
+        description: 'Aerial for angler'
       },
       {
         startExp: 737_627,
-        rate: 95_282,
-        description: 'Cut-eat barb'
+        rate: 112_030,
+        description: 'Barb + bank sturgeon (91.6k rate)'
       },
       {
-        startExp: 2_421_087,
-        rate: 101_997,
-        description: 'Cut-eat barb'
+        startExp: 2_951_373,
+        rate: 150_540,
+        description: 'Decant barblore (99.8k rate)'
       },
       {
         startExp: 5_902_831,
-        rate: 106_519,
-        description: 'Cut-eat barb'
+        rate: 160_220,
+        description: 'Decant barblore (103.5k rate)'
       },
       {
         startExp: 10_692_629,
-        rate: 108_879,
-        description: 'Cut-eat barb'
+        rate: 166_140,
+        description: 'Decant barblore (105.6k rate)'
       },
       {
         startExp: 13_034_431,
-        rate: 141_070,
-        description: 'Barblore'
+        rate: 175_490,
+        description: 'Decant barblore (108.4k rate)'
       }
     ],
     bonuses: [
       {
         originSkill: Skill.FISHING,
         bonusSkill: Skill.STRENGTH,
-        startExp: 83_014,
+        startExp: 737_627,
         endExp: 200_000_000,
         end: false,
         ratio: 0.0885
@@ -292,18 +265,18 @@ export default [
       {
         originSkill: Skill.FISHING,
         bonusSkill: Skill.COOKING,
-        startExp: 83_014,
+        startExp: 737_627,
         endExp: 200_000_000,
         end: true,
-        ratio: 0.15
+        ratio: 0.108
       },
       {
         originSkill: Skill.FISHING,
         bonusSkill: Skill.AGILITY,
-        startExp: 83_014,
-        endExp: 200_000_000,
+        startExp: 737_627,
+        endExp: 2_951_373,
         end: false,
-        ratio: 0.0885
+        ratio: 0.08893
       }
     ]
   },
@@ -317,33 +290,33 @@ export default [
       },
       {
         startExp: 101_333,
-        rate: 238_800,
-        description: 'Wintertodt + bxp/bankstanding'
+        rate: 240_800,
+        description: 'Wintertodt hop + fletch, wc, con & loot ehp (207k rate)'
       },
       {
         startExp: 273_742,
-        rate: 281_000,
-        description: 'Wintertodt + bxp/bankstanding'
+        rate: 284_600,
+        description: 'Wintertodt hop + fletch, wc, con & loot ehp (244k rate)'
       },
       {
         startExp: 737_627,
-        rate: 324_900,
-        description: 'Wintertodt + bxp/bankstanding'
+        rate: 328_300,
+        description: 'Wintertodt hop + fletch, wc, con & loot ehp (282k rate)'
       },
       {
         startExp: 1_986_068,
-        rate: 368_800,
-        description: 'Wintertodt + bxp/bankstanding'
+        rate: 372_000,
+        description: 'Wintertodt hop + fletch, wc, con & loot ehp (319k rate)'
       },
       {
         startExp: 5_346_332,
-        rate: 412_600,
-        description: 'Wintertodt + bxp/bankstanding'
+        rate: 412_900,
+        description: 'Wintertodt hop + fletch, wc, con & loot ehp (355k rate)'
       },
       {
         startExp: 13_034_431,
-        rate: 433_500,
-        description: 'Wintertodt + bxp/bankstanding'
+        rate: 456_900,
+        description: 'Wintertodt hop + fletch, wc, con & loot ehp (392k rate)'
       }
     ],
     bonuses: []
@@ -354,17 +327,17 @@ export default [
       {
         startExp: 0,
         rate: 50_000,
-        description: 'Seaweed+sandstone'
+        description: 'Glassblow no superglass'
       },
       {
         startExp: 302_288,
-        rate: 89_700,
-        description: 'Seaweed+sandstone w/ superglass'
+        rate: 165_200,
+        description: 'Glassblow artefact + zmi (261k effective rate)'
       },
       {
         startExp: 3_972_294,
-        rate: 111_500,
-        description: 'Seaweed+sandstone w/ superglass'
+        rate: 205_300,
+        description: 'Glassblow artefact + zmi (332k effective rate)'
       }
     ],
     bonuses: []
@@ -374,18 +347,18 @@ export default [
     methods: [
       {
         startExp: 0,
-        rate: 40_000,
-        description: '-'
+        rate: 72_800,
+        description: 'Quests, wt ore + gold'
       },
       {
         startExp: 273_742,
-        rate: 310_000,
-        description: 'UIM gold'
+        rate: 245_700,
+        description: 'Uim gold 2 client (315k rate) - gp adjusted'
       },
       {
         startExp: 13_034_431,
-        rate: 320_000,
-        description: 'UIM gold'
+        rate: 301_900,
+        description: 'Uim gold 2 client (330k rate) - gp adjusted'
       }
     ],
     bonuses: []
@@ -395,13 +368,13 @@ export default [
     methods: [
       {
         startExp: 0,
-        rate: 8_000,
+        rate: 17_000,
         description: 'Quests'
       },
       {
-        startExp: 13_363,
-        rate: 59_158,
-        description: 'Iron'
+        startExp: 25_525,
+        rate: 70_000,
+        description: '3t4s at quarry'
       },
       {
         startExp: 61_512,
@@ -415,7 +388,7 @@ export default [
       },
       {
         startExp: 302_288,
-        rate: 97_697,
+        rate: 97_923,
         description: '3t4g at quarry'
       },
       {
@@ -424,14 +397,14 @@ export default [
         description: '3t4g at quarry'
       },
       {
-        startExp: 986_068,
+        startExp: 1_986_068,
         rate: 109_143,
         description: '3t4g at quarry'
       },
       {
         startExp: 3_258_594,
         rate: 46_500,
-        description: 'Motherlode Mine for Prospector Outfit'
+        description: 'Mlm prospector'
       },
       {
         startExp: 3_548_694,
@@ -456,12 +429,12 @@ export default [
     methods: [
       {
         startExp: 0,
-        rate: 64_000,
+        rate: 71_560,
         description: 'Contracts + kingdom'
       },
       {
         startExp: 13_034_431,
-        rate: 70_130,
+        rate: 73_560,
         description: 'Contracts + kingdom'
       }
     ],
@@ -472,33 +445,44 @@ export default [
     methods: [
       {
         startExp: 0,
-        rate: 0,
-        description: 'Bonus xp from fishing'
+        rate: 10_000,
+        description: 'Quests'
       },
       {
-        startExp: 273_742,
-        rate: 54_000,
-        description: 'Bonus xp from fishing'
+        startExp: 61_600,
+        rate: 35_000,
+        description: 'Bonus xp from fishing (wildy rate)'
       },
       {
-        startExp: 1_986_068,
-        rate: 62_743,
-        description: 'Bonus xp from fishing'
+        startExp: 123_660,
+        rate: 45_847,
+        description: 'Bonus xp from fishing (sepulchre rate)'
+      },
+      {
+        startExp: 333_804,
+        rate: 57_300,
+        description: 'Sepulchre'
+      },
+      {
+        startExp: 899_257,
+        rate: 67_700,
+        description: 'Sepulchre'
       },
       {
         startExp: 2_421_087,
-        rate: 73_929,
-        description: 'Bonus xp from fishing'
+        rate: 73_800,
+        description: 'Sepulchre'
       },
       {
         startExp: 6_517_253,
-        rate: 95_000,
-        description: 'Bonus xp from fishing'
+        rate: 98_500,
+        description: 'Sepulchre'
       },
       {
-        startExp: 17_675_774,
-        rate: 93_000,
-        description: 'Sepulchre + 20m ardy'
+        startExp: 13_034_431,
+        rate: 102_600,
+        description:
+          'Sepulchre (100.8k no loot rate) + con ehp. Real time agility rate when efficiently looting is 89.3k, time spent looting is added to gp adjusted skills.'
       }
     ],
     bonuses: []
@@ -508,8 +492,8 @@ export default [
     methods: [
       {
         startExp: 0,
-        rate: 15_000,
-        description: 'Quests'
+        rate: 26_000,
+        description: 'Quests + fruit stall'
       },
       {
         startExp: 61_512,
@@ -518,33 +502,33 @@ export default [
       },
       {
         startExp: 91_721,
-        rate: 337_600,
-        description: 'Artefact + glassblowing'
+        rate: 193_600,
+        description: 'Artefact + glassblowing (152k, 71k rate)'
       },
       {
         startExp: 273_742,
-        rate: 384_000,
-        description: 'Artefact + glassblowing'
+        rate: 220_200,
+        description: 'Artefact + glassblowing (172k, 71k rate)'
       },
       {
         startExp: 668_051,
-        rate: 430_300,
-        description: 'Artefact + glassblowing'
+        rate: 246_700,
+        description: 'Artefact + glassblowing (193k, 71k rate)'
       },
       {
         startExp: 1_798_808,
-        rate: 476_600,
-        description: 'Artefact + glassblowing'
+        rate: 273_300,
+        description: 'Artefact + glassblowing (214k, 71k rate)'
       },
       {
         startExp: 4_842_295,
-        rate: 522_900,
-        description: 'Artefact + glassblowing'
+        rate: 299_900,
+        description: 'Artefact + glassblowing (235k, 71k rate)'
       },
       {
         startExp: 13_034_431,
-        rate: 545_000,
-        description: 'Artefact + glassblowing'
+        rate: 312_500,
+        description: 'Artefact + glassblowing (245k, 71k rate)'
       }
     ],
     bonuses: []
@@ -554,53 +538,61 @@ export default [
     methods: [
       {
         startExp: 0,
-        rate: 5_000,
-        description: 'Efficient slayer'
+        rate: 4_600,
+        description: 'Gear + turael & konar'
       },
       {
-        startExp: 37_224,
-        rate: 12_000,
-        description: 'Efficient slayer'
+        startExp: 105_000,
+        rate: 20_700,
+        description: 'Nieve slayer'
       },
       {
-        startExp: 101_333,
-        rate: 15_000,
-        description: 'Efficient slayer'
+        startExp: 273_742,
+        rate: 30_200,
+        description: 'Nieve slayer'
       },
       {
         startExp: 449_428,
-        rate: 18_000,
-        description: 'Efficient slayer'
-      },
-      {
-        startExp: 1_210_421,
-        rate: 25_000,
-        description: 'Efficient slayer'
+        rate: 35_200,
+        description: 'Nieve slayer'
       },
       {
         startExp: 1_986_068,
-        rate: 35_000,
-        description: 'Efficient slayer'
+        rate: 40_800,
+        description: 'Duradel slayer'
+      },
+      {
+        startExp: 3_258_594,
+        rate: 50_700,
+        description: 'Duradel slayer'
       },
       {
         startExp: 7_195_629,
-        rate: 45_000,
-        description: 'Efficient slayer'
+        rate: 56_300,
+        description: 'Duradel slayer'
       },
       {
         startExp: 13_034_431,
-        rate: 56_530,
-        description: 'Chally + barrage'
+        rate: 67_450,
+        description: 'Duradel slayer + banked ehp (52.7k rate)'
       }
     ],
     bonuses: [
+      {
+        originSkill: Skill.SLAYER,
+        bonusSkill: Skill.RANGED,
+        startExp: 0,
+        endExp: 200_000_000,
+        end: true,
+        ratio: 0.0268
+      },
       {
         originSkill: Skill.SLAYER,
         bonusSkill: Skill.DEFENCE,
         startExp: 0,
         endExp: 200_000_000,
         end: false,
-        ratio: 0.9991
+        ratio: 1
       },
       {
         originSkill: Skill.SLAYER,
@@ -608,7 +600,7 @@ export default [
         startExp: 0,
         endExp: 200_000_000,
         end: false,
-        ratio: 0.9991
+        ratio: 1
       },
       {
         originSkill: Skill.SLAYER,
@@ -616,15 +608,7 @@ export default [
         startExp: 0,
         endExp: 200_000_000,
         end: false,
-        ratio: 0.9106
-      },
-      {
-        originSkill: Skill.SLAYER,
-        bonusSkill: Skill.RANGED,
-        startExp: 13_034_431,
-        endExp: 200_000_000,
-        end: true,
-        ratio: 0.0881
+        ratio: 0.9118
       }
     ]
   },
@@ -634,21 +618,21 @@ export default [
       {
         startExp: 0,
         rate: 500_000,
-        description: 'Low lvl trees'
+        description: 'Low lv trees'
       },
       {
-        startExp: 185_428,
+        startExp: 150_872,
         rate: 66_000,
-        description: 'Tithe rewards'
+        description: 'Seed box + autoweed'
       },
       {
-        startExp: 496_254,
+        startExp: 415_000,
         rate: 2_000_000,
-        description: 'Pre 99 trees'
+        description: 'Tree runs'
       },
       {
         startExp: 13_034_431,
-        rate: 2_900_000,
+        rate: 2_880_000,
         description: 'Magic+ tree runs'
       }
     ],
@@ -659,28 +643,48 @@ export default [
     methods: [
       {
         startExp: 0,
-        rate: 8_000,
+        rate: 16_000,
         description: 'Quests'
       },
       {
-        startExp: 7_842,
-        rate: 48_000,
-        description: 'Lavas med pouch'
+        startExp: 36_000,
+        rate: 54_700,
+        description: '1.5t daeyalt lavas (85k rate)'
       },
       {
         startExp: 101_333,
-        rate: 60_000,
-        description: 'Lavas large pouch'
+        rate: 60_600,
+        description: '1.5t daeyalt lavas (101k rate)'
+      },
+      {
+        startExp: 737_627,
+        rate: 56_000,
+        description: '1.5t daeyalt zmi (77k rate)'
       },
       {
         startExp: 1_210_421,
-        rate: 62_000,
-        description: '1.5t daeylt'
+        rate: 64_000,
+        description: '1.5t daeyalt zmi (91k rate)'
+      },
+      {
+        startExp: 1_986_068,
+        rate: 60_000,
+        description: 'Gotr outfit'
+      },
+      {
+        startExp: 3_258_594,
+        rate: 75_200,
+        description: '1.5t daeyalt zmi (114k rate)'
+      },
+      {
+        startExp: 5_346_332,
+        rate: 77_900,
+        description: '1.5t daeyalt zmi (118k rate)'
       },
       {
         startExp: 13_034_431,
-        rate: 63_000,
-        description: '1.5t daeylt/library'
+        rate: 80_000,
+        description: '1.5t daeyalt zmi (122k rate)'
       }
     ],
     bonuses: []
@@ -695,13 +699,18 @@ export default [
       },
       {
         startExp: 101_333,
-        rate: 158_800,
-        description: 'Mahog bh'
+        rate: 175_300,
+        description: 'Mahogany bh'
       },
       {
-        startExp: 1_096_278,
-        rate: 188_600,
-        description: 'Magic bh'
+        startExp: 668_051,
+        rate: 84_490,
+        description: 'Aerial for angler'
+      },
+      {
+        startExp: 1_214_914,
+        rate: 185_000,
+        description: 'Mahogany+ bh'
       },
       {
         startExp: 1_986_068,
@@ -720,8 +729,8 @@ export default [
       },
       {
         startExp: 13_034_431,
-        rate: 240_000,
-        description: 'Black chins'
+        rate: 245_300,
+        description: 'Avg rate of black chins & bh runs'
       }
     ],
     bonuses: []
@@ -741,8 +750,13 @@ export default [
       },
       {
         startExp: 75_127,
-        rate: 259_600,
-        description: '1.5t teak myth capes + kingdom mahogany'
+        rate: 202_091,
+        description: '1.5t teak myth capes (430k rate) + kingdom mahogany benches (1050k rate) - gp adjusted'
+      },
+      {
+        startExp: 13_034_431,
+        rate: 233_800,
+        description: '1.5t teak myth capes (430k rate) + kingdom mahogany benches (1050k rate) - gp adjusted'
       }
     ],
     bonuses: []

--- a/server/__tests__/data/efficiency/configs/ehp/lvl3-test.ehp.ts
+++ b/server/__tests__/data/efficiency/configs/ehp/lvl3-test.ehp.ts
@@ -2,83 +2,6 @@ import { Skill } from '../../../../../src/utils';
 
 export default [
   {
-    skill: Skill.ATTACK,
-    methods: [
-      {
-        startExp: 0,
-        rate: 0,
-        description: '-'
-      }
-    ],
-    bonuses: []
-  },
-  {
-    skill: Skill.DEFENCE,
-    methods: [
-      {
-        startExp: 0,
-        rate: 0,
-        description: '-'
-      }
-    ],
-    bonuses: []
-  },
-  {
-    skill: Skill.STRENGTH,
-    methods: [
-      {
-        startExp: 0,
-        rate: 0,
-        description: '-'
-      }
-    ],
-    bonuses: []
-  },
-  {
-    skill: Skill.HITPOINTS,
-    methods: [
-      {
-        startExp: 0,
-        rate: 0,
-        description: '-'
-      }
-    ],
-    bonuses: []
-  },
-  {
-    skill: Skill.RANGED,
-    methods: [
-      {
-        startExp: 0,
-        rate: 0,
-        description: '-'
-      }
-    ],
-    bonuses: []
-  },
-  {
-    skill: Skill.PRAYER,
-    methods: [
-      {
-        startExp: 0,
-        rate: 0,
-        description: '-'
-      }
-    ],
-    bonuses: []
-  },
-  {
-    skill: Skill.MAGIC,
-    methods: [
-      {
-        startExp: 0,
-        rate: 0,
-        description: '-'
-      }
-    ],
-    bonuses: []
-  },
-  {
     skill: Skill.COOKING,
     methods: [
       {
@@ -149,42 +72,42 @@ export default [
       },
       {
         startExp: 22_406,
-        rate: 89_733,
+        rate: 87_750,
         description: '1.5t Teaks'
       },
       {
         startExp: 41_171,
-        rate: 108_130,
+        rate: 108_161,
         description: '1.5t Teaks'
       },
       {
         startExp: 111_945,
-        rate: 119_190,
+        rate: 119_224,
         description: '1.5t Teaks'
       },
       {
         startExp: 302_288,
-        rate: 148_428,
+        rate: 148_471,
         description: '1.5t Teaks'
       },
       {
         startExp: 737_627,
-        rate: 158_816,
+        rate: 158_861,
         description: '1.5t Teaks'
       },
       {
         startExp: 1_986_068,
-        rate: 171_782,
+        rate: 171_832,
         description: '1.5t Teaks'
       },
       {
         startExp: 5_346_332,
-        rate: 183_571,
+        rate: 183_623,
         description: '1.5t Teaks'
       },
       {
         startExp: 13_034_431,
-        rate: 195_122,
+        rate: 195_178,
         description: '1.5t Teaks'
       }
     ],
@@ -198,17 +121,6 @@ export default [
         ratio: 0.2
       }
     ]
-  },
-  {
-    skill: Skill.FLETCHING,
-    methods: [
-      {
-        startExp: 0,
-        rate: 0,
-        description: 'Multi-skilling darts'
-      }
-    ],
-    bonuses: []
   },
   {
     skill: Skill.FISHING,
@@ -225,35 +137,36 @@ export default [
       },
       {
         startExp: 101_333,
-        rate: 94_364,
-        description: 'Drift net'
+        rate: 82_355,
+        description: 'Fly fishing (Trout & Salmon)'
       },
       {
         startExp: 273_742,
-        rate: 113_709,
-        description: 'Drift net'
+        rate: 97_862,
+        description: 'Fly fishing (Trout & Salmon)'
       },
       {
         startExp: 737_627,
-        rate: 130_434,
-        description: 'Drift net'
+        rate: 124_127,
+        description: 'Fly fishing (Trout & Salmon)'
       },
       {
-        startExp: 151_728_219,
-        rate: 119_261,
-        description: '2t Tuna & Swordfish'
+        startExp: 1_986_068,
+        rate: 128_908,
+        description: 'Fly fishing (Trout & Salmon)'
+      },
+      {
+        startExp: 5_346_332,
+        rate: 131_109,
+        description: 'Fly fishing (Trout & Salmon)'
+      },
+      {
+        startExp: 13_034_431,
+        rate: 95_000,
+        description: 'Fly fishing (Trout & Salmon)'
       }
     ],
-    bonuses: [
-      {
-        originSkill: Skill.FISHING,
-        bonusSkill: Skill.COOKING,
-        startExp: 151_728_219,
-        endExp: 200_000_000,
-        end: true,
-        ratio: 0.216
-      }
-    ]
+    bonuses: []
   },
   {
     skill: Skill.FIREMAKING,
@@ -286,22 +199,22 @@ export default [
       {
         startExp: 101_333,
         rate: 232_155,
-        description: 'Mahogany logs'
+        description: 'Firebwan (Mahogany logs)'
       },
       {
         startExp: 273_742,
         rate: 298_485,
-        description: 'Yew logs'
+        description: 'Firebwan (Yew logs)'
       },
       {
         startExp: 1_210_421,
         rate: 447_801,
-        description: 'Magic logs'
+        description: 'Firebwan (Magic logs)'
       },
       {
         startExp: 5_346_332,
         rate: 505_000,
-        description: 'Firebwan'
+        description: 'Firebwan (Redwood logs)'
       }
     ],
     bonuses: [
@@ -377,7 +290,7 @@ export default [
       {
         startExp: 13_034_431,
         rate: 410_000,
-        description: 'Blast Furnance Gold bars'
+        description: 'Blast Furnace Gold'
       }
     ],
     bonuses: []
@@ -392,7 +305,7 @@ export default [
       },
       {
         startExp: 13_363,
-        rate: 59_158,
+        rate: 53_780,
         description: '3t Iron'
       },
       {
@@ -407,17 +320,17 @@ export default [
       },
       {
         startExp: 302_288,
-        rate: 88_815,
+        rate: 88_350,
         description: '3t4g at Desert Quarry'
       },
       {
         startExp: 737_627,
-        rate: 94_319,
+        rate: 93_609,
         description: '3t4g at Desert Quarry'
       },
       {
-        startExp: 986_068,
-        rate: 99_221,
+        startExp: 1_986_068,
+        rate: 98_474,
         description: '3t4g at Desert Quarry'
       },
       {
@@ -426,8 +339,8 @@ export default [
         description: 'Motherlode Mine for Prospector kit'
       },
       {
-        startExp: 3_548_694,
-        rate: 102_988,
+        startExp: 3_693_744,
+        rate: 103_620,
         description: '3t4g at Desert Quarry'
       },
       {
@@ -585,6 +498,7 @@ export default [
       {
         startExp: 13_034_431,
         rate: 260_000,
+        realRate: 139_062,
         description: 'Swimming'
       }
     ],
@@ -595,21 +509,9 @@ export default [
         startExp: 13_034_431,
         endExp: 200_000_000,
         end: true,
-        ratio: 0.2727,
-        maxBonus: 12_029_509
+        ratio: 0.2727272727
       }
     ]
-  },
-  {
-    skill: Skill.SLAYER,
-    methods: [
-      {
-        startExp: 0,
-        rate: 0,
-        description: '-'
-      }
-    ],
-    bonuses: []
   },
   {
     skill: Skill.FARMING,
@@ -672,42 +574,67 @@ export default [
         description: 'Varrock Museum'
       },
       {
-        startExp: 2_411,
+        startExp: 2_107,
         rate: 82_000,
         description: 'Oak bird house runs'
       },
       {
-        startExp: 7_842,
+        startExp: 7_028,
         rate: 110_000,
         description: 'Willow bird house runs'
       },
       {
-        startExp: 22_406,
+        startExp: 20_224,
         rate: 138_000,
         description: 'Teak bird house runs'
       },
       {
-        startExp: 61_512,
+        startExp: 55_649,
         rate: 161_000,
         description: 'Maple bird house runs'
       },
       {
         startExp: 101_333,
-        rate: 251_565,
+        rate: 361_981,
         description: 'Drift net'
       },
       {
         startExp: 273_742,
-        rate: 291_175,
+        rate: 427_613,
         description: 'Drift net'
       },
       {
         startExp: 737_627,
-        rate: 344_512,
+        rate: 430_165,
         description: 'Drift net'
+      },
+      {
+        startExp: 1_986_068,
+        rate: 391_950,
+        description: 'Drift net'
+      },
+      {
+        startExp: 5_346_332,
+        rate: 377_338,
+        description: 'Drift net'
+      },
+      {
+        startExp: 13_034_431,
+        rate: 310_000,
+        realRate: 118_535,
+        description: 'Drift net (Bird house runs)'
       }
     ],
-    bonuses: []
+    bonuses: [
+      {
+        originSkill: Skill.HUNTER,
+        bonusSkill: Skill.FISHING,
+        startExp: 13_034_431,
+        endExp: 200_000_000,
+        end: true,
+        ratio: 0.7586029443
+      }
+    ]
   },
   {
     skill: Skill.CONSTRUCTION,
@@ -726,6 +653,11 @@ export default [
         startExp: 123_660,
         rate: 935_000,
         description: 'Mahogany tables'
+      },
+      {
+        startExp: 1_475_581,
+        rate: 1_050_000,
+        description: 'Mahogany benches'
       }
     ],
     bonuses: []

--- a/server/__tests__/data/efficiency/configs/ehp/main-test.ehp.ts
+++ b/server/__tests__/data/efficiency/configs/ehp/main-test.ehp.ts
@@ -27,12 +27,12 @@ export default [
       {
         startExp: 1_210_421,
         rate: 315_000,
-        description: 'Bonus XP from Slayer (Nechwark)'
+        description: 'Bonus XP from Slayer'
       },
       {
         startExp: 13_034_431,
-        rate: 330_000,
-        description: 'Bonus XP from Slayer (Nechwark)'
+        rate: 440_000,
+        description: 'Bonus XP from Slayer'
       }
     ],
     bonuses: []
@@ -42,11 +42,28 @@ export default [
     methods: [
       {
         startExp: 0,
-        rate: 700_000,
+        rate: 406_000,
         description: "Chinning in Kruk's Dungeon"
       }
     ],
-    bonuses: []
+    bonuses: [
+      {
+        originSkill: Skill.DEFENCE,
+        bonusSkill: Skill.RANGED,
+        startExp: 0,
+        endExp: 200_000_000,
+        end: false,
+        ratio: 1.2094
+      },
+      {
+        originSkill: Skill.DEFENCE,
+        bonusSkill: Skill.PRAYER,
+        startExp: 0,
+        endExp: 200_000_000,
+        end: true,
+        ratio: 0.09399465048
+      }
+    ]
   },
   {
     skill: Skill.STRENGTH,
@@ -59,42 +76,31 @@ export default [
       {
         startExp: 37_224,
         rate: 38_000,
-        description: 'Crystal Halberd Nechryael'
+        description: 'Bonus XP from Slayer'
       },
       {
         startExp: 61_512,
         rate: 145_000,
-        description: 'Crystal Halberd Nechryael'
+        description: 'Bonus XP from Slayer'
       },
       {
         startExp: 449_428,
         rate: 245_000,
-        description: 'Crystal Halberd Nechryael'
+        description: 'Bonus XP from Slayer'
       },
       {
         startExp: 1_986_068,
         rate: 300_000,
-        description: 'Crystal Halberd Nechryael'
+        description: 'Bonus XP from Slayer'
       },
       {
         startExp: 6_517_253,
         rate: 335_000,
-        description: 'Crystal Halberd Nechryael'
+        description: 'Bonus XP from Slayer'
       },
       {
         startExp: 13_034_431,
-        rate: 380_000,
-        description: 'Crystal Halberd Nechryael'
-      }
-    ],
-    bonuses: []
-  },
-  {
-    skill: Skill.DEFENCE,
-    methods: [
-      {
-        startExp: 0,
-        rate: 0,
+        rate: 390_000,
         description: 'Bonus XP from Slayer'
       }
     ],
@@ -115,7 +121,7 @@ export default [
       },
       {
         startExp: 13_034_431,
-        rate: 1_180_000,
+        rate: 1_154_000,
         description: "Chinning in Kruk's Dungeon"
       }
     ],
@@ -133,17 +139,6 @@ export default [
         startExp: 737_627,
         rate: 1_800_000,
         description: 'Superior dragon bones at Chaos Altar'
-      }
-    ],
-    bonuses: []
-  },
-  {
-    skill: Skill.MAGIC,
-    methods: [
-      {
-        startExp: 0,
-        rate: 0,
-        description: 'Bonus XP from Slayer & Magic Imbue'
       }
     ],
     bonuses: []
@@ -270,17 +265,6 @@ export default [
     ]
   },
   {
-    skill: Skill.FLETCHING,
-    methods: [
-      {
-        startExp: 0,
-        rate: 0,
-        description: 'Multi-skilling darts'
-      }
-    ],
-    bonuses: []
-  },
-  {
     skill: Skill.FISHING,
     methods: [
       {
@@ -296,17 +280,17 @@ export default [
       {
         startExp: 101_333,
         rate: 94_364,
-        description: 'Drift net (2t Fishing)'
+        description: '2t Swordfish'
       },
       {
         startExp: 273_742,
         rate: 113_709,
-        description: 'Drift net (2t Fishing)'
+        description: '2t Swordfish'
       },
       {
         startExp: 737_627,
         rate: 132_000,
-        description: 'Drift net (2t Fishing)'
+        description: '2t Swordfish'
       }
     ],
     bonuses: []
@@ -342,22 +326,22 @@ export default [
       {
         startExp: 101_333,
         rate: 232_155,
-        description: 'Mahogany logs'
+        description: 'Firebwan (Mahogany logs)'
       },
       {
         startExp: 273_742,
         rate: 298_485,
-        description: 'Yew logs'
+        description: 'Firebwan (Yew logs)'
       },
       {
         startExp: 1_210_421,
         rate: 447_801,
-        description: 'Magic logs'
+        description: 'Firebwan (Magic logs)'
       },
       {
         startExp: 5_346_332,
         rate: 505_000,
-        description: 'Firebwan'
+        description: 'Firebwan (Redwood logs)'
       }
     ],
     bonuses: [
@@ -413,12 +397,12 @@ export default [
       {
         startExp: 37_224,
         rate: 380_000,
-        description: 'Blast Furnance Gold bars'
+        description: 'Blast Furnace Gold'
       },
       {
         startExp: 13_034_431,
         rate: 410_000,
-        description: 'Blast Furnance Gold bars'
+        description: 'Blast Furnace Gold'
       }
     ],
     bonuses: []
@@ -569,7 +553,7 @@ export default [
       },
       {
         startExp: 6_517_253,
-        rate: 95_000,
+        rate: 98_500,
         description: 'Floors 1-5 of The Hallowed Sepulchre'
       }
     ],
@@ -640,196 +624,36 @@ export default [
       },
       {
         startExp: 449_428,
-        rate: 69_500,
+        rate: 74_250,
         description: 'Efficient Slayer'
       },
       {
         startExp: 1_986_068,
-        rate: 68_500,
+        rate: 79_000,
         description: 'Efficient Slayer'
       },
       {
         startExp: 3_258_594,
-        rate: 76_000,
+        rate: 86_500,
         description: 'Efficient Slayer'
       },
       {
         startExp: 5_346_332,
-        rate: 76_000,
+        rate: 87_000,
         description: 'Efficient Slayer'
       },
       {
         startExp: 7_195_629,
-        rate: 82_000,
+        rate: 93_000,
         description: 'Efficient Slayer'
       },
       {
         startExp: 13_034_431,
-        rate: 83_000,
+        rate: 99_000,
         description: 'Efficient Slayer'
       }
     ],
     bonuses: [
-      {
-        originSkill: Skill.SLAYER,
-        bonusSkill: Skill.STRENGTH,
-        startExp: 0,
-        endExp: 1_986_068,
-        end: false,
-        ratio: 0.23
-      },
-      {
-        originSkill: Skill.SLAYER,
-        bonusSkill: Skill.STRENGTH,
-        startExp: 1_986_068,
-        endExp: 3_258_594,
-        end: false,
-        ratio: 1.35
-      },
-      {
-        originSkill: Skill.SLAYER,
-        bonusSkill: Skill.STRENGTH,
-        startExp: 3_258_594,
-        endExp: 7_195_629,
-        end: false,
-        ratio: 0.81
-      },
-      {
-        originSkill: Skill.SLAYER,
-        bonusSkill: Skill.STRENGTH,
-        startExp: 7_195_629,
-        endExp: 200_000_000,
-        end: false,
-        ratio: 0.59
-      },
-      {
-        originSkill: Skill.SLAYER,
-        bonusSkill: Skill.DEFENCE,
-        startExp: 0,
-        endExp: 1_986_068,
-        end: false,
-        ratio: 0.47
-      },
-      {
-        originSkill: Skill.SLAYER,
-        bonusSkill: Skill.DEFENCE,
-        startExp: 1_986_068,
-        endExp: 3_258_594,
-        end: false,
-        ratio: 0.34
-      },
-      {
-        originSkill: Skill.SLAYER,
-        bonusSkill: Skill.DEFENCE,
-        startExp: 3_258_594,
-        endExp: 7_195_629,
-        end: false,
-        ratio: 0.47
-      },
-      {
-        originSkill: Skill.SLAYER,
-        bonusSkill: Skill.DEFENCE,
-        startExp: 7_195_629,
-        endExp: 13_034_431,
-        end: false,
-        ratio: 0.51
-      },
-      {
-        originSkill: Skill.SLAYER,
-        bonusSkill: Skill.DEFENCE,
-        startExp: 13_034_431,
-        endExp: 200_000_000,
-        end: false,
-        ratio: 0.52
-      },
-      {
-        originSkill: Skill.SLAYER,
-        bonusSkill: Skill.RANGED,
-        startExp: 0,
-        endExp: 1_986_068,
-        end: false,
-        ratio: 0.62
-      },
-      {
-        originSkill: Skill.SLAYER,
-        bonusSkill: Skill.RANGED,
-        startExp: 1_986_068,
-        endExp: 3_258_594,
-        end: false,
-        ratio: 0.47
-      },
-      {
-        originSkill: Skill.SLAYER,
-        bonusSkill: Skill.RANGED,
-        startExp: 3_258_594,
-        endExp: 7_195_629,
-        end: false,
-        ratio: 0.37
-      },
-      {
-        originSkill: Skill.SLAYER,
-        bonusSkill: Skill.RANGED,
-        startExp: 7_195_629,
-        endExp: 13_034_431,
-        end: false,
-        ratio: 0.31
-      },
-      {
-        originSkill: Skill.SLAYER,
-        bonusSkill: Skill.RANGED,
-        startExp: 13_034_431,
-        endExp: 200_000_000,
-        end: false,
-        ratio: 0.3
-      },
-      {
-        originSkill: Skill.SLAYER,
-        bonusSkill: Skill.PRAYER,
-        startExp: 0,
-        endExp: 1_986_068,
-        end: false,
-        ratio: 0.019
-      },
-      {
-        originSkill: Skill.SLAYER,
-        bonusSkill: Skill.PRAYER,
-        startExp: 1_986_068,
-        endExp: 3_258_594,
-        end: false,
-        ratio: 0.058
-      },
-      {
-        originSkill: Skill.SLAYER,
-        bonusSkill: Skill.PRAYER,
-        startExp: 3_258_594,
-        endExp: 5_346_332,
-        end: false,
-        ratio: 0.112
-      },
-      {
-        originSkill: Skill.SLAYER,
-        bonusSkill: Skill.PRAYER,
-        startExp: 5_346_332,
-        endExp: 7_195_629,
-        end: false,
-        ratio: 0.213
-      },
-      {
-        originSkill: Skill.SLAYER,
-        bonusSkill: Skill.PRAYER,
-        startExp: 7_195_629,
-        endExp: 13_034_431,
-        end: false,
-        ratio: 0.194
-      },
-      {
-        originSkill: Skill.SLAYER,
-        bonusSkill: Skill.PRAYER,
-        startExp: 13_034_431,
-        endExp: 200_000_000,
-        end: false,
-        ratio: 0.197
-      },
       {
         originSkill: Skill.SLAYER,
         bonusSkill: Skill.ATTACK,
@@ -837,6 +661,118 @@ export default [
         endExp: 200_000_000,
         end: false,
         ratio: 1
+      },
+      {
+        originSkill: Skill.SLAYER,
+        bonusSkill: Skill.STRENGTH,
+        startExp: 0,
+        endExp: 200_000_000,
+        end: false,
+        ratio: 1
+      },
+      {
+        originSkill: Skill.SLAYER,
+        bonusSkill: Skill.DEFENCE,
+        startExp: 0,
+        endExp: 200_000_000,
+        end: false,
+        ratio: 0.427844
+      },
+      {
+        originSkill: Skill.SLAYER,
+        bonusSkill: Skill.RANGED,
+        startExp: 0,
+        endExp: 1_986_068,
+        end: false,
+        ratio: 0.3299
+      },
+      {
+        originSkill: Skill.SLAYER,
+        bonusSkill: Skill.RANGED,
+        startExp: 1_986_068,
+        endExp: 3_258_594,
+        end: false,
+        ratio: 0.2494
+      },
+      {
+        originSkill: Skill.SLAYER,
+        bonusSkill: Skill.RANGED,
+        startExp: 3_258_594,
+        endExp: 5_346_332,
+        end: false,
+        ratio: 0.1896
+      },
+      {
+        originSkill: Skill.SLAYER,
+        bonusSkill: Skill.RANGED,
+        startExp: 5_346_332,
+        endExp: 7_195_629,
+        end: false,
+        ratio: 0.174
+      },
+      {
+        originSkill: Skill.SLAYER,
+        bonusSkill: Skill.RANGED,
+        startExp: 7_195_629,
+        endExp: 13_034_431,
+        end: false,
+        ratio: 0.1521
+      },
+      {
+        originSkill: Skill.SLAYER,
+        bonusSkill: Skill.RANGED,
+        startExp: 13_034_431,
+        endExp: 200_000_000,
+        end: false,
+        ratio: 0.1728
+      },
+      {
+        originSkill: Skill.SLAYER,
+        bonusSkill: Skill.PRAYER,
+        startExp: 0,
+        endExp: 1_986_068,
+        end: false,
+        ratio: 0.0673
+      },
+      {
+        originSkill: Skill.SLAYER,
+        bonusSkill: Skill.PRAYER,
+        startExp: 1_986_068,
+        endExp: 3_258_594,
+        end: false,
+        ratio: 0.0824
+      },
+      {
+        originSkill: Skill.SLAYER,
+        bonusSkill: Skill.PRAYER,
+        startExp: 3_258_594,
+        endExp: 5_346_332,
+        end: false,
+        ratio: 0.11917
+      },
+      {
+        originSkill: Skill.SLAYER,
+        bonusSkill: Skill.PRAYER,
+        startExp: 5_346_332,
+        endExp: 7_195_629,
+        end: false,
+        ratio: 0.21689
+      },
+      {
+        originSkill: Skill.SLAYER,
+        bonusSkill: Skill.PRAYER,
+        startExp: 7_195_629,
+        endExp: 13_034_431,
+        end: false,
+        ratio: 0.18914
+      },
+      {
+        originSkill: Skill.SLAYER,
+        bonusSkill: Skill.PRAYER,
+        startExp: 13_034_431,
+        endExp: 200_000_000,
+        end: false,
+        ratio: 0.21605
       }
     ]
   },
@@ -906,39 +842,40 @@ export default [
         description: 'Varrock Museum'
       },
       {
-        startExp: 2_411,
+        startExp: 2_107,
         rate: 82_000,
         description: 'Oak bird house runs'
       },
       {
-        startExp: 7_842,
+        startExp: 7_028,
         rate: 110_000,
         description: 'Willow bird house runs'
       },
       {
-        startExp: 22_406,
+        startExp: 20_224,
         rate: 138_000,
         description: 'Teak bird house runs'
       },
       {
-        startExp: 61_512,
+        startExp: 55_649,
         rate: 161_000,
         description: 'Maple bird house runs'
       },
       {
         startExp: 101_333,
         rate: 251_565,
-        description: 'Drift Net (Chinchompas)'
+        description: 'Drift Net'
       },
       {
         startExp: 273_742,
         rate: 291_175,
-        description: 'Drift Net (Chinchompas)'
+        description: 'Drift Net'
       },
       {
         startExp: 737_627,
         rate: 255_000,
-        description: 'Drift Net (Chinchompas)'
+        realRate: 118_535,
+        description: 'Drift Net (Black Chinchompas)'
       }
     ],
     bonuses: [
@@ -948,8 +885,7 @@ export default [
         startExp: 737_627,
         endExp: 200_000_000,
         end: true,
-        ratio: 0.7586,
-        maxBonus: 24_985_376
+        ratio: 0.7586029443
       }
     ]
   },
@@ -970,6 +906,11 @@ export default [
         startExp: 123_660,
         rate: 935_000,
         description: 'Mahogany tables'
+      },
+      {
+        startExp: 1_475_581,
+        rate: 1_050_000,
+        description: 'Mahogany benches'
       }
     ],
     bonuses: []

--- a/server/__tests__/suites/integration/efficiency.test.ts
+++ b/server/__tests__/suites/integration/efficiency.test.ts
@@ -92,17 +92,17 @@ afterAll(async () => {
 describe('Efficiency API', () => {
   describe('1 - Maximum TTM and TT200m', () => {
     test('Check maximum TTM', () => {
-      expect(ALGORITHMS.main.maxedEHP).toBeCloseTo(1009.3534010368603, 4);
-      expect(ALGORITHMS.ironman.maxedEHP).toBeCloseTo(1762.2395881043994, 4);
-      expect(ALGORITHMS.lvl3.maxedEHP).toBeCloseTo(882.1445120689223, 4);
-      expect(ALGORITHMS.f2p.maxedEHP).toBeCloseTo(1843.5639973947145, 4);
+      expect(ALGORITHMS.main.maxedEHP).toBeCloseTo(962.9246300000013, 4);
+      expect(ALGORITHMS.ironman.maxedEHP).toBeCloseTo(1603.4281499999997, 4);
+      expect(ALGORITHMS.lvl3.maxedEHP).toBeCloseTo(880.0553999999993, 4);
+      expect(ALGORITHMS.f2p.maxedEHP).toBeCloseTo(1578.9323799999984, 4);
     });
 
     test('Check maximum TT200m', () => {
-      expect(ALGORITHMS.main.maximumEHP).toBeCloseTo(13524.420219560474, 4);
-      expect(ALGORITHMS.ironman.maximumEHP).toBeCloseTo(22452.8113112858, 4);
-      expect(ALGORITHMS.lvl3.maximumEHP).toBeCloseTo(11767.772868272423);
-      expect(ALGORITHMS.f2p.maximumEHP).toBeCloseTo(25061.345909596945, 4);
+      expect(ALGORITHMS.main.maximumEHP).toBeCloseTo(12813.80829, 4);
+      expect(ALGORITHMS.ironman.maximumEHP).toBeCloseTo(20300.84631, 4);
+      expect(ALGORITHMS.lvl3.maximumEHP).toBeCloseTo(11796.08924, 4);
+      expect(ALGORITHMS.f2p.maximumEHP).toBeCloseTo(23319.208, 4);
     });
   });
 

--- a/server/__tests__/suites/integration/players.test.ts
+++ b/server/__tests__/suites/integration/players.test.ts
@@ -368,7 +368,7 @@ describe('Player API', () => {
       });
 
       // Using the test "main" rates, we should get this number for regular accs
-      expect(response.body.ehp).toBeCloseTo(694.4541800000006, 4);
+      expect(response.body.ehp).toBeCloseTo(673.7863500000003, 4);
 
       expect(onPlayerUpdatedEvent).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.2.8",
+  "version": "2.2.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.2.8",
+      "version": "2.2.9",
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^4.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.2.8",
+  "version": "2.2.9",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/modules/efficiency/configs/ehp/ironman.ehp.ts
+++ b/server/src/api/modules/efficiency/configs/ehp/ironman.ehp.ts
@@ -276,8 +276,7 @@ export default [
         startExp: 737_627,
         endExp: 2_951_373,
         end: false,
-        ratio: 0.08893,
-        maxBonus: 196_868
+        ratio: 0.08893
       }
     ]
   },

--- a/server/src/api/modules/efficiency/configs/ehp/lvl3.ehp.ts
+++ b/server/src/api/modules/efficiency/configs/ehp/lvl3.ehp.ts
@@ -118,8 +118,7 @@ export default [
         startExp: 302_288,
         endExp: 200_000_000,
         end: true,
-        ratio: 0.2,
-        maxBonus: 39_939_542
+        ratio: 0.2
       }
     ]
   },
@@ -225,8 +224,7 @@ export default [
         startExp: 101_333,
         endExp: 200_000_000,
         end: true,
-        ratio: 0.7,
-        maxBonus: 111_971_387
+        ratio: 0.7
       }
     ]
   },
@@ -363,8 +361,7 @@ export default [
         startExp: 302_288,
         endExp: 200_000_000,
         end: true,
-        ratio: 0.08,
-        maxBonus: 15_975_817
+        ratio: 0.08
       }
     ]
   },

--- a/server/src/api/modules/efficiency/configs/ehp/lvl3.ehp.ts
+++ b/server/src/api/modules/efficiency/configs/ehp/lvl3.ehp.ts
@@ -498,6 +498,7 @@ export default [
       {
         startExp: 13_034_431,
         rate: 260_000,
+        realRate: 139_062,
         description: 'Swimming'
       }
     ],
@@ -508,8 +509,7 @@ export default [
         startExp: 13_034_431,
         endExp: 200_000_000,
         end: true,
-        ratio: 0.2727,
-        maxBonus: 12_029_509
+        ratio: 0.2727272727
       }
     ]
   },
@@ -621,6 +621,7 @@ export default [
       {
         startExp: 13_034_431,
         rate: 310_000,
+        realRate: 118_535,
         description: 'Drift net (Bird house runs)'
       }
     ],
@@ -631,8 +632,7 @@ export default [
         startExp: 13_034_431,
         endExp: 200_000_000,
         end: true,
-        ratio: 0.7586,
-        maxBonus: 49_288_098
+        ratio: 0.7586029443
       }
     ]
   },

--- a/server/src/api/modules/efficiency/configs/ehp/lvl3.ehp.ts
+++ b/server/src/api/modules/efficiency/configs/ehp/lvl3.ehp.ts
@@ -508,6 +508,7 @@ export default [
         bonusSkill: Skill.AGILITY,
         startExp: 13_034_431,
         endExp: 200_000_000,
+        maxBonus: 12_029_509,
         end: true,
         ratio: 0.2727272727
       }
@@ -631,6 +632,7 @@ export default [
         bonusSkill: Skill.FISHING,
         startExp: 13_034_431,
         endExp: 200_000_000,
+        maxBonus: 49_288_098,
         end: true,
         ratio: 0.7586029443
       }

--- a/server/src/api/modules/efficiency/configs/ehp/main.ehp.ts
+++ b/server/src/api/modules/efficiency/configs/ehp/main.ehp.ts
@@ -731,7 +731,7 @@ export default [
         bonusSkill: Skill.PRAYER,
         startExp: 0,
         endExp: 1_986_068,
-        end: true,
+        end: false,
         ratio: 0.0673
       },
       {
@@ -739,7 +739,7 @@ export default [
         bonusSkill: Skill.PRAYER,
         startExp: 1_986_068,
         endExp: 3_258_594,
-        end: true,
+        end: false,
         ratio: 0.0824
       },
       {
@@ -747,7 +747,7 @@ export default [
         bonusSkill: Skill.PRAYER,
         startExp: 3_258_594,
         endExp: 5_346_332,
-        end: true,
+        end: false,
         ratio: 0.11917
       },
       {
@@ -755,7 +755,7 @@ export default [
         bonusSkill: Skill.PRAYER,
         startExp: 5_346_332,
         endExp: 7_195_629,
-        end: true,
+        end: false,
         ratio: 0.21689
       },
       {
@@ -763,7 +763,7 @@ export default [
         bonusSkill: Skill.PRAYER,
         startExp: 7_195_629,
         endExp: 13_034_431,
-        end: true,
+        end: false,
         ratio: 0.18914
       },
       {
@@ -771,7 +771,7 @@ export default [
         bonusSkill: Skill.PRAYER,
         startExp: 13_034_431,
         endExp: 200_000_000,
-        end: true,
+        end: false,
         ratio: 0.21605
       }
     ]

--- a/server/src/api/modules/efficiency/configs/ehp/main.ehp.ts
+++ b/server/src/api/modules/efficiency/configs/ehp/main.ehp.ts
@@ -50,7 +50,7 @@ export default [
       {
         originSkill: Skill.DEFENCE,
         bonusSkill: Skill.RANGED,
-        startExp: 85_565_839,
+        startExp: 0,
         endExp: 200_000_000,
         end: false,
         ratio: 1.2094
@@ -58,9 +58,9 @@ export default [
       {
         originSkill: Skill.DEFENCE,
         bonusSkill: Skill.PRAYER,
-        startExp: 85_565_839,
+        startExp: 0,
         endExp: 200_000_000,
-        end: false,
+        end: true,
         ratio: 0.09399465048
       }
     ]
@@ -731,7 +731,7 @@ export default [
         bonusSkill: Skill.PRAYER,
         startExp: 0,
         endExp: 1_986_068,
-        end: false,
+        end: true,
         ratio: 0.0673
       },
       {
@@ -739,7 +739,7 @@ export default [
         bonusSkill: Skill.PRAYER,
         startExp: 1_986_068,
         endExp: 3_258_594,
-        end: false,
+        end: true,
         ratio: 0.0824
       },
       {
@@ -747,7 +747,7 @@ export default [
         bonusSkill: Skill.PRAYER,
         startExp: 3_258_594,
         endExp: 5_346_332,
-        end: false,
+        end: true,
         ratio: 0.11917
       },
       {
@@ -755,7 +755,7 @@ export default [
         bonusSkill: Skill.PRAYER,
         startExp: 5_346_332,
         endExp: 7_195_629,
-        end: false,
+        end: true,
         ratio: 0.21689
       },
       {
@@ -763,7 +763,7 @@ export default [
         bonusSkill: Skill.PRAYER,
         startExp: 7_195_629,
         endExp: 13_034_431,
-        end: false,
+        end: true,
         ratio: 0.18914
       },
       {
@@ -771,7 +771,7 @@ export default [
         bonusSkill: Skill.PRAYER,
         startExp: 13_034_431,
         endExp: 200_000_000,
-        end: false,
+        end: true,
         ratio: 0.21605
       }
     ]
@@ -874,6 +874,7 @@ export default [
       {
         startExp: 737_627,
         rate: 255_000,
+        realRate: 118_535,
         description: 'Drift Net (Black Chinchompas)'
       }
     ],
@@ -884,8 +885,7 @@ export default [
         startExp: 737_627,
         endExp: 200_000_000,
         end: true,
-        ratio: 0.7586,
-        maxBonus: 32_414_530
+        ratio: 0.7586029443
       }
     ]
   },

--- a/server/src/api/modules/efficiency/configs/ehp/main.ehp.ts
+++ b/server/src/api/modules/efficiency/configs/ehp/main.ehp.ts
@@ -260,8 +260,7 @@ export default [
         startExp: 302_288,
         endExp: 200_000_000,
         end: true,
-        ratio: 0.2,
-        maxBonus: 39_939_542
+        ratio: 0.2
       }
     ]
   },
@@ -352,8 +351,7 @@ export default [
         startExp: 101_333,
         endExp: 200_000_000,
         end: true,
-        ratio: 0.7,
-        maxBonus: 111_971_387
+        ratio: 0.7
       }
     ]
   },
@@ -475,8 +473,7 @@ export default [
         startExp: 302_288,
         endExp: 200_000_000,
         end: true,
-        ratio: 0.08,
-        maxBonus: 15_975_817
+        ratio: 0.08
       }
     ]
   },
@@ -567,8 +564,7 @@ export default [
         startExp: 6_517_253,
         endExp: 200_000_000,
         end: true,
-        ratio: 0.017,
-        maxBonus: 3_289_207
+        ratio: 0.017
       }
     ]
   },

--- a/server/src/api/modules/efficiency/configs/ehp/main.ehp.ts
+++ b/server/src/api/modules/efficiency/configs/ehp/main.ehp.ts
@@ -884,6 +884,7 @@ export default [
         bonusSkill: Skill.FISHING,
         startExp: 737_627,
         endExp: 200_000_000,
+        maxBonus: 32_414_530,
         end: true,
         ratio: 0.7586029443
       }

--- a/server/src/api/modules/efficiency/configs/ehp/ultimate.ehp.ts
+++ b/server/src/api/modules/efficiency/configs/ehp/ultimate.ehp.ts
@@ -291,8 +291,7 @@ export default [
         startExp: 83_014,
         endExp: 8_417_783,
         end: false,
-        ratio: 0.0885,
-        maxBonus: 737_627
+        ratio: 0.0885
       }
     ]
   },

--- a/server/src/api/modules/efficiency/efficiency.types.ts
+++ b/server/src/api/modules/efficiency/efficiency.types.ts
@@ -18,13 +18,16 @@ export enum EfficiencyAlgorithmType {
   F2P = 'f2p'
 }
 
+export interface SkillMetaMethod {
+  rate: number;
+  realRate?: number;
+  startExp: number;
+  description: string;
+}
+
 export interface SkillMetaConfig {
   skill: Skill;
-  methods: Array<{
-    rate: number;
-    startExp: number;
-    description: string;
-  }>;
+  methods: Array<SkillMetaMethod>;
   bonuses: Bonus[];
 }
 
@@ -40,7 +43,6 @@ export interface Bonus {
   endExp: number;
   end: boolean;
   ratio: number;
-  maxBonus?: number;
 }
 
 export interface EfficiencyAlgorithm {

--- a/server/src/api/modules/efficiency/efficiency.types.ts
+++ b/server/src/api/modules/efficiency/efficiency.types.ts
@@ -41,6 +41,7 @@ export interface Bonus {
   bonusSkill: Skill;
   startExp: number;
   endExp: number;
+  maxBonus?: number;
   end: boolean;
   ratio: number;
 }

--- a/server/src/api/modules/efficiency/efficiency.utils.ts
+++ b/server/src/api/modules/efficiency/efficiency.utils.ts
@@ -194,7 +194,7 @@ function calculateTT200mMap(experienceMap: ExperienceMap, metas: SkillMetaConfig
   const startBonusExp = calculateBonuses(fixedMap, getBonuses(metas, BonusType.START), true);
   const startExps = Object.fromEntries(SKILLS.map(s => [s, fixedMap[s] + (startBonusExp[s] || 0)]));
 
-  const endBonusExp = calculateBonuses(startExps as ExperienceMap, getBonuses(metas, BonusType.END), false);
+  const endBonusExp = calculateBonuses(fixedMap as ExperienceMap, getBonuses(metas, BonusType.END), false);
 
   const endExps = Object.fromEntries(
     SKILLS.map(s => [s, s in endBonusExp ? MAX_SKILL_EXP - endBonusExp[s] : MAX_SKILL_EXP])

--- a/server/src/api/modules/efficiency/efficiency.utils.ts
+++ b/server/src/api/modules/efficiency/efficiency.utils.ts
@@ -55,21 +55,6 @@ export function buildAlgorithmCache(skillMetas: SkillMetaConfig[], bossMetas: Bo
   const maxedEHP = _calculateTT200m(ZERO_STATS) - _calculateTT200m(MAXED_STATS);
   const maximumEHP = _calculateTT200m(ZERO_STATS);
 
-  /**
-   * Create a map of Skills and their bonus origins (Defence -> Slayer, Smithing -> Mining)
-   */
-  const bonusMap = new Map<Skill, Skill[]>();
-
-  getBonuses(skillMetas).forEach(bonus => {
-    const currentValues = bonusMap.get(bonus.bonusSkill);
-
-    if (!currentValues) {
-      bonusMap.set(bonus.bonusSkill, [bonus.originSkill]);
-    } else if (!currentValues.includes(bonus.originSkill)) {
-      bonusMap.set(bonus.bonusSkill, [...currentValues, bonus.originSkill]);
-    }
-  });
-
   function _calculateTT200m(experienceMap: ExperienceMap) {
     return calculateTT200mMap(experienceMap, skillMetas)[Metric.OVERALL];
   }
@@ -89,15 +74,7 @@ export function buildAlgorithmCache(skillMetas: SkillMetaConfig[], bossMetas: Bo
 
   function _calculateSkillEHP(skill: Skill, experienceMap: ExperienceMap) {
     if (skill === Skill.OVERALL) return _calculateEHP(experienceMap);
-
-    const resetSkills = bonusMap.get(skill) || [];
-    const resetExpMap = { ...experienceMap };
-
-    resetSkills.forEach(skill => {
-      resetExpMap[skill] = 0;
-    });
-
-    return _calculateTT200m({ ...resetExpMap, [skill]: 0 }) - _calculateTT200m(resetExpMap);
+    return _calculateTT200m({ ...experienceMap, [skill]: 0 }) - _calculateTT200m(experienceMap);
   }
 
   function _calculateBossEHB(boss: Boss, killcountMap: KillcountMap) {

--- a/server/src/api/modules/efficiency/efficiency.utils.ts
+++ b/server/src/api/modules/efficiency/efficiency.utils.ts
@@ -34,6 +34,9 @@ import lvl3SkillingMetas from './configs/ehp/lvl3.ehp';
 import f2pSkillingMetas from './configs/ehp/f2p.ehp';
 import ultimateSkillingMetas from './configs/ehp/ultimate.ehp';
 
+const ZERO_STATS = Object.fromEntries(SKILLS.map(s => [s, 0])) as ExperienceMap;
+const MAXED_STATS = Object.fromEntries(SKILLS.map(s => [s, SKILL_EXP_AT_99])) as ExperienceMap;
+
 export const ALGORITHMS: AlgorithmCache = {
   [EfficiencyAlgorithmType.MAIN]: buildAlgorithmCache(mainSkillingMetas, mainBossingMetas),
   [EfficiencyAlgorithmType.IRONMAN]: buildAlgorithmCache(ironmanSkillingMetas, ironmanBossingMetas),
@@ -46,8 +49,8 @@ export const ALGORITHMS: AlgorithmCache = {
  * Builds a cache of the EHP/EHB algorithms for each player type and build.
  */
 export function buildAlgorithmCache(skillMetas: SkillMetaConfig[], bossMetas: BossMetaConfig[] = []) {
-  const maxedEHP = calculateMaxedEHP(skillMetas);
-  const maximumEHP = calculateMaximumEHP(skillMetas);
+  const maxedEHP = calculateTT200m(ZERO_STATS, skillMetas) - calculateTT200m(MAXED_STATS, skillMetas);
+  const maximumEHP = calculateTT200m(ZERO_STATS, skillMetas);
 
   function _calculateTT200m(experienceMap: ExperienceMap) {
     return calculateTT200m(experienceMap, skillMetas);
@@ -140,19 +143,6 @@ function calculateBonuses(experienceMap: ExperienceMap, bonuses: Bonus[]) {
   });
 
   return map;
-}
-
-function calculateMaximumEHP(metas: SkillMetaConfig[]) {
-  const zeroStats = Object.fromEntries(SKILLS.map(s => [s, 0])) as ExperienceMap;
-
-  return calculateTT200m(zeroStats, metas);
-}
-
-function calculateMaxedEHP(metas: SkillMetaConfig[]) {
-  const zeroStats = Object.fromEntries(SKILLS.map(s => [s, 0])) as ExperienceMap;
-  const maxedStats = Object.fromEntries(SKILLS.map(s => [s, SKILL_EXP_AT_99])) as ExperienceMap;
-
-  return calculateTT200m(zeroStats, metas) - calculateTT200m(maxedStats, metas);
 }
 
 function calculateBossEHB(boss: Boss, killcount: number, metas: BossMetaConfig[]) {

--- a/server/src/api/modules/efficiency/efficiency.utils.ts
+++ b/server/src/api/modules/efficiency/efficiency.utils.ts
@@ -26,7 +26,8 @@ import {
   EfficiencyMap,
   ExperienceMap,
   KillcountMap,
-  SkillMetaConfig
+  SkillMetaConfig,
+  SkillMetaMethod
 } from './efficiency.types';
 import mainBossingMetas from './configs/ehb/main.ehb';
 import mainSkillingMetas from './configs/ehp/main.ehp';
@@ -73,7 +74,16 @@ export function buildAlgorithmCache(skillMetas: SkillMetaConfig[], bossMetas: Bo
 
   function _calculateSkillEHP(skill: Skill, experienceMap: ExperienceMap) {
     if (skill === Skill.OVERALL) return _calculateEHP(experienceMap);
-    return _calculateTT200m({ ...experienceMap, [skill]: 0 }) - _calculateTT200m(experienceMap);
+    // This one fails for a bunch of skills like defence and prayer
+    // return (
+    //   calculateTT200mMap(ZERO_STATS, skillMetas)[skill] - calculateTT200mMap(experienceMap, skillMetas)[skill]
+    // );
+
+    // This one fails for a bunch of skills like attack and strength
+    // return _calculateTT200m({ ...experienceMap, [skill]: 0 }) - _calculateTT200m(experienceMap);
+
+    // This one fails for slayer and hunter
+    return _calculateTT200m(ZERO_STATS) - _calculateTT200m({ ...ZERO_STATS, [skill]: experienceMap[skill] });
   }
 
   function _calculateBossEHB(boss: Boss, killcountMap: KillcountMap) {
@@ -131,18 +141,44 @@ function getBonuses(metas: SkillMetaConfig[], type: BonusType): Bonus[] {
     .filter(b => b?.end === (type === BonusType.END));
 }
 
-function calculateBonuses(experienceMap: ExperienceMap, bonuses: Bonus[]) {
+function calculateBonuses(experienceMap: ExperienceMap, bonuses: Bonus[], isStart: boolean) {
   // Creates an object with an entry for each bonus skill (0 bonus exp)
   const map = Object.fromEntries(bonuses.map(b => [b.bonusSkill, 0]));
 
-  bonuses.forEach(b => {
-    const bonusCap = b.maxBonus || MAX_SKILL_EXP;
-    const expCap = Math.min(b.endExp, MAX_SKILL_EXP);
-    const start = Math.max(experienceMap[b.originSkill], b.startExp);
-    const target = b.originSkill in map ? expCap - map[b.originSkill] : expCap;
+  // Create a dependency map to determine the order in which bonuses should be applied
+  const dependencyMap = new Map<Skill, Skill[]>();
 
-    map[b.bonusSkill] = Math.min(bonusCap, map[b.bonusSkill] + Math.max(0, target - start) * b.ratio);
+  bonuses.forEach(b => {
+    const dependants = dependencyMap.get(b.originSkill);
+
+    if (dependants) {
+      if (!dependants.includes(b.bonusSkill)) {
+        dependencyMap.set(b.originSkill, [...dependants, b.bonusSkill]);
+      }
+    } else {
+      dependencyMap.set(b.originSkill, [b.bonusSkill]);
+    }
   });
+
+  bonuses
+    .sort((a, b) => {
+      // Sort the bonuses by the number of dependants they have.
+      // This ensures skills with no received bonus exp are applied first. (Slayer -> Defence -> Ranged)
+      return (
+        (dependencyMap.get(b.originSkill)?.length ?? 0) - (dependencyMap.get(a.originSkill)?.length ?? 0)
+      );
+    })
+    .forEach(b => {
+      const expCap = Math.min(b.endExp, MAX_SKILL_EXP);
+
+      const originStart =
+        Math.max(experienceMap[b.originSkill], b.startExp) + (isStart ? map[b.originSkill] ?? 0 : 0);
+
+      const originEnd = !isStart && b.originSkill in map ? expCap - map[b.originSkill] : expCap;
+      const bonusToApply = Math.max(0, originEnd - originStart) * b.ratio;
+
+      map[b.bonusSkill] = Math.min(MAX_SKILL_EXP, map[b.bonusSkill] + bonusToApply);
+    });
 
   return map;
 }
@@ -164,26 +200,22 @@ function calculateTT200mMap(experienceMap: ExperienceMap, metas: SkillMetaConfig
   // Ensure unranked skills (-1) are treated as 0 exp
   const fixedMap = mapValues(experienceMap, exp => Math.max(0, exp));
 
-  const startBonusExp = calculateBonuses(fixedMap, getBonuses(metas, BonusType.START));
-  const endBonusExp = calculateBonuses(fixedMap, getBonuses(metas, BonusType.END));
-
+  const startBonusExp = calculateBonuses(fixedMap, getBonuses(metas, BonusType.START), true);
   const startExps = Object.fromEntries(SKILLS.map(s => [s, fixedMap[s] + (startBonusExp[s] || 0)]));
 
-  const targetExps = Object.fromEntries(
+  const endBonusExp = calculateBonuses(startExps as ExperienceMap, getBonuses(metas, BonusType.END), false);
+
+  const endExps = Object.fromEntries(
     SKILLS.map(s => [s, s in endBonusExp ? MAX_SKILL_EXP - endBonusExp[s] : MAX_SKILL_EXP])
   );
 
-  const map = Object.fromEntries(SKILLS.map(s => [s, 0])) as MapOf<Skill, number>;
-
-  REAL_SKILLS.forEach(skill => {
+  function calculateSkillTT200m(skill: Skill, startExp: number, useRealRates = false) {
     const methods = metas.find(sm => sm.skill === skill)?.methods;
-    const startExp = startExps[skill];
-    const endExp = targetExps[skill];
+    const endExp = endExps[skill];
 
     // Handle 0 time skills (Hitpoints, Magic, Fletching)
     if (!methods || (methods.length === 1 && methods[0].rate === 0)) {
-      map[skill] = (endExp - startExp) / MAX_SKILL_EXP;
-      return;
+      return (endExp - startExp) / MAX_SKILL_EXP;
     }
 
     let skillTime = 0;
@@ -194,20 +226,82 @@ function calculateTT200mMap(experienceMap: ExperienceMap, metas: SkillMetaConfig
 
       if (current.rate === 0) continue;
 
+      const rate = useRealRates && current.realRate ? current.realRate : current.rate;
+
       // Start exp is within this method's boundaries
       if (next && next.startExp > startExp && current.startExp < endExp) {
         const gained = Math.min(next.startExp, endExp) - Math.max(startExp, current.startExp);
-        skillTime += Math.max(0, gained / current.rate);
+        skillTime += Math.max(0, gained / rate);
       }
 
       // End exp is beyond this method's boundaries
       if (!next && endExp > current.startExp) {
         const gained = endExp - Math.max(current.startExp, startExp);
-        skillTime += Math.max(0, gained / current.rate);
+        skillTime += Math.max(0, gained / rate);
       }
     }
 
-    map[skill] = skillTime;
+    return skillTime;
+  }
+
+  function getScaledMaxBonus(
+    originSkill: Skill,
+    bonusSkill: Skill,
+    originSkillMethod: SkillMetaMethod,
+    bonusSkillMethod: SkillMetaMethod,
+    bonusRatio: number
+  ) {
+    if (!originSkillMethod || !bonusSkillMethod || !bonusRatio) return undefined;
+
+    const originSkillStart = Math.max(originSkillMethod.startExp, fixedMap[originSkill]);
+    const bonusSkillStart = fixedMap[bonusSkill];
+
+    const originExpLeft = MAX_SKILL_EXP - originSkillStart;
+
+    const realTime =
+      calculateSkillTT200m(originSkill, originSkillStart, true) +
+      calculateSkillTT200m(bonusSkill, bonusSkillStart, true);
+
+    const fakeTime =
+      calculateSkillTT200m(originSkill, originSkillStart, false) +
+      calculateSkillTT200m(bonusSkill, bonusSkillStart, false);
+
+    const excessBonuses = (realTime - fakeTime) * bonusSkillMethod.rate;
+    const fakeBonusLeft = originExpLeft * bonusRatio;
+
+    return fakeBonusLeft - excessBonuses;
+  }
+
+  const driftNetScaledBonuses = getScaledMaxBonus(
+    Skill.HUNTER,
+    Skill.FISHING,
+    metas.find(sm => sm.skill === Skill.HUNTER)?.methods.find(m => !!m.realRate),
+    metas.find(sm => sm.skill === Skill.FISHING)?.methods.at(-1),
+    metas.find(sm => sm.skill === Skill.HUNTER)?.bonuses[0]?.ratio
+  );
+
+  const swimmingScaledBonuses = getScaledMaxBonus(
+    Skill.THIEVING,
+    Skill.AGILITY,
+    metas.find(sm => sm.skill === Skill.THIEVING)?.methods.find(m => !!m.realRate),
+    metas.find(sm => sm.skill === Skill.AGILITY)?.methods.at(-1),
+    metas.find(sm => sm.skill === Skill.THIEVING)?.bonuses[0]?.ratio
+  );
+
+  if (driftNetScaledBonuses) {
+    endBonusExp[Skill.FISHING] = driftNetScaledBonuses;
+    endExps[Skill.FISHING] = MAX_SKILL_EXP - driftNetScaledBonuses;
+  }
+
+  if (swimmingScaledBonuses) {
+    endBonusExp[Skill.AGILITY] = swimmingScaledBonuses;
+    endExps[Skill.AGILITY] = MAX_SKILL_EXP - swimmingScaledBonuses;
+  }
+
+  const map = Object.fromEntries(SKILLS.map(s => [s, 0])) as MapOf<Skill, number>;
+
+  REAL_SKILLS.forEach(skill => {
+    map[skill] = calculateSkillTT200m(skill, startExps[skill]);
   });
 
   const sum = Object.values(map).reduce((a, c) => a + c, 0);


### PR DESCRIPTION
- Fixes Overall EHP (TT200m) calcs
  - Calculates scaled bonuses correctly (drift net, fossil island swimming, etc)
  - Calculates end bonuses based on start exp + start bonuses (previously only start exp)

⚠️ The calcs for an individual Skill's EHP are still incorrect, but I'll revisit those another time, if anyone knows how to calculate that, lmk