### PR TITLE
Remove top 10 limit on "competition ended" discord event

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.2.7",
+      "version": "2.2.8",
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^4.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/services/external/discord.service.ts
+++ b/server/src/api/services/external/discord.service.ts
@@ -155,8 +155,7 @@ function dispatchCompetitionEnded(competition: CompetitionDetails) {
   // Map the competition's end standings
   const standings = participations
     .filter(p => p.progress.gained > 0)
-    .map(p => ({ displayName: p.player.displayName, teamName: p.teamName, gained: p.progress.gained }))
-    .slice(0, 10);
+    .map(p => ({ displayName: p.player.displayName, teamName: p.teamName, gained: p.progress.gained }));
 
   // Omit participations field when sending to discord, to decrease payload size
   dispatch('COMPETITION_ENDED', {


### PR DESCRIPTION
This worked fine for regular competition "ended" announcements since we only show the top 3 on the bot, but for team competitions, it was only counting the top 10 player's exp, which isn't the teams' full exp at all.