### PR TITLE
Replace usage of Promise.all for write operations

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.2.20",
+  "version": "2.2.21",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.2.20",
+      "version": "2.2.21",
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^4.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.2.20",
+  "version": "2.2.21",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/jobs/instances/RefreshApiKeysJobs.ts
+++ b/server/src/api/jobs/instances/RefreshApiKeysJobs.ts
@@ -13,7 +13,9 @@ class RefreshApiKeysJob implements JobDefinition<unknown> {
     const apiKeys = await prisma.apiKey.findMany();
 
     // Cache all these api keys in Redis, so that they can be quickly accessed on every API request
-    await Promise.all(apiKeys.map(key => redisService.setValue('api-key', key.id, String(key.active))));
+    for (const key of apiKeys) {
+      await redisService.setValue('api-key', key.id, String(key.active));
+    }
   }
 }
 

--- a/server/src/api/jobs/instances/ScheduleCompetitionEventsJob.ts
+++ b/server/src/api/jobs/instances/ScheduleCompetitionEventsJob.ts
@@ -25,18 +25,14 @@ class ScheduleCompetitionEventsJob implements JobDefinition<unknown> {
 
   async execute() {
     // Schedule "starting" and "started" events for each interval
-    await Promise.all(
-      START_TIME_INTERVALS.map(async t => {
-        await scheduleStarting(t * 60 * 1000);
-      })
-    );
+    for (const start of START_TIME_INTERVALS) {
+      await scheduleStarting(start * 60 * 1000);
+    }
 
     // Schedule "ending" and "ended" events for each interval
-    await Promise.all(
-      END_TIME_INTERVALS.map(async t => {
-        await scheduleEnding(t * 60 * 1000);
-      })
-    );
+    for (const end of END_TIME_INTERVALS) {
+      await scheduleEnding(end * 60 * 1000);
+    }
   }
 }
 

--- a/server/src/api/modules/competitions/services/EditCompetitionService.ts
+++ b/server/src/api/modules/competitions/services/EditCompetitionService.ts
@@ -211,14 +211,12 @@ async function recalculateParticipationsStart(competitionId: number, startDate: 
   const snapshotMap = new Map<number, Snapshot>(playerSnapshots.map(s => [s.playerId, s]));
 
   // Update participations with the new start snapshot IDs
-  await Promise.all(
-    playerIds.map(playerId => {
-      return prisma.participation.update({
-        where: { playerId_competitionId: { competitionId, playerId } },
-        data: { startSnapshotId: snapshotMap.get(playerId) ? snapshotMap.get(playerId).id : null }
-      });
-    })
-  );
+  for (const playerId of playerIds) {
+    await prisma.participation.update({
+      where: { playerId_competitionId: { competitionId, playerId } },
+      data: { startSnapshotId: snapshotMap.get(playerId) ? snapshotMap.get(playerId).id : null }
+    });
+  }
 }
 
 async function recalculateParticipationsEnd(competitionId: number, endDate: Date) {
@@ -237,14 +235,12 @@ async function recalculateParticipationsEnd(competitionId: number, endDate: Date
   const snapshotMap = new Map<number, Snapshot>(playerSnapshots.map(s => [s.playerId, s]));
 
   // Update participations with the new end snapshot IDs
-  await Promise.all(
-    playerIds.map(playerId => {
-      return prisma.participation.update({
-        where: { playerId_competitionId: { competitionId, playerId } },
-        data: { endSnapshotId: snapshotMap.get(playerId) ? snapshotMap.get(playerId).id : null }
-      });
-    })
-  );
+  for (const playerId of playerIds) {
+    await prisma.participation.update({
+      where: { playerId_competitionId: { competitionId, playerId } },
+      data: { endSnapshotId: snapshotMap.get(playerId) ? snapshotMap.get(playerId).id : null }
+    });
+  }
 }
 
 async function executeUpdate(

--- a/server/src/api/modules/competitions/services/SyncParticipationsService.ts
+++ b/server/src/api/modules/competitions/services/SyncParticipationsService.ts
@@ -29,35 +29,33 @@ async function syncParticipations(payload: SyncParticipationsParams): Promise<vo
 
   if (!participations || participations.length === 0) return;
 
-  await Promise.all(
-    participations.map(async participation => {
-      const updateFields: PrismaTypes.ParticipationUncheckedUpdateInput = {
-        // Update this participation's latest (end) snapshot
-        endSnapshotId: params.latestSnapshotId
-      };
+  for (const participation of participations) {
+    const updateFields: PrismaTypes.ParticipationUncheckedUpdateInput = {
+      // Update this participation's latest (end) snapshot
+      endSnapshotId: params.latestSnapshotId
+    };
 
-      // If this participation's starting snapshot has not been set,
-      // find the first snapshot created since the start date and set it
-      if (!participation.startSnapshotId) {
-        const startSnapshot = await snapshotServices.findPlayerSnapshot({
-          id: params.playerId,
-          minDate: participation.competition.startsAt
-        });
-
-        updateFields.startSnapshotId = startSnapshot.id;
-      }
-
-      await prisma.participation.update({
-        where: {
-          playerId_competitionId: {
-            playerId: params.playerId,
-            competitionId: participation.competitionId
-          }
-        },
-        data: { ...updateFields }
+    // If this participation's starting snapshot has not been set,
+    // find the first snapshot created since the start date and set it
+    if (!participation.startSnapshotId) {
+      const startSnapshot = await snapshotServices.findPlayerSnapshot({
+        id: params.playerId,
+        minDate: participation.competition.startsAt
       });
-    })
-  );
+
+      updateFields.startSnapshotId = startSnapshot.id;
+    }
+
+    await prisma.participation.update({
+      where: {
+        playerId_competitionId: {
+          playerId: params.playerId,
+          competitionId: participation.competitionId
+        }
+      },
+      data: { ...updateFields }
+    });
+  }
 }
 
 export { syncParticipations };

--- a/server/src/api/modules/deltas/services/SyncPlayerDeltasService.ts
+++ b/server/src/api/modules/deltas/services/SyncPlayerDeltasService.ts
@@ -67,7 +67,9 @@ async function syncPlayerDeltas(player: Player, latestSnapshot: Snapshot): Promi
   }
 
   // Execute all update promises, sequentially
-  await Promise.all(PERIODS.map(buildUpdatePromise));
+  for (const period of PERIODS) {
+    await buildUpdatePromise(period);
+  }
 }
 
 export { syncPlayerDeltas };

--- a/server/src/api/modules/name-changes/services/BulkSubmitNameChangesService.ts
+++ b/server/src/api/modules/name-changes/services/BulkSubmitNameChangesService.ts
@@ -1,4 +1,3 @@
-import { NameChange } from '@prisma/client';
 import { z } from 'zod';
 import { BadRequestError } from '../../../errors';
 import * as playerUtils from '../../players/player.utils';
@@ -33,24 +32,25 @@ type BulkSubmitResult = {
 
 async function bulkSubmitNameChanges(payload: BulkSubmitParams): Promise<BulkSubmitResult> {
   const input = inputSchema.parse(payload);
-  const submitted: NameChange[] = [];
+  let submitted = 0;
 
   // Submit all the entries one by one, using the submitNameChange service.
   for (const entry of input) {
     try {
-      submitted.push(await submitNameChange(entry));
+      await submitNameChange(entry);
+      submitted++;
     } catch (_) {
       // Skip over errors
     }
   }
 
-  if (submitted.length === 0) {
+  if (submitted === 0) {
     throw new BadRequestError(`Could not find any valid name changes to submit.`);
   }
 
   return {
-    nameChangesSubmitted: submitted.length,
-    message: `Successfully submitted ${submitted.length}/${input.length} name changes.`
+    nameChangesSubmitted: submitted,
+    message: `Successfully submitted ${submitted}/${input.length} name changes.`
   };
 }
 

--- a/server/src/api/modules/records/services/SyncPlayerRecordsService.ts
+++ b/server/src/api/modules/records/services/SyncPlayerRecordsService.ts
@@ -64,10 +64,8 @@ async function syncPlayerRecords(payload: SyncPlayerRecordsParams): Promise<void
     await prisma.record.createMany({ data: toCreate, skipDuplicates: true });
   }
 
-  if (toUpdate.length > 0) {
-    await Promise.all(
-      toUpdate.map(r => prisma.record.update({ where: { id: r.recordId }, data: { value: r.newValue } }))
-    );
+  for (const update of toUpdate) {
+    await prisma.record.update({ where: { id: update.recordId }, data: { value: update.newValue } });
   }
 }
 


### PR DESCRIPTION
This PR replaces the usage of `Promise.all` in situations where it was being used for write operations.

The following occurrences were not replaced as they are read operations:

- FindPlayerParticipationsStandingsService.ts
- FindGroupDeltasService.ts
- FindPlayerDeltasService.ts
- ImportPlayerHistoryService.ts
- job.manager.ts
