### PR TITLE
Update the test script for more fine grained control

### DIFF
--- a/.github/contributing/app-guide.md
+++ b/.github/contributing/app-guide.md
@@ -66,7 +66,7 @@ SKIP_PREFLIGHT_CHECK=true
 # REACT_APP_BASE_API_URL=http://localhost:5000/api
 ```
 
-**Notice how the REACT_APP_BASE_API_URL variable is commented out using a `#` at the start of it. When this variable is commented out, the app will use the production API URL (`https://api.wiseoldman.net`) by default. If you are running your own local server, you can uncomment that variable and insert your local server URL. This local server URL can differ from localhost,  ou can find out what yours is by visiting the "Running the Server" section of the [server development guide](https://github.com/wise-old-man/wise-old-man/blob/master/.github/contributing/server-guide.md).**
+**Notice how the REACT_APP_BASE_API_URL variable is commented out using a `#` at the start of it. When this variable is commented out, the app will use the production API URL (`https://api.wiseoldman.net`) by default. If you are running your own local server, you can uncomment that variable and insert your local server URL. This local server URL can differ from localhost,  you can find out what yours is by visiting the "Running the Server" section of the [server development guide](https://github.com/wise-old-man/wise-old-man/blob/master/.github/contributing/server-guide.md).**
 
 <br />
 <br />

--- a/.github/contributing/server-guide.md
+++ b/.github/contributing/server-guide.md
@@ -150,7 +150,7 @@ and run `npm run dev` again.
 
 ## Accessing the database
 
-You can use pgadmin to manage your database, by visting the API url, and replacing the 5000 port with 54321.
+You can use pgadmin to manage your database, by visiting the API url, and replacing the 5000 port with 54321.
 
 Example: http://localhost:54321 or http://192.168.99.100:54321
 

--- a/.github/contributing/server-guide.md
+++ b/.github/contributing/server-guide.md
@@ -172,18 +172,38 @@ You should now have access to the database, on the left side panel.
 
 <br />
 
-## Running integration tests
+## Running tests
 
-I suggest running integration tests before commiting, to make sure your new code doesn't ruin any previous code.
+It is recommended to run tests before committing, to make sure your new code doesn't cause any regressions.
 
-Open the terminal and type the following commands:
+Start by changing directory into the server:
 
 ```
 cd server
 ```
 
+To run all unit and integration tests:
+
 ```
 npm run test
+```
+
+To run both the `players.test.ts` unit and integration test files:
+
+```
+npm run test players
+```
+
+To run an individual unit test file, append a `u` to the end of the command:
+
+```
+npm run test countries u
+```
+
+To run an individual integration test file, append an `i` to the end of the command:
+
+```
+npm run test snapshots i
 ```
 
 Read the logs in the terminal, and if all the tests passed, go ahead and commit your changes!

--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -54,7 +54,7 @@ jobs:
         run: npm run build
 
       - name: Run Integration Tests
-        run: npm run test -
+        run: npm run test ci
   type-check-client-js:
     name: Type-check Client JS package
     runs-on: ubuntu-latest

--- a/server/scripts/run-tests.sh
+++ b/server/scripts/run-tests.sh
@@ -41,7 +41,7 @@ if [ $2 ]; then
 
     if ! [ -f $TARGET ]; then
         # The requested test is not valid
-        fail "$1 is not a valid test name.";
+        fail "'$1' is not a valid test name.";
     fi
 
     # Run only the single requested test

--- a/server/scripts/run-tests.sh
+++ b/server/scripts/run-tests.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 ARGS="--verbose --runInBand";
 BASE="__tests__/suites";
@@ -6,19 +6,19 @@ I="integration";
 S=".test.ts";
 U="unit";
 
-function fail() {
+fail() {
     echo "Error: $1";
     exit 1;
 }
 
-function setup() {
+setup() {
     # Reset the test database
     export CORE_DATABASE=wise-old-man-test;
     export NODE_ENV=test TZ=UTC;
     prisma migrate reset --force;
 }
 
-function execute() {
+execute() {
     # Setup docker dependencies (Postgres, PGAdmin and Redis)
     docker-compose up --build -d;
     setup;


### PR DESCRIPTION
This PR updates the `run-tests.sh` script to allow for passing a test name and also a test suite to the command.

Examples:

```
# Run all tests
npm run test 

# Run players.test.ts integration and unit test
npm run test players 

# Run only the countries unit test
npm run test countries u

# Run only the snapshots integration test
npm run test snapshots i
```

Note: the `u` and the `i` can be replaced with any of the following and still work:
`U`, `I`, `-u`, `-i`, `-U`, `-I`, `integration`, `unit`

There is currently no support for passing multiple test file names, but that could potentially be added in the future. 
For now just being able to narrow it down to a single file name feels useful enough.

Updated docs for server contribution with these examples.