### PR TITLE
Fix excessive losses calc and add hespori check

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.2.16",
+  "version": "2.2.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.2.16",
+      "version": "2.2.18",
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^4.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.2.17",
+  "version": "2.2.18",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/modules/players/services/ReviewFlaggedPlayerService.ts
+++ b/server/src/api/modules/players/services/ReviewFlaggedPlayerService.ts
@@ -126,17 +126,32 @@ function hasLostTooMuch(previous: FormattedSnapshot, rejected: FormattedSnapshot
   const previousEHP = previous.data.skills.overall.ehp;
   const previousEHB = BOSSES.map(b => previous.data.bosses[b].ehb).reduce((a, b) => a + b, 0);
 
-  const lostEHP = REAL_SKILLS.map(s => rejected.data.skills[s].ehp - previous.data.skills[s].ehp)
-    .filter(ehpDiff => ehpDiff < 0)
-    .reduce((a, b) => a + b, 0);
+  const lostEHP = Math.abs(
+    REAL_SKILLS.map(s => rejected.data.skills[s].ehp - previous.data.skills[s].ehp)
+      .filter(ehpDiff => ehpDiff < 0)
+      .reduce((a, b) => a + b, 0)
+  );
 
-  const lostEHB = BOSSES.map(s => rejected.data.bosses[s].ehb - previous.data.bosses[s].ehb)
-    .filter(ehbDiff => ehbDiff < 0)
-    .reduce((a, b) => a + b, 0);
+  const lostEHB = Math.abs(
+    BOSSES.map(s => rejected.data.bosses[s].ehb - previous.data.bosses[s].ehb)
+      .filter(ehbDiff => ehbDiff < 0)
+      .reduce((a, b) => a + b, 0)
+  );
 
-  // If lost over 24h (or 20%) of EHP and EHB, then it's probably not a rollback.
+  const hesporiKcLoss =
+    Math.max(0, rejected.data.bosses.hespori.kills) - Math.max(0, previous.data.bosses.hespori.kills);
+
+  console.log(hesporiKcLoss);
+
+  if (hesporiKcLoss <= -3) {
+    // If lost more than 3 Hespori kills, then it's probably not a rollback.
+    // Because that would mean this player killed 3 hesporis in a very short period of time (before Jagex reset the servers).
+    return true;
+  }
+
+  // If lost over 12h (or 20%) of EHP and EHB, then it's probably not a rollback.
   // Rollbacks are usually quickly fixed by Jagex, so it's unlikely that a player gains a huge amount of EHP and EHB in a short period of time.
-  return lostEHP + lostEHB > Math.min(24, (previousEHP + previousEHB) * 0.2);
+  return lostEHP + lostEHB > Math.min(12, (previousEHP + previousEHB) * 0.2);
 }
 
 export { reviewFlaggedPlayer };

--- a/server/src/api/modules/players/services/ReviewFlaggedPlayerService.ts
+++ b/server/src/api/modules/players/services/ReviewFlaggedPlayerService.ts
@@ -141,8 +141,6 @@ function hasLostTooMuch(previous: FormattedSnapshot, rejected: FormattedSnapshot
   const hesporiKcLoss =
     Math.max(0, rejected.data.bosses.hespori.kills) - Math.max(0, previous.data.bosses.hespori.kills);
 
-  console.log(hesporiKcLoss);
-
   if (hesporiKcLoss <= -3) {
     // If lost more than 3 Hespori kills, then it's probably not a rollback.
     // Because that would mean this player killed 3 hesporis in a very short period of time (before Jagex reset the servers).


### PR DESCRIPTION
- Fixes the "excessive losses" check that determines if a player has been flagged due to a hiscores rollback or a name transfer
- Added the "hesopri check", which basically means that if a player has lost over 3 hespori kc, then it's probably not just a hiscores rollback (because then it would mean they killed 3 hespori in a very short period of time, while jagex was resetting their servers)