### PR TITLE
Update docs for name change review context

### DIFF
--- a/docs/docs/names-api/name-type-definitions.md
+++ b/docs/docs/names-api/name-type-definitions.md
@@ -18,7 +18,7 @@ sidebar_position: 1
 ### Name Change Review Context
 
 This JSON object can have many shapes, depending on the context that lead to the name change being denied or skipped.
-These are examples of some possible values:
+These are examples of all possible shapes:
 
 <br />
 
@@ -86,16 +86,16 @@ These are examples of some possible values:
 
 ### `(Object)` Name Change
 
-| Field         | Type                                                                         | Description                                                                 |
-| :------------ | :--------------------------------------------------------------------------- | :-------------------------------------------------------------------------- |
-| id            | integer                                                                      | The name change's unique ID.                                                |
-| playerId      | integer                                                                      | The name change's parent player ID.                                         |
-| oldName       | string                                                                       | The player's "previous" username.                                           |
-| newName       | string                                                                       | The player's "new" username.                                                |
-| status        | [NameChangeStatus](/names-api/name-type-definitions#enum-name-change-status) | The name change's status.                                                   |
-| reviewContext | [ReviewContext](/names-api/name-type-definitions#name-change-review-context) | The name change's reason to have been denied or skipped during auto-review. |
-| resolvedAt    | date?                                                                        | The date at which the name change has been approved/denied.                 |
-| updatedAt     | date                                                                         | The date at which the name change was last modified.                        |
-| createdAt     | date                                                                         | The date at which the name change was submitted.                            |
+| Field         | Type                                                                          | Description                                                                 |
+| :------------ | :---------------------------------------------------------------------------- | :-------------------------------------------------------------------------- |
+| id            | integer                                                                       | The name change's unique ID.                                                |
+| playerId      | integer                                                                       | The name change's parent player ID.                                         |
+| oldName       | string                                                                        | The player's "previous" username.                                           |
+| newName       | string                                                                        | The player's "new" username.                                                |
+| status        | [NameChangeStatus](/names-api/name-type-definitions#enum-name-change-status)  | The name change's status.                                                   |
+| reviewContext | [ReviewContext](/names-api/name-type-definitions#name-change-review-context)? | The name change's reason to have been denied or skipped during auto-review. |
+| resolvedAt    | date?                                                                         | The date at which the name change has been approved/denied.                 |
+| updatedAt     | date                                                                          | The date at which the name change was last modified.                        |
+| createdAt     | date                                                                          | The date at which the name change was submitted.                            |
 
 <br />


### PR DESCRIPTION
This PR updates the docs for `Name Change` to correctly display the `reviewContext` as nullable.

Also corrects wording in the `Name Change Review Context` description.
