### PR TITLE
Update competition score when it starts and ends

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.2.28",
+  "version": "2.2.29",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.2.28",
+      "version": "2.2.29",
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^4.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.2.28",
+  "version": "2.2.29",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/modules/competitions/competition.events.ts
+++ b/server/src/api/modules/competitions/competition.events.ts
@@ -41,6 +41,11 @@ async function onCompetitionStarted(competition: Competition) {
 
   // Dispatch a competition started event to our discord bot API.
   await metrics.trackEffect(discordService.dispatchCompetitionStarted, competition);
+
+  jobManager.add({
+    type: JobType.UPDATE_COMPETITION_SCORE,
+    payload: { competitionId: competition.id }
+  });
 }
 
 async function onCompetitionEnded(competition: Competition) {
@@ -49,6 +54,11 @@ async function onCompetitionEnded(competition: Competition) {
 
   // Dispatch a competition ended event to our discord bot API.
   await metrics.trackEffect(discordService.dispatchCompetitionEnded, competitionDetails);
+
+  jobManager.add({
+    type: JobType.UPDATE_COMPETITION_SCORE,
+    payload: { competitionId: competition.id }
+  });
 }
 
 async function onCompetitionStarting(competition: Competition, period: EventPeriodDelay) {


### PR DESCRIPTION
Schedule an "update score" job when a competition starts and ends, this prevents finished competitions from appearing on top of the competitions page.

