### PR TITLE
Fix number formatting for values between 100k and 10m

### DIFF
--- a/client-js/package-lock.json
+++ b/client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "2.1.17",
+  "version": "2.1.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wise-old-man/utils",
-      "version": "2.1.17",
+      "version": "2.1.18",
       "license": "ISC",
       "dependencies": {
         "axios": "^0.27.2",

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "2.1.17",
+  "version": "2.1.18",
   "description": "A JavaScript/TypeScript client that interfaces and consumes the Wise Old Man API, an API that tracks and measures players' progress in Old School Runescape.",
   "keywords": [
     "wiseoldman",

--- a/server/__tests__/suites/unit/strings.test.ts
+++ b/server/__tests__/suites/unit/strings.test.ts
@@ -14,6 +14,7 @@ describe('Util - Strings', () => {
     expect(formatNumber(-1000, true)).toBe('-1,000');
     expect(formatNumber(10_000, true)).toBe('10k');
     expect(formatNumber(12_523, true)).toBe('12.52k');
+    expect(formatNumber(6_673_573, true)).toBe('6674k');
     expect(formatNumber(9_123_000, true)).toBe('9123k');
     expect(formatNumber(10_000_000, true)).toBe('10m');
     expect(formatNumber(-10_500_000, true)).toBe('-10.50m');
@@ -24,7 +25,7 @@ describe('Util - Strings', () => {
     expect(formatNumber(3456, true, 3)).toBe('3,456');
     expect(formatNumber(10_564, true, 3)).toBe('10.564k');
     expect(formatNumber(10_000, true, 3)).toBe('10k');
-    expect(formatNumber(200_453, true, 3)).toBe('200.453k');
+    expect(formatNumber(200_453, true, 3)).toBe('200k');
     expect(formatNumber(10_000_000, true, 3)).toBe('10m');
     expect(formatNumber(12_967_712, true, 3)).toBe('12.968m');
     expect(formatNumber(2_436_267_123, true, 3)).toBe('2.436b');

--- a/server/src/utils/strings.ts
+++ b/server/src/utils/strings.ts
@@ -10,12 +10,17 @@ function formatNumber(num: number, withLetters = false, decimalPrecision = 2) {
     return num.toLocaleString();
   }
 
-  // < 10 million
-  if (num < 10_000_000 && num > -10_000_000) {
+  // < 100k
+  if (num < 100_000 && num > -100_000) {
     // If has no decimals, return as whole number instead (10.00k => 10k)
     if ((num / 1000) % 1 === 0) return `${num / 1000}k`;
 
     return `${(num / 1000).toFixed(decimalPrecision)}k`;
+  }
+
+  // < 10 million
+  if (num < 10_000_000 && num > -10_000_000) {
+    return `${Math.round(num / 1000)}k`;
   }
 
   // < 1 billion


### PR DESCRIPTION
Numbers between 100k and 10m shouldn't have any decimals

`104.14k` -> `104k`
`284.856k` -> `285k`