### PR TITLE
Add value (desc) to the records index

### DIFF
--- a/server/prisma/migrations/20230609174846_add_value_to_records_index/migration.sql
+++ b/server/prisma/migrations/20230609174846_add_value_to_records_index/migration.sql
@@ -1,0 +1,5 @@
+-- DropIndex
+DROP INDEX "records_metric_period";
+
+-- CreateIndex
+CREATE INDEX "records_metric_period_value" ON "records"("metric", "period", "value" DESC);

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -319,7 +319,7 @@ model Record {
 
   // Indices
   @@index([playerId], map: "records_player_id")
-  @@index([metric, period], map: "records_metric_period")
+  @@index([metric, period, value(sort: Desc)], map: "records_metric_period_value")
   // Map
   @@map("records")
 }

--- a/server/scripts/run-prod.sh
+++ b/server/scripts/run-prod.sh
@@ -1,6 +1,6 @@
 # Migrate the production database.
 # This will check for, and apply any missing migrations
-prisma migrate deploy
+# prisma migrate deploy
 
 # Run pm2 (on 4 CPU cores) on dist/src/server.ts and keep the process alive, restarting if it crashes
 export NODE_ENV=production


### PR DESCRIPTION
Records are sorted by `value` when querying for the leaderboards, previously it had to do a scan on 200-300k rows to find the top 20.

This index adds the `value` column to the compound index and makes it so that we no longer need to do a table scan to find the top rows.

It's much faster now, this is the change in average `/records/leaderboard` request duration:

<img width="569" alt="image" src="https://github.com/wise-old-man/wise-old-man/assets/3278148/bb0536a2-a361-4004-86e7-9a981e51140e">
