### PR TITLE
Add missing foreign key indices

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.2.32",
+  "version": "2.2.33",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.2.32",
+      "version": "2.2.33",
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^4.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.2.32",
+  "version": "2.2.33",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/prisma/migrations/20230613061920_add_missing_foreign_key_indices/migration.sql
+++ b/server/prisma/migrations/20230613061920_add_missing_foreign_key_indices/migration.sql
@@ -1,0 +1,14 @@
+-- CreateIndex
+CREATE INDEX "memberships_group_id" ON "memberships"("groupId");
+
+-- CreateIndex
+CREATE INDEX "participations_competition_id" ON "participations"("competitionId");
+
+-- CreateIndex
+CREATE INDEX "participations_end_snapshot_id" ON "participations"("endSnapshotId");
+
+-- CreateIndex
+CREATE INDEX "participations_start_snapshot_id" ON "participations"("startSnapshotId");
+
+-- CreateIndex
+CREATE INDEX "players_latest_snapshot_id" ON "players"("latestSnapshotId");

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -188,7 +188,7 @@ model Group {
   competitions Competition[]
   memberships  Membership[]
 
-  // Constaints
+  // Constraints
   @@unique([name], map: "groups_name_key")
   // Map
   @@map("groups")
@@ -205,8 +205,10 @@ model Membership {
   group  Group  @relation(fields: [groupId], references: [id], onDelete: Cascade, onUpdate: NoAction)
   player Player @relation(fields: [playerId], references: [id], onDelete: Cascade, onUpdate: NoAction)
 
-  // Indices
+  // Constraints
   @@id([playerId, groupId])
+  // Indices
+  @@index([groupId], map: "memberships_group_id")
   // Map
   @@map("memberships")
 }
@@ -249,6 +251,10 @@ model Participation {
 
   // Constraints
   @@id([playerId, competitionId])
+  // Indices
+  @@index([competitionId], map: "participations_competition_id")
+  @@index([endSnapshotId], map: "participations_end_snapshot_id")
+  @@index([startSnapshotId], map: "participations_start_snapshot_id")
   // Map
   @@map("participations")
 }
@@ -287,6 +293,7 @@ model Player {
   @@index([type], map: "players_type")
   @@index([build], map: "players_build")
   @@index([country], map: "players_country")
+  @@index([latestSnapshotId], map: "players_latest_snapshot_id")
   // Map
   @@map("players")
 }


### PR DESCRIPTION
Apparently postgres doesn't automatically create indices for foreign keys so there were a few missing indices that were causing some queries to do full table scans.

Luckily most of these were happening on small tables so it was never much of a concern, but this should speed up loading times for group and competition pages.