### PR TITLE
api: Add more details to group deltas

### DIFF
--- a/app/src/pages/Group/containers/GainedTable.jsx
+++ b/app/src/pages/Group/containers/GainedTable.jsx
@@ -159,7 +159,18 @@ function getTableConfig(metric, period) {
         )
       },
       {
+        key: 'start',
+        get: row => row.data.start,
+        transform: val => <NumberLabel value={val} />
+      },
+      {
+        key: 'end',
+        get: row => row.data.end,
+        transform: val => <NumberLabel value={val} />
+      },
+      {
         key: 'gained',
+        get: row => row.data.gained,
         transform: val => <NumberLabel value={val} isColored isSigned />
       },
       {

--- a/client-js/package-lock.json
+++ b/client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "2.1.18",
+  "version": "2.1.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wise-old-man/utils",
-      "version": "2.1.18",
+      "version": "2.1.19",
       "license": "ISC",
       "dependencies": {
         "axios": "^0.27.2",

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "2.1.18",
+  "version": "2.1.19",
   "description": "A JavaScript/TypeScript client that interfaces and consumes the Wise Old Man API, an API that tracks and measures players' progress in Old School Runescape.",
   "keywords": [
     "wiseoldman",

--- a/client-js/src/clients/GroupsClient.ts
+++ b/client-js/src/clients/GroupsClient.ts
@@ -8,8 +8,8 @@ import {
   NameChange,
   GroupStatistics,
   RecordLeaderboardEntry,
-  DeltaLeaderboardEntry,
-  ExtendedAchievementWithPlayer
+  ExtendedAchievementWithPlayer,
+  DeltaGroupLeaderboardEntry
 } from '../../../server/src/utils';
 import type {
   CreateGroupPayload,
@@ -121,7 +121,10 @@ export default class GroupsClient extends BaseAPIClient {
   }
 
   getGroupGains(id: number, filter: GetGroupGainsFilter, pagination?: PaginationOptions) {
-    return this.getRequest<DeltaLeaderboardEntry[]>(`/groups/${id}/gained`, { ...pagination, ...filter });
+    return this.getRequest<DeltaGroupLeaderboardEntry[]>(`/groups/${id}/gained`, {
+      ...pagination,
+      ...filter
+    });
   }
 
   /**

--- a/docs/docs/groups-api/group-type-definitions.md
+++ b/docs/docs/groups-api/group-type-definitions.md
@@ -135,6 +135,27 @@ Used as an input for group modification endpoints (create, edit, add members, et
 
 <br />
 
+### `(Object)` Group Delta Progress
+
+| Field  | Type    | Description                                   |
+| :----- | :------ | :-------------------------------------------- |
+| start  | integer | A player's start value for some time period.  |
+| end    | integer | A player's end value for some time period.    |
+| gained | integer | A player's gained value for some time period. |
+
+<br />
+
+### `(Object)` Delta Group Leaderboard Entry
+
+| Field     | Type                                                                                   | Description                                |
+| :-------- | :------------------------------------------------------------------------------------- | :----------------------------------------- |
+| player    | [Player](/players-api/player-type-definitions#object-player)                           | The delta's parent player object.          |
+| data      | [Group Delta Progress](/groups-api/group-type-definitions#object-group-delta-progress) | The delta's progress.                      |
+| startDate | date                                                                                   | The starting date of the delta's timespan. |
+| endDate   | date                                                                                   | The ending date of the delta's timespan.   |
+
+<br />
+
 ### `(Object)` Group Statistics
 
 | Field            | Type                                                                       | Description                                                     |

--- a/server/__tests__/suites/integration/deltas.test.ts
+++ b/server/__tests__/suites/integration/deltas.test.ts
@@ -354,12 +354,12 @@ describe('Deltas API', () => {
 
       expect(directResponse[0]).toMatchObject({
         player: { username: 'psikoi' },
-        gained: 50_000
+        data: { gained: 50_000 }
       });
 
       expect(directResponse[1]).toMatchObject({
         player: { username: 'hydrox6' },
-        gained: 0
+        data: { gained: 0 }
       });
 
       expect(Date.now() - directResponse[0].startDate.getTime()).toBeLessThan(604_800_000);
@@ -375,12 +375,12 @@ describe('Deltas API', () => {
 
       expect(directResponse[0]).toMatchObject({
         player: { username: 'psikoi' },
-        gained: 50_000
+        data: { gained: 50_000 }
       });
 
       expect(directResponse[1]).toMatchObject({
         player: { username: 'hydrox6' },
-        gained: 0
+        data: { gained: 0 }
       });
 
       expect(Date.now() - directResponse[0].startDate.getTime()).toBeLessThan(280_800_000);
@@ -417,12 +417,12 @@ describe('Deltas API', () => {
 
       expect(recentGains[0]).toMatchObject({
         player: { username: 'psikoi' },
-        gained: 50_000
+        data: { gained: 50_000 }
       });
 
       expect(recentGains[1]).toMatchObject({
         player: { username: 'hydrox6' },
-        gained: 0
+        data: { gained: 0 }
       });
 
       expect(recentGains[0].startDate.getTime()).toBeGreaterThan(
@@ -473,7 +473,7 @@ describe('Deltas API', () => {
 
       expect(result[0]).toMatchObject({
         player: { username: 'hydrox6' },
-        gained: 0
+        data: { gained: 0 }
       });
     });
   });

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.2.34",
+  "version": "2.2.35",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.2.34",
+      "version": "2.2.35",
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^4.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.2.34",
+  "version": "2.2.35",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/modules/deltas/delta.types.ts
+++ b/server/src/api/modules/deltas/delta.types.ts
@@ -54,3 +54,14 @@ export interface DeltaLeaderboardEntry {
   endDate: Date;
   gained: number;
 }
+
+export interface DeltaGroupLeaderboardEntry {
+  player: Player;
+  startDate: Date;
+  endDate: Date;
+  data: {
+    start: number;
+    end: number;
+    gained: number;
+  };
+}

--- a/server/src/api/modules/deltas/services/FindGroupDeltasService.ts
+++ b/server/src/api/modules/deltas/services/FindGroupDeltasService.ts
@@ -5,7 +5,7 @@ import { PAGINATION_SCHEMA } from '../../../util/validation';
 import { BadRequestError, NotFoundError } from '../../../errors';
 import * as snapshotServices from '../../snapshots/snapshot.services';
 import { calculateMetricDelta } from '../delta.utils';
-import { DeltaLeaderboardEntry } from '../delta.types';
+import { DeltaGroupLeaderboardEntry } from '../delta.types';
 
 const inputSchema = z
   .object({
@@ -27,7 +27,7 @@ const inputSchema = z
 
 type FindGroupDeltasParams = z.infer<typeof inputSchema>;
 
-async function findGroupDeltas(payload: FindGroupDeltasParams): Promise<DeltaLeaderboardEntry[]> {
+async function findGroupDeltas(payload: FindGroupDeltasParams): Promise<DeltaGroupLeaderboardEntry[]> {
   const params = inputSchema.parse(payload);
 
   // Fetch this group and all of its memberships
@@ -67,14 +67,13 @@ async function findGroupDeltas(payload: FindGroupDeltasParams): Promise<DeltaLea
 
       return {
         player,
-        playerId: Number(playerId),
         startDate: startSnapshot.createdAt as Date,
         endDate: endSnapshot.createdAt as Date,
-        gained: calculateMetricDelta(player, params.metric, startSnapshot, endSnapshot).gained
+        data: calculateMetricDelta(player, params.metric, startSnapshot, endSnapshot)
       };
     })
     .filter(r => r !== null)
-    .sort((a, b) => b.gained - a.gained)
+    .sort((a, b) => b.data.gained - a.data.gained)
     .slice(params.offset, params.offset + params.limit);
 
   return results;

--- a/server/src/api/modules/deltas/services/FindGroupDeltasService.ts
+++ b/server/src/api/modules/deltas/services/FindGroupDeltasService.ts
@@ -65,11 +65,15 @@ async function findGroupDeltas(payload: FindGroupDeltasParams): Promise<DeltaGro
       const { player, startSnapshot, endSnapshot } = playerMap[playerId];
       if (!player || !startSnapshot || !endSnapshot) return null;
 
+      const data = calculateMetricDelta(player, params.metric, startSnapshot, endSnapshot);
+
       return {
         player,
         startDate: startSnapshot.createdAt as Date,
         endDate: endSnapshot.createdAt as Date,
-        data: calculateMetricDelta(player, params.metric, startSnapshot, endSnapshot)
+        data,
+        gained: data.gained, // TODO: delete this soon
+        playerId: Number(player.id) // TODO: delete this soon
       };
     })
     .filter(r => r !== null)


### PR DESCRIPTION
- Adds "start" / "end" values to the `/groups/:id/gained` endpoint (I need these to implement some designs on the v2 app)

# Diff

```diff
{
    player: {
        id: 22878,
        username: "comrade ali",
        displayName: "Comrade Ali",
        type: "ironman",
        build: "main",
        status: "active",
        country: null,
        exp: 351200272,
        ehp: 1303.696620000002,
        ehb: 624.26495,
        ttm: 335.7183100000002,
        tt200m: 18997.14969,
        registeredAt: "2020-07-10T22:29:28.044Z",
        updatedAt: "2023-06-14T16:07:14.700Z",
        lastChangedAt: "2023-06-14T16:07:14.700Z",
        lastImportedAt: "2023-06-14T16:07:15.307Z"
    },
-    playerId: 22878,
-    gained: 2634140
      startDate: "2023-06-09T13:41:19.571Z",
      endDate: "2023-06-14T16:07:14.700Z",
+    data: {
+         start: 6286853,
+         end: 8920993,
+.        gained: 2634140
+     }
}
```


