### PR TITLE
[incomplete] Remove lodash dependency with custom functions

### DIFF
--- a/server/__tests__/suites/unit/groups.test.ts
+++ b/server/__tests__/suites/unit/groups.test.ts
@@ -4,6 +4,9 @@ describe('Util - Groups', () => {
   test('Props', () => {
     expect(GROUP_ROLES.some(t => !(t in GroupRoleProps))).toBe(false);
     expect(Object.keys(GroupRole).length).toBe(Object.keys(GroupRoleProps).length);
+
+    expect(GroupRoleProps[GroupRole.ARTISAN].name).toBe('Artisan');
+    expect(GroupRoleProps[GroupRole.LEADER].isPriveleged).toBe(true);
   });
 
   test('findGroupRole', () => {

--- a/server/src/api/modules/competitions/services/CreateCompetitionService.ts
+++ b/server/src/api/modules/competitions/services/CreateCompetitionService.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
-import { omit } from 'lodash';
 import prisma, { modifyPlayer } from '../../../../prisma';
 import { CompetitionType, Metric } from '../../../../utils';
+import { omit } from '../../../util/objects';
 import { BadRequestError, ForbiddenError, NotFoundError } from '../../../errors';
 import * as playerServices from '../../players/player.services';
 import * as cryptService from '../../../services/external/crypt.service';

--- a/server/src/api/modules/competitions/services/EditCompetitionService.ts
+++ b/server/src/api/modules/competitions/services/EditCompetitionService.ts
@@ -8,6 +8,7 @@ import prisma, {
   modifyPlayer
 } from '../../../../prisma';
 import logger from '../../../util/logging';
+import { omit } from '../../../util/objects';
 import * as playerServices from '../../players/player.services';
 import * as snapshotServices from '../../snapshots/snapshot.services';
 import { BadRequestError, NotFoundError, ServerError } from '../../../errors';
@@ -19,7 +20,6 @@ import {
   sanitizeTitle
 } from '../competition.utils';
 import { standardize } from '../../players/player.utils';
-import { omit } from 'lodash';
 import { CompetitionWithParticipations } from '../competition.types';
 
 const INVALID_TYPE_ERROR =

--- a/server/src/api/modules/competitions/services/FetchCompetitionDetailsService.ts
+++ b/server/src/api/modules/competitions/services/FetchCompetitionDetailsService.ts
@@ -1,6 +1,6 @@
-import { omit } from 'lodash';
 import { z } from 'zod';
 import prisma, { modifyPlayer, modifySnapshot } from '../../../../prisma';
+import { omit } from '../../../util/objects';
 import { getMetricValueKey, isComputedMetric, Metric } from '../../../../utils';
 import { NotFoundError } from '../../../errors';
 import { CompetitionDetails } from '../competition.types';
@@ -40,7 +40,7 @@ async function fetchCompetitionDetails(payload: FetchCompetitionDetailsParams): 
   const participants = await calculateParticipantsStandings(params.id, params.metric || competition.metric);
 
   return {
-    ...omit(competition, ['verificationHash']),
+    ...omit(competition, 'verificationHash'),
     group: competition.group
       ? {
           ...omit(competition.group, '_count', 'verificationHash'),
@@ -80,7 +80,7 @@ async function calculateParticipantsStandings(competitionId: number, metric: Met
       );
 
       return {
-        ...omit(p, ['startSnapshotId', 'endSnapshotId', 'startSnapshot', 'endSnapshot']),
+        ...omit(p, 'startSnapshotId', 'endSnapshotId', 'startSnapshot', 'endSnapshot'),
         player: modifiedPlayer,
         progress: diff
       };

--- a/server/src/api/modules/competitions/services/FindGroupCompetitionsService.ts
+++ b/server/src/api/modules/competitions/services/FindGroupCompetitionsService.ts
@@ -1,6 +1,6 @@
-import { omit } from 'lodash';
 import { z } from 'zod';
 import prisma from '../../../../prisma';
+import { omit } from '../../../util/objects';
 import { NotFoundError } from '../../../errors';
 // import { PAGINATION_SCHEMA } from '../../../util/validation'; // disable pagination for now
 import { CompetitionListItem } from '../competition.types';
@@ -52,7 +52,7 @@ async function findGroupCompetitions(payload: FindGroupCompetitionsParams): Prom
 
   return competitions.map(g => {
     return {
-      ...omit(g, ['_count', 'verificationHash']),
+      ...omit(g, '_count', 'verificationHash'),
       group: g.group
         ? {
             ...omit(g.group, '_count', 'verificationHash'),

--- a/server/src/api/modules/competitions/services/FindPlayerParticipationsService.ts
+++ b/server/src/api/modules/competitions/services/FindPlayerParticipationsService.ts
@@ -1,6 +1,6 @@
-import { omit } from 'lodash';
 import { z } from 'zod';
 import prisma, { PrismaTypes } from '../../../../prisma';
+import { omit } from '../../../util/objects';
 import { CompetitionStatus } from '../../../../utils';
 // import { PAGINATION_SCHEMA } from '../../../util/validation';  // disable pagination for now
 import { ParticipationWithCompetition } from '../competition.types';
@@ -65,9 +65,9 @@ async function findPlayerParticipations(
 
   return participations.map(participation => {
     return {
-      ...omit(participation, ['startSnapshotId', 'endSnapshotId']),
+      ...omit(participation, 'startSnapshotId', 'endSnapshotId'),
       competition: {
-        ...omit(participation.competition, ['_count', 'verificationHash']),
+        ...omit(participation.competition, '_count', 'verificationHash'),
         group: participation.competition.group
           ? {
               ...omit(participation.competition.group, '_count', 'verificationHash'),

--- a/server/src/api/modules/competitions/services/FindPlayerParticipationsStandingsService.ts
+++ b/server/src/api/modules/competitions/services/FindPlayerParticipationsStandingsService.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { omit } from 'lodash';
 import { CompetitionStatus } from '../../../../utils';
+import { omit } from '../../../util/objects';
 import { findPlayerParticipations } from './FindPlayerParticipationsService';
 import { ParticipationWithCompetitionAndStandings } from '../competition.types';
 import { calculateParticipantsStandings } from './FetchCompetitionDetailsService';
@@ -41,7 +41,7 @@ async function findPlayerParticipationsStandings(
     const participation = c.participants[playerIndex];
 
     return {
-      ...omit(participation, ['player']),
+      ...omit(participation, 'player'),
       competition: c.competition,
       rank: playerIndex + 1,
       progress: participation.progress

--- a/server/src/api/modules/competitions/services/SearchCompetitionsService.ts
+++ b/server/src/api/modules/competitions/services/SearchCompetitionsService.ts
@@ -1,7 +1,7 @@
-import { omit } from 'lodash';
 import { z } from 'zod';
 import prisma, { PrismaTypes } from '../../../../prisma';
 import { Metric, CompetitionStatus, CompetitionType } from '../../../../utils';
+import { omit } from '../../../util/objects';
 import { PAGINATION_SCHEMA } from '../../../util/validation';
 import { CompetitionListItem } from '../competition.types';
 
@@ -63,7 +63,7 @@ async function searchCompetitions(payload: SearchCompetitionsParams): Promise<Co
 
   return competitions.map(g => {
     return {
-      ...omit(g, ['_count', 'verificationHash']),
+      ...omit(g, '_count', 'verificationHash'),
       group: g.group
         ? {
             ...omit(g.group, '_count', 'verificationHash'),

--- a/server/src/api/modules/efficiency/efficiency.utils.ts
+++ b/server/src/api/modules/efficiency/efficiency.utils.ts
@@ -1,4 +1,3 @@
-import { mapValues } from 'lodash';
 import { Player, Snapshot } from '../../../prisma';
 import {
   round,
@@ -16,6 +15,7 @@ import {
   REAL_SKILLS,
   MapOf
 } from '../../../utils';
+import { mapValues } from '../../util/objects';
 import {
   AlgorithmCache,
   Bonus,

--- a/server/src/api/modules/groups/services/CreateGroupService.ts
+++ b/server/src/api/modules/groups/services/CreateGroupService.ts
@@ -1,13 +1,13 @@
 import { z } from 'zod';
 import prisma, { modifyPlayer } from '../../../../prisma';
 import { GroupRole, PRIVELEGED_GROUP_ROLES } from '../../../../utils';
+import { omit } from '../../../util/objects';
 import * as cryptService from '../../../services/external/crypt.service';
 import { BadRequestError, ServerError } from '../../../errors';
 import { GroupDetails } from '../group.types';
 import { isValidUsername, sanitize, standardize } from '../../players/player.utils';
 import * as playerServices from '../../players/player.services';
 import { sanitizeName } from '../group.utils';
-import { omit } from 'lodash';
 
 const MIN_NAME_ERROR = 'Group name must have at least one character.';
 
@@ -106,7 +106,7 @@ async function createGroup(payload: CreateGroupParams): Promise<CreateGroupResul
 
   return {
     group: {
-      ...omit(createdGroup, ['verificationHash']),
+      ...omit(createdGroup, 'verificationHash'),
       memberCount: sortedMemberships.length,
       memberships: sortedMemberships
     },

--- a/server/src/api/modules/groups/services/EditGroupService.ts
+++ b/server/src/api/modules/groups/services/EditGroupService.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod';
-import { omit } from 'lodash';
 import prisma, {
   Membership,
   modifyPlayer,
@@ -10,6 +9,7 @@ import prisma, {
 } from '../../../../prisma';
 import { GroupRole, PRIVELEGED_GROUP_ROLES } from '../../../../utils';
 import logger from '../../../util/logging';
+import { omit } from '../../../util/objects';
 import { BadRequestError, ServerError } from '../../../errors';
 import { GroupDetails } from '../group.types';
 import { isValidUsername, sanitize, standardize } from '../../players/player.utils';
@@ -115,7 +115,7 @@ async function editGroup(payload: EditGroupParams): Promise<GroupDetails> {
     .sort((a, b) => priorities.indexOf(b.role) - priorities.indexOf(a.role) || a.role.localeCompare(b.role));
 
   return {
-    ...omit(updatedGroup, ['verificationHash']),
+    ...omit(updatedGroup, 'verificationHash'),
     memberCount: sortedMemberships.length,
     memberships: sortedMemberships
   };

--- a/server/src/api/modules/groups/services/FetchGroupDetailsService.ts
+++ b/server/src/api/modules/groups/services/FetchGroupDetailsService.ts
@@ -1,7 +1,7 @@
-import { omit } from 'lodash';
 import { z } from 'zod';
 import prisma, { modifyPlayer } from '../../../../prisma';
 import { PRIVELEGED_GROUP_ROLES } from '../../../..//utils';
+import { omit } from '../../../util/objects';
 import { NotFoundError } from '../../../errors';
 import { GroupDetails } from '../group.types';
 
@@ -30,7 +30,7 @@ async function fetchGroupDetails(payload: FetchGroupDetailsParams): Promise<Grou
   const priorities = PRIVELEGED_GROUP_ROLES.reverse();
 
   return {
-    ...omit(group, ['verificationHash']),
+    ...omit(group, 'verificationHash'),
     memberCount: group.memberships.length,
     // Sort the members list by role
     memberships: group.memberships

--- a/server/src/api/modules/groups/services/FindPlayerMembershipsService.ts
+++ b/server/src/api/modules/groups/services/FindPlayerMembershipsService.ts
@@ -1,6 +1,6 @@
-import { omit } from 'lodash';
 import { z } from 'zod';
 import prisma from '../../../../prisma';
+import { omit } from '../../../util/objects';
 import { PAGINATION_SCHEMA } from '../../../util/validation';
 import { MembershipWithGroup } from '../group.types';
 
@@ -37,7 +37,7 @@ async function findPlayerMemberships(payload: FindPlayerMembershipsParams): Prom
     return {
       ...membership,
       group: {
-        ...omit(membership.group, ['_count', 'verificationHash']),
+        ...omit(membership.group, '_count', 'verificationHash'),
         memberCount: membership.group._count.memberships
       }
     };

--- a/server/src/api/modules/groups/services/SearchGroupsService.ts
+++ b/server/src/api/modules/groups/services/SearchGroupsService.ts
@@ -1,6 +1,6 @@
-import { omit } from 'lodash';
 import { z } from 'zod';
 import prisma from '../../../../prisma';
+import { omit } from '../../../util/objects';
 import { PAGINATION_SCHEMA } from '../../../util/validation';
 import { GroupListItem } from '../group.types';
 
@@ -36,7 +36,7 @@ async function searchGroups(payload: SearchGroupsParams): Promise<GroupListItem[
 
   return groups.map(g => {
     return {
-      ...omit(g, ['_count', 'verificationHash']),
+      ...omit(g, '_count', 'verificationHash'),
       memberCount: g._count.memberships
     };
   });

--- a/server/src/api/modules/groups/services/VerifyGroupService.ts
+++ b/server/src/api/modules/groups/services/VerifyGroupService.ts
@@ -1,7 +1,7 @@
-import { omit } from 'lodash';
 import { z } from 'zod';
 import prisma from '../../../../prisma';
 import { NotFoundError } from '../../../errors';
+import { omit } from '../../../util/objects';
 import logger from '../../../util/logging';
 import { GroupListItem } from '../group.types';
 
@@ -30,7 +30,7 @@ async function verifyGroup(payload: VerifyGroupService): Promise<GroupListItem> 
     logger.moderation(`[Group:${params.id}] Verified`);
 
     return {
-      ...omit(updatedGroup, ['_count', 'verificationHash']),
+      ...omit(updatedGroup, '_count', 'verificationHash'),
       memberCount: updatedGroup._count.memberships
     };
   } catch (error) {

--- a/server/src/api/services/external/discord.service.ts
+++ b/server/src/api/services/external/discord.service.ts
@@ -1,9 +1,9 @@
 import axios from 'axios';
 import { WebhookClient } from 'discord.js';
-import { omit } from 'lodash';
 import env, { isTesting } from '../../../env';
 import { FlaggedPlayerReviewContext } from '../../../utils';
 import prisma, { Achievement, Player, Competition } from '../../../prisma';
+import { omit } from '../../util/objects';
 import logger from '../../util/logging';
 import {
   CompetitionDetails,

--- a/server/src/api/util/objects.ts
+++ b/server/src/api/util/objects.ts
@@ -1,0 +1,25 @@
+export function omit<T extends object, K extends keyof T>(
+  object: T,
+  ...fields: K[]
+): Pick<T, Exclude<keyof T, K>> {
+  const clone = structuredClone(object);
+
+  fields.forEach(f => {
+    delete clone[f as keyof object];
+  });
+
+  return clone;
+}
+
+export function mapValues<T extends object, TResult>(
+  obj: T,
+  callback: (value: T[keyof T], key: string, collection: T) => TResult
+): { [P in keyof T]: TResult } {
+  const clone = {};
+
+  Object.keys(obj).forEach(key => {
+    clone[key] = callback(obj[key], key, obj);
+  });
+
+  return clone as { [P in keyof T]: TResult };
+}

--- a/server/src/utils/groups.ts
+++ b/server/src/utils/groups.ts
@@ -1,5 +1,5 @@
-import { mapValues } from 'lodash';
 import { GroupRole } from '../prisma/enum-adapter';
+import { mapValues } from '../api/util/objects';
 import { MapOf } from './types';
 
 const GROUP_ROLES = Object.values(GroupRole);

--- a/server/src/utils/metrics.ts
+++ b/server/src/utils/metrics.ts
@@ -1,5 +1,5 @@
-import { mapValues } from 'lodash';
 import { Skill, Boss, Activity, ComputedMetric, Metric } from '../prisma/enum-adapter';
+import { mapValues } from '../api/util/objects';
 import { MapOf } from './types';
 
 enum MetricType {


### PR DESCRIPTION
Lodash is bloated and I'm really only using 2 relatively simple functions from it.

The bundle size wasn't as much of a concern when it was only used in the server, but now it also gets bundled into the client-js npm package and that's not good as lodash alone takes up about 55.8% of the package's minified size. (82kb)

I also used to use a lot more lodash functions but have been removing them as I could, but now, 2 functions for 82kb doesn't seem worth it at all.

**This PR is incomplete as it fails to pass tests and I don't want to spend much time on this**, if anyone wants to take a look at what's wrong and push it over the line, that'd be great 🙏 