### PR TITLE
api: Add snapshots timeline endpoint

### DIFF
--- a/client-js/package-lock.json
+++ b/client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "2.1.19",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wise-old-man/utils",
-      "version": "2.1.19",
+      "version": "2.2.0",
       "license": "ISC",
       "dependencies": {
         "axios": "^0.27.2",

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "2.1.19",
+  "version": "2.2.0",
   "description": "A JavaScript/TypeScript client that interfaces and consumes the Wise Old Man API, an API that tracks and measures players' progress in Old School Runescape.",
   "keywords": [
     "wiseoldman",

--- a/client-js/src/clients/PlayersClient.ts
+++ b/client-js/src/clients/PlayersClient.ts
@@ -17,7 +17,8 @@ import {
   ParticipationWithCompetition,
   FormattedSnapshot,
   MembershipWithGroup,
-  ParticipationWithCompetitionAndStandings
+  ParticipationWithCompetitionAndStandings,
+  Metric
 } from '../../../server/src/utils';
 import { PaginationOptions } from '../utils';
 import BaseAPIClient from './BaseAPIClient';
@@ -142,6 +143,17 @@ export default class PlayersClient extends BaseAPIClient {
    */
   getPlayerSnapshots(username: string, options?: TimeRangeFilter) {
     return this.getRequest<FormattedSnapshot[]>(`/players/${username}/snapshots`, options);
+  }
+
+  /**
+   * Fetches all of the player's past snapshots' timeline.
+   * @returns A list of timeseries data (value, date)
+   */
+  getPlayerSnapshotTimeline(username: string, metric: Metric, options?: TimeRangeFilter) {
+    return this.getRequest<{ value: number; date: Date }[]>(`/players/${username}/snapshots/timeline`, {
+      ...options,
+      metric
+    });
   }
 
   /**

--- a/docs/docs/players-api/player-endpoints.mdx
+++ b/docs/docs/players-api/player-endpoints.mdx
@@ -1262,6 +1262,80 @@ const snapshots = await client.players.getPlayerSnapshots('zezima', { period: Pe
 
 ---
 
+## Get Player Snapshots Timeline
+
+<Endpoint verb="GET" path="/players/:username/snapshots/timeline" />
+<br />
+
+Fetches all of the player's past snapshots (as a value/date timeseries array). Returns an array of [Timeline Datapoints](/players-api/player-type-definitions#object-timeline-datapoint) objects.
+
+**Request Params**
+
+| Field    | Type   | Required | Description            |
+| -------- | ------ | -------- | ---------------------- |
+| username | string | `true`   | The player's username. |
+
+<br />
+
+**Request Params**
+
+| Field     | Type                                           | Required | Description                            |
+| --------- | ---------------------------------------------- | -------- | -------------------------------------- |
+| metric    | [Metric](/global-type-definitions#enum-metric) | `true`   | The record's metric.                   |
+| period    | [Period](/global-type-definitions#enum-period) | `false`  | The period to filter the snapshots by. |
+| startDate | date                                           | `false`  | The minimum date for the snapshots.    |
+| endDate   | date                                           | `false`  | The maximum date for the snapshots.    |
+
+:::info
+This endpoint accepts either `period` or `startDate` + `endDate`.
+:::
+
+<br />
+
+**Example Request**
+
+<TabbedCodeBlock>
+
+```curl
+curl -X GET https://api.wiseoldman.net/v2/players/zezima/snapshots/timeline?metric=magic&period=week \
+  -H "Content-Type: application/json"
+```
+
+```javascript
+const { WOMClient, Period, Metric } = require('@wise-old-man/utils');
+
+const client = new WOMClient();
+
+const snapshots = await client.players.getPlayerSnapshotTimeline('zezima', Metric.MAGIC, {
+  period: Period.WEEK
+});
+```
+
+</TabbedCodeBlock>
+
+<br />
+
+**Example Response**
+
+```json
+[
+  {
+    "value": 19314798,
+    "date": "2023-06-15T06:45:08.867Z"
+  },
+  {
+    "value": 19221704,
+    "date": "2023-06-14T11:13:36.000Z"
+  },
+  {
+    "value": 19219580,
+    "date": "2023-06-13T23:58:48.000Z"
+  }
+]
+```
+
+---
+
 ## Get Player Name Changes
 
 <Endpoint verb="GET" path="/players/:username/names" />

--- a/docs/docs/players-api/player-type-definitions.md
+++ b/docs/docs/players-api/player-type-definitions.md
@@ -182,3 +182,12 @@ Although this type mostly extends from [Achievement](/players-api/player-type-de
 | relativeProgress | float   | The player's current progress (0-1, with 1 being 100%) towards an achievement, starting from the previous achievement for that metric and measure. <br /> <br /> Example: At 30M agility exp, you'd be (**absolutely**) 60% of the way to the 50M agility achievement, but since the previous achievement is 13M (99) agility, you're (**relatively**) at 46% between 99 agility and 50M agility.) |
 
 <br />
+
+### `(Object)` Timeline Datapoint
+
+| Field | Type   | Description                                                            |
+| :---- | :----- | :--------------------------------------------------------------------- |
+| value | number | The player's value for a specific metric, at a specific point in time. |
+| date  | date   | The date at which the datapoint was recorded.                          |
+
+<br />

--- a/server/__tests__/suites/integration/players.test.ts
+++ b/server/__tests__/suites/integration/players.test.ts
@@ -897,6 +897,22 @@ describe('Player API', () => {
         ).length
       ).toBe(0); // there should be no imported snapshots from AFTER May 10th 2020
 
+      const snapshotsTimelineResponse = await api.get(`/players/psikoi/snapshots/timeline`).query({
+        metric: 'magic',
+        startDate: new Date('2010-01-01'),
+        endDate: new Date('2030-01-01')
+      });
+
+      expect(snapshotsTimelineResponse.status).toBe(200);
+      expect(snapshotsTimelineResponse.body.length).toBe(222); // 219 imported, 3 tracked (during this test session)
+
+      for (let i = 0; i < snapshotsTimelineResponse.body.length; i++) {
+        expect(snapshotsTimelineResponse.body[i].value).toBe(
+          snapshotsResponse.body[i].data.skills.magic.experience
+        );
+        expect(snapshotsTimelineResponse.body[i].date).toBe(snapshotsResponse.body[i].createdAt);
+      }
+
       // Mock the history fetch from CML
       registerCMLMock(axiosMock, 404);
     }, 10000); // Set the timeout to 10 seconds for this long running test

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.2.36",
+  "version": "2.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.2.36",
+      "version": "2.3.0",
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^4.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.2.36",
+  "version": "2.3.0",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/modules/players/player.controller.ts
+++ b/server/src/api/modules/players/player.controller.ts
@@ -227,6 +227,24 @@ async function snapshots(req: Request): Promise<ControllerResponse> {
   };
 }
 
+// GET /players/:username/snapshots/timeline
+async function timeline(req: Request): Promise<ControllerResponse> {
+  const player = await playerUtils.resolvePlayer(getString(req.params.username));
+
+  const results = await snapshotServices.findPlayerSnapshotTimeline({
+    id: player.id,
+    metric: getEnum(req.query.metric),
+    period: getEnum(req.query.period),
+    minDate: getDate(req.query.startDate),
+    maxDate: getDate(req.query.endDate)
+  });
+
+  return {
+    statusCode: 200,
+    response: results
+  };
+}
+
 // GET /players/:username/names
 async function names(req: Request): Promise<ControllerResponse> {
   const playerId = await playerUtils.resolvePlayerId(getString(req.params.username));
@@ -330,6 +348,7 @@ export {
   groups,
   gained,
   records,
+  timeline,
   snapshots,
   names,
   changeCountry,

--- a/server/src/api/modules/players/player.routes.ts
+++ b/server/src/api/modules/players/player.routes.ts
@@ -12,6 +12,7 @@ api.get('/:username/groups', setupController(controller.groups));
 api.get('/:username/gained', setupController(controller.gained));
 api.get('/:username/records', setupController(controller.records));
 api.get('/:username/snapshots', setupController(controller.snapshots));
+api.get('/:username/snapshots/timeline', setupController(controller.timeline));
 api.get('/:username/achievements', setupController(controller.achievements));
 api.get('/:username/achievements/progress', setupController(controller.achievementsProgress));
 api.get('/:username/competitions', setupController(controller.competitions));

--- a/server/src/api/modules/snapshots/services/FindPlayerSnapshotTimelineService.ts
+++ b/server/src/api/modules/snapshots/services/FindPlayerSnapshotTimelineService.ts
@@ -1,0 +1,81 @@
+import { z } from 'zod';
+import prisma, { modifySnapshots, PrismaTypes } from '../../../../prisma';
+import { Metric, getMetricValueKey, parsePeriodExpression } from '../../../../utils';
+import { BadRequestError } from '../../../errors';
+
+const inputSchema = z
+  .object({
+    id: z.number().int().positive(),
+    metric: z.nativeEnum(Metric),
+    // These can be filtered by a period string (week, day, 2m3w6d)
+    period: z.string().optional(),
+    // or by a time range (min date and max date)
+    minDate: z.date().optional(),
+    maxDate: z.date().optional(),
+    limit: z.number().int().positive().optional().default(100_000)
+  })
+  .refine(s => !(s.minDate && s.maxDate && s.minDate >= s.maxDate), {
+    message: 'Min date must be before the max date.'
+  });
+
+type FindPlayerSnapshotTimelineParams = z.infer<typeof inputSchema>;
+
+async function findPlayerSnapshotTimeline(
+  payload: FindPlayerSnapshotTimelineParams
+): Promise<Array<{ value: number; date: Date }>> {
+  const params = inputSchema.parse(payload);
+
+  const filterQuery = buildFilterQuery(params);
+  const metricValueKey = getMetricValueKey(params.metric);
+
+  const snapshots = await prisma.snapshot
+    .findMany({
+      select: {
+        [metricValueKey]: true,
+        createdAt: true
+      },
+      where: { playerId: params.id, ...filterQuery },
+      orderBy: { createdAt: 'desc' },
+      take: params.limit
+    })
+    .then(modifySnapshots);
+
+  const history = snapshots.map(snapshot => {
+    return {
+      value: snapshot[metricValueKey],
+      date: snapshot.createdAt
+    };
+  });
+
+  return history;
+}
+
+function buildFilterQuery(params: FindPlayerSnapshotTimelineParams): PrismaTypes.SnapshotWhereInput {
+  if (params.minDate && params.maxDate) {
+    return {
+      createdAt: {
+        gte: params.minDate,
+        lte: params.maxDate
+      }
+    };
+  }
+
+  if (params.period) {
+    const parsedPeriod = parsePeriodExpression(params.period);
+
+    if (!parsedPeriod) {
+      throw new BadRequestError(`Invalid period: ${params.period}.`);
+    }
+
+    return {
+      createdAt: {
+        gte: new Date(Date.now() - parsedPeriod.durationMs),
+        lte: new Date()
+      }
+    };
+  }
+
+  return {};
+}
+
+export { findPlayerSnapshotTimeline };

--- a/server/src/api/modules/snapshots/snapshot.services.ts
+++ b/server/src/api/modules/snapshots/snapshot.services.ts
@@ -3,3 +3,4 @@ export * from './services/RollbackSnapshotsService';
 export * from './services/FindGroupSnapshotsService';
 export * from './services/FindPlayerSnapshotService';
 export * from './services/FindPlayerSnapshotsService';
+export * from './services/FindPlayerSnapshotTimelineService';


### PR DESCRIPTION
Adds `/players/:username/snapshots/timeline` endpoint, a lightweight version of `/players/:username/snapshots` that only returns minimal timeseries data for a specific metric.

Created this because the regular snapshots endpoint isn't ideal for rendering a player's "gained" page, as it loads too much data, most of which is never even seen by the user.

Example curl:
```curl
curl -X GET https://api.wiseoldman.net/v2/players/zezima/snapshots/timeline?metric=magic&period=week \
  -H "Content-Type: application/json"
```

Example response:


```json
[
  {
    "value": 19314798,
    "date": "2023-06-15T06:45:08.867Z"
  },
  {
    "value": 19221704,
    "date": "2023-06-14T11:13:36.000Z"
  },
  {
    "value": 19219580,
    "date": "2023-06-13T23:58:48.000Z"
  }
]
```
