### PR TITLE
api: Auto-update "serious" participants 2h before comp ends

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^4.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/jobs/instances/ScheduleCompetitionEventsJob.ts
+++ b/server/src/api/jobs/instances/ScheduleCompetitionEventsJob.ts
@@ -13,8 +13,8 @@ const EXECUTION_FREQUENCY = 60_000;
 // 6h, 5min, now
 const START_TIME_INTERVALS = [360, 5, 0];
 
-// 12h, 30min, now
-const END_TIME_INTERVALS = [720, 30, 0];
+// 12h, 2h, 30min, now
+const END_TIME_INTERVALS = [720, 120, 30, 0];
 
 class ScheduleCompetitionEventsJob implements JobDefinition<unknown> {
   type: JobType;


### PR DESCRIPTION
Adds a job to auto-update any participants with > 0 gains, 2 hours before a competition ends.

This is just a precaution in case the competition manager forgets to update people before the end. With this in place, we can ensure that any "serious" competitors will at least be updated once before the competition ends (so they'll at most lose 2 hours of progress, or 8 with 6h logs)

We're doing this at 2h before instead of 1h, 30mins, 5mins as to still allow comp managers to hit the "update all" in the final hour. They are still responsible for babysitting the competition ending and updating people before the clock runs out.