### PR TITLE
chore: Add _LOCAL and _TEST suffixes to the database names

### DIFF
--- a/.github/contributing/server-guide.md
+++ b/.github/contributing/server-guide.md
@@ -74,7 +74,7 @@ cp .env.example .env
 By default the example files contain the following example snippets
 
 ```
-CORE_DATABASE=wise-old-man
+CORE_DATABASE=wise-old-man_LOCAL
 
 DB_HOST=localhost
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,4 +1,4 @@
-CORE_DATABASE=wise-old-man
+CORE_DATABASE=wise-old-man_LOCAL
 
 DB_HOST=localhost
 POSTGRES_PORT=5432

--- a/server/scripts/run-tests.sh
+++ b/server/scripts/run-tests.sh
@@ -13,7 +13,7 @@ fail() {
 
 setup() {
     # Reset the test database
-    export CORE_DATABASE=wise-old-man-test;
+    export CORE_DATABASE=wise-old-man_TEST;
     export NODE_ENV=test TZ=UTC;
     prisma migrate reset --force;
 }


### PR DESCRIPTION
Just to help prevent future cases of "oops I deleted the production database by accident"