### PR TITLE
[WIP] Add member activity

### DIFF
--- a/docs/docs/groups-api/group-endpoints.mdx
+++ b/docs/docs/groups-api/group-endpoints.mdx
@@ -1766,3 +1766,103 @@ const statistics = await client.groups.getGroupStatistics(123);
   }
 }
 ```
+
+## Get Group Activity
+
+<Endpoint verb="GET" path="/groups/:id/activity" />
+<br />
+
+Fetches a group's activity. Returns an array of [GroupActivity](/groups-api/group-type-definitions#object-group-activity) objects.
+
+<br />
+
+**Request Params**
+
+| Field | Type    | Required | Description     |
+| ----- | ------- | -------- | --------------- |
+| id    | integer | `true`   | The group's ID. |
+
+<br />
+
+**Query Params**
+
+| Field  | Type    | Required | Description                                           |
+| ------ | ------- | -------- | ----------------------------------------------------- |
+| limit  | integer | `false`  | The pagination limit. See [Pagination](/#pagination)  |
+| offset | integer | `false`  | The pagination offset. See [Pagination](/#pagination) |
+
+<br />
+
+**Example Request**
+
+<TabbedCodeBlock>
+
+```curl
+curl -X GET https://api.wiseoldman.net/v2/groups/123/activity?limit=5 \
+ -H "Content-type: application/json"
+```
+
+```javascript
+const { WOMClient } = require('@wise-old-man/utils');
+
+const client = new WOMClient();
+
+const activity = await client.groups.getGroupActivity(123);
+```
+
+</TabbedCodeBlock>
+
+<br />
+
+**Example Response**
+
+```json
+[
+  {
+    "player": {
+      "id": 4156,
+      "username": "rro",
+      "displayName": "Rro",
+      "type": "regular",
+      "build": "main",
+      "status": "active",
+      "country": null,
+      "exp": 694156199,
+      "ehp": 1635.832120000001,
+      "ehb": 1160.30569,
+      "ttm": 0,
+      "tt200m": 11177.97617,
+      "registeredAt": "2023-07-03T21:54:22.107Z",
+      "updatedAt": "2023-07-06T11:24:30.890Z",
+      "lastChangedAt": "2023-07-06T11:24:30.890Z",
+      "lastImportedAt": "2023-07-03T21:54:26.329Z"
+    },
+    "type": "changed_role",
+    "role": "gnome_child",
+    "createdAt": "2023-07-07T19:53:32.162Z"
+  },
+  {
+    "player": {
+      "id": 4156,
+      "username": "rro",
+      "displayName": "Rro",
+      "type": "regular",
+      "build": "main",
+      "status": "active",
+      "country": null,
+      "exp": 694156199,
+      "ehp": 1635.832120000001,
+      "ehb": 1160.30569,
+      "ttm": 0,
+      "tt200m": 11177.97617,
+      "registeredAt": "2023-07-03T21:54:22.107Z",
+      "updatedAt": "2023-07-06T11:24:30.890Z",
+      "lastChangedAt": "2023-07-06T11:24:30.890Z",
+      "lastImportedAt": "2023-07-03T21:54:26.329Z"
+    },
+    "type": "joined",
+    "role": null,
+    "createdAt": "2023-07-07T18:33:12.029Z"
+  }
+]
+```

--- a/docs/docs/groups-api/group-type-definitions.md
+++ b/docs/docs/groups-api/group-type-definitions.md
@@ -15,6 +15,14 @@ sidebar_position: 1
 
 <br />
 
+### (`Enum`) Activity Type
+
+```bash
+'joined', 'left', 'changed_role'
+```
+
+<br />
+
 ### `(Object)` Group
 
 | Field       | Type    | Description                              |
@@ -264,5 +272,14 @@ Used as an input for group modification endpoints (create, edit, add members, et
   }
 }
 ```
+
+### `(Object)` Group Activity
+
+| Field     | Type                                                                  | Description                              |
+| :-------- | :-------------------------------------------------------------------- | :--------------------------------------- |
+| player    | [Player](/players-api/player-type-definitions#object-player)          | The activity entry's parent player ID.   |
+| type      | [ActivityType](/groups-api/group-type-definitions#enum-activity-type) | The type of activity                     |
+| role      | [GroupRole](/groups-api/group-type-definitions#enum-group-role)?      | The player's role (rank) in the group.   |
+| createdAt | date                                                                  | The date at which the activity happened. |
 
 <br />

--- a/server/prisma/migrations/20230706130300_add_members_activity_table/migration.sql
+++ b/server/prisma/migrations/20230706130300_add_members_activity_table/migration.sql
@@ -1,0 +1,16 @@
+-- CreateEnum
+CREATE TYPE "activity_type" AS ENUM ('joined', 'left', 'changed_role');
+
+-- CreateTable
+CREATE TABLE "member_activity" (
+    "groupId" INTEGER NOT NULL,
+    "playerId" INTEGER NOT NULL,
+    "type" "activity_type" NOT NULL,
+    "role" "group_role",
+    "createdAt" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "member_activity_pkey" PRIMARY KEY ("groupId","playerId","createdAt")
+);
+
+-- CreateIndex
+CREATE INDEX "member_activity_group_id_created_at" ON "member_activity"("groupId", "createdAt" DESC);

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -548,7 +548,7 @@ model MemberActivity {
   @@id([groupId, playerId, createdAt])
   // Indices
   @@index([groupId, createdAt(sort: Desc)], map: "member_activity_group_id_created_at")
-  //Map
+  // Map
   @@map("member_activity")
 }
 

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -540,9 +540,9 @@ model Snapshot {
 model MemberActivity {
   groupId   Int
   playerId  Int
-  type      AchievementType
+  type      ActivityType
   role      GroupRole?
-  createdAt DateTime
+  createdAt DateTime  @default(now()) @db.Timestamptz(6)
 
   // Constraints
   @@id([groupId, playerId, createdAt])
@@ -1235,10 +1235,10 @@ enum Metric {
   @@map("metric")
 }
 
-enum AchievementType {
+enum ActivityType {
   joined
   left
   changed_role
 
-  @@map("achievement_type")
+  @@map("activity_type")
 }

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -537,6 +537,21 @@ model Snapshot {
   @@map("snapshots")
 }
 
+model MemberActivity {
+  groupId   Int
+  playerId  Int
+  type      AchievementType
+  role      GroupRole?
+  createdAt DateTime
+
+  // Constraints
+  @@id([groupId, playerId, createdAt])
+  // Indices
+  @@index([groupId, createdAt(sort: Desc)], map: "member_activity_group_id_created_at")
+  //Map
+  @@map("member_activity")
+}
+
 enum NameChangeStatus {
   pending
   denied
@@ -1218,4 +1233,12 @@ enum Metric {
   guardians_of_the_rift
 
   @@map("metric")
+}
+
+enum AchievementType {
+  joined
+  left
+  changed_role
+
+  @@map("achievement_type")
 }

--- a/server/src/api/modules/groups/group.controller.ts
+++ b/server/src/api/modules/groups/group.controller.ts
@@ -192,6 +192,17 @@ async function competitions(req: Request): Promise<ControllerResponse> {
   return { statusCode: 200, response: results };
 }
 
+// GET /groups/:id/activity
+async function activity(req: Request): Promise<ControllerResponse> {
+  const results = await groupServices.fetchGroupActivities({
+    groupId: getNumber(req.params.id),
+    limit: getNumber(req.query.limit),
+    offset: getNumber(req.query.offset)
+  });
+
+  return { statusCode: 200, response: results };
+}
+
 // GET /groups/:id/gained
 async function gained(req: Request): Promise<ControllerResponse> {
   const results = await deltaServices.findGroupDeltas({
@@ -298,6 +309,7 @@ export {
   nameChanges,
   statistics,
   competitions,
+  activity,
   addMembers,
   removeMembers,
   migrateTemple,

--- a/server/src/api/modules/groups/group.events.ts
+++ b/server/src/api/modules/groups/group.events.ts
@@ -1,11 +1,16 @@
-import { Membership, PlayerType } from '../../../utils';
+import { GroupRole, Membership, PlayerType } from '../../../utils';
 import { jobManager, JobType } from '../../jobs';
 import metrics from '../../services/external/metrics.service';
+import { MemberActivity } from '../../../prisma';
 import * as discordService from '../../services/external/discord.service';
 import * as playerServices from '../players/player.services';
 import * as competitionServices from '../competitions/competition.services';
 
-async function onMembersJoined(memberships: Membership[]) {
+async function onMemberRoleChanged(memberActivity: MemberActivity, previousRole: GroupRole) {
+  await metrics.trackEffect(discordService.dispatchMemberRoleChanged, memberActivity, previousRole);
+}
+
+async function onMembersJoined(memberships: Omit<Membership, 'createdAt' | 'updatedAt'>[]) {
   const groupId = memberships[0].groupId;
   const playerIds = memberships.map(m => m.playerId);
 
@@ -36,4 +41,4 @@ async function onMembersLeft(groupId: number, playerIds: number[]) {
   await metrics.trackEffect(discordService.dispatchMembersLeft, groupId, playerIds);
 }
 
-export { onMembersJoined, onMembersLeft };
+export { onMembersJoined, onMembersLeft, onMemberRoleChanged };

--- a/server/src/api/modules/groups/group.routes.ts
+++ b/server/src/api/modules/groups/group.routes.ts
@@ -26,6 +26,7 @@ api.get('/:id/records', setupController(controller.records));
 api.get('/:id/hiscores', setupController(controller.hiscores));
 api.get('/:id/name-changes', setupController(controller.nameChanges));
 api.get('/:id/statistics', setupController(controller.statistics));
+api.get('/:id/activity', setupController(controller.activity));
 
 api.get('/migrate/temple/:id', setupController(controller.migrateTemple));
 api.get('/migrate/cml/:id', setupController(controller.migrateCML));

--- a/server/src/api/modules/groups/group.services.ts
+++ b/server/src/api/modules/groups/group.services.ts
@@ -13,3 +13,4 @@ export * from './services/ResetGroupCodeService';
 export * from './services/SearchGroupsService';
 export * from './services/UpdateAllMembersService';
 export * from './services/VerifyGroupService';
+export * from './services/FetchGroupActivityService';

--- a/server/src/api/modules/groups/group.types.ts
+++ b/server/src/api/modules/groups/group.types.ts
@@ -1,6 +1,7 @@
 import { GroupRole } from '../../../utils';
 import { Group, Membership, Player } from '../../../prisma';
 import { MetricLeaders, FormattedSnapshot } from '../snapshots/snapshot.types';
+import { ActivityType } from '../../../prisma/enum-adapter';
 
 export interface GroupListItem extends Omit<Group, 'verificationHash'> {
   memberCount: number;
@@ -51,6 +52,13 @@ export interface GroupHiscoresEntry {
     | GroupHiscoresBossItem
     | GroupHiscoresActivityItem
     | GroupHiscoresComputedMetricItem;
+}
+
+export interface GroupActivitiesEntry {
+  player: Player;
+  type: ActivityType;
+  role?: GroupRole;
+  createdAt: Date;
 }
 
 export interface GroupStatistics {

--- a/server/src/api/modules/groups/services/AddMembersService.ts
+++ b/server/src/api/modules/groups/services/AddMembersService.ts
@@ -38,38 +38,45 @@ async function addMembers(payload: AddMembersService): Promise<{ count: number }
     );
   }
 
+  // Find all existing members' ids
+  const existingIds = (
+    await prisma.membership.findMany({
+      where: { groupId: params.id },
+      select: { playerId: true }
+    })
+  ).map(p => p.playerId);
+
+  // Find or create all players with the given usernames
+  const players = await playerServices.findPlayers({
+    usernames: params.members.map(m => m.username),
+    createIfNotFound: true
+  });
+
+  // Filter out any already existing usersnames to find the new unique usernames
+  const newPlayers = existingIds.length === 0 ? players : players.filter(p => !existingIds.includes(p.id));
+
+  if (!newPlayers || newPlayers.length === 0) {
+    throw new BadRequestError('All players given are already members.');
+  }
+
+  const newMemberships = newPlayers.map(player => {
+    const role = params.members.find(m => standardize(m.username) === player.username)?.role;
+
+    if (!role) return;
+
+    return { groupId: params.id, playerId: player.id, role };
+  });
+
+  const newActivites = newMemberships.map(membership => {
+    return {
+      groupId: membership.groupId,
+      playerId: membership.playerId,
+      type: ActivityType.JOINED
+    };
+  });
+
   const count = await prisma
     .$transaction(async transaction => {
-      // Find all existing members' ids
-      const existingIds = (
-        await transaction.membership.findMany({
-          where: { groupId: params.id },
-          select: { playerId: true }
-        })
-      ).map(p => p.playerId);
-
-      // Find or create all players with the given usernames
-      const players = await playerServices.findPlayers({
-        usernames: params.members.map(m => m.username),
-        createIfNotFound: true
-      });
-
-      // Filter out any already existing usersnames to find the new unique usernames
-      const newPlayers =
-        existingIds.length === 0 ? players : players.filter(p => !existingIds.includes(p.id));
-
-      if (!newPlayers || newPlayers.length === 0) {
-        throw new BadRequestError('All players given are already members.');
-      }
-
-      const newMemberships = newPlayers.map(player => {
-        const role = params.members.find(m => standardize(m.username) === player.username)?.role;
-
-        if (!role) return;
-
-        return { groupId: params.id, playerId: player.id, role };
-      });
-
       const { count } = await transaction.membership.createMany({
         data: newMemberships
       });
@@ -77,14 +84,6 @@ async function addMembers(payload: AddMembersService): Promise<{ count: number }
       await transaction.group.update({
         where: { id: params.id },
         data: { updatedAt: new Date() }
-      });
-
-      const newActivites = newMemberships.map(membership => {
-        return {
-          groupId: membership.groupId,
-          playerId: membership.playerId,
-          type: ActivityType.JOINED
-        };
       });
 
       await transaction.memberActivity
@@ -96,11 +95,11 @@ async function addMembers(payload: AddMembersService): Promise<{ count: number }
       return count;
     })
     .catch(error => {
-      logger.error('Failed to add memers', error);
+      logger.error('Failed to add members', error);
       throw new ServerError('Failed to add members.');
     });
 
-  return { count: count };
+  return { count };
 }
 
 export { addMembers };

--- a/server/src/api/modules/groups/services/ChangeMemberRoleService.ts
+++ b/server/src/api/modules/groups/services/ChangeMemberRoleService.ts
@@ -5,6 +5,7 @@ import { BadRequestError, ServerError } from '../../../errors';
 import { MembershipWithPlayer } from '../group.types';
 import { standardize } from '../../players/player.utils';
 import { ActivityType } from '../../../../prisma/enum-adapter';
+import logger from '../../../util/logging';
 import * as groupEvents from '../group.events';
 
 const inputSchema = z.object({
@@ -18,71 +19,75 @@ type ChangeMemberRoleService = z.infer<typeof inputSchema>;
 async function changeMemberRole(payload: ChangeMemberRoleService): Promise<MembershipWithPlayer> {
   const params = inputSchema.parse(payload);
 
-  const membership = await prisma.membership.findFirst({
-    where: {
-      groupId: params.id,
-      player: { username: standardize(params.username) }
-    }
-  });
-
-  if (!membership) {
-    const group = await prisma.group.findFirst({
-      where: { id: params.id }
-    });
-
-    if (group) {
-      throw new BadRequestError(`${params.username} is not a member of ${group.name}.`);
-    } else {
-      throw new ServerError('Failed to change member role.');
-    }
-  }
-
-  if (membership.role === params.role) {
-    throw new BadRequestError(`${params.username} is already a ${membership.role}.`);
-  }
-
-  const updatedMembership = await prisma.membership.update({
-    where: {
-      playerId_groupId: {
-        playerId: membership.playerId,
-        groupId: membership.groupId
-      }
-    },
-    data: {
-      role: params.role,
-      group: {
-        update: {
-          updatedAt: new Date()
+  const result = await prisma
+    .$transaction(async transaction => {
+      const membership = await transaction.membership.findFirst({
+        where: {
+          groupId: params.id,
+          player: { username: standardize(params.username) }
         }
-      }
-    },
-    include: {
-      player: true
-    }
-  });
-
-  try {
-    await prisma.memberActivity
-      .create({
-        data: {
-          groupId: membership.groupId,
-          playerId: membership.playerId,
-          type: ActivityType.CHANGED_ROLE,
-          role: params.role,
-          createdAt: new Date()
-        }
-      })
-      .then(async newMemberActivity => {
-        await groupEvents.onMemberRoleChanged(newMemberActivity, membership.role);
       });
-  } catch (error) {
-    throw new ServerError('Failed to create changed_role member activity');
-  }
 
-  return {
-    ...updatedMembership,
-    player: modifyPlayer(updatedMembership.player)
-  };
+      if (!membership) {
+        const group = await transaction.group.findFirst({
+          where: { id: params.id }
+        });
+
+        if (group) {
+          throw new BadRequestError(`${params.username} is not a member of ${group.name}.`);
+        } else {
+          throw new ServerError('Failed to change member role.');
+        }
+      }
+
+      if (membership.role === params.role) {
+        throw new BadRequestError(`${params.username} is already a ${membership.role}.`);
+      }
+
+      const updatedMembership = await transaction.membership.update({
+        where: {
+          playerId_groupId: {
+            playerId: membership.playerId,
+            groupId: membership.groupId
+          }
+        },
+        data: {
+          role: params.role,
+          group: {
+            update: {
+              updatedAt: new Date()
+            }
+          }
+        },
+        include: {
+          player: true
+        }
+      });
+
+      await transaction.memberActivity
+        .create({
+          data: {
+            groupId: membership.groupId,
+            playerId: membership.playerId,
+            type: ActivityType.CHANGED_ROLE,
+            role: params.role,
+            createdAt: new Date()
+          }
+        })
+        .then(newMemberActivity => {
+          groupEvents.onMemberRoleChanged(newMemberActivity, membership.role);
+        });
+
+      return {
+        ...updatedMembership,
+        player: modifyPlayer(updatedMembership.player)
+      };
+    })
+    .catch(error => {
+      logger.error('Failed to change member role', error);
+      throw error;
+    });
+  return result;
 }
 
 export { changeMemberRole };

--- a/server/src/api/modules/groups/services/FetchGroupActivityService.ts
+++ b/server/src/api/modules/groups/services/FetchGroupActivityService.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod';
+import { PAGINATION_SCHEMA } from '../../../util/validation';
+import { GroupActivitiesEntry } from '../group.types';
+import prisma from '../../../../prisma';
+import * as playerSevice from '../../players/player.services';
+import { NotFoundError } from '@prisma/client/runtime';
+
+const inputSchema = z
+  .object({
+    groupId: z.number().positive()
+  })
+  .merge(PAGINATION_SCHEMA);
+
+type FetchGroupActivitiesParams = z.infer<typeof inputSchema>;
+
+async function fetchGroupActivities(payload: FetchGroupActivitiesParams): Promise<GroupActivitiesEntry[]> {
+  const params = inputSchema.parse(payload);
+
+  const activities = await prisma.memberActivity.findMany({
+    where: { groupId: params.groupId },
+    orderBy: { createdAt: 'desc' },
+    take: params.limit,
+    skip: params.offset
+  });
+
+  if (!activities || activities.length === 0) {
+    const group = await prisma.group.findFirst({
+      where: { id: params.groupId }
+    });
+
+    if (!group) {
+      throw new NotFoundError('Group not found');
+    }
+    return [];
+  }
+
+  const players = await playerSevice.findPlayers({
+    ids: activities.map(activity => activity.playerId)
+  });
+
+  // Sort by descending createdAt dates
+  const result = activities.map(activity => {
+    return {
+      player: players.find(p => p.id === activity.playerId),
+      type: activity.type,
+      role: activity.role,
+      createdAt: activity.createdAt
+    };
+  });
+
+  return result;
+}
+
+export { fetchGroupActivities };

--- a/server/src/api/modules/groups/services/RemoveMembersService.ts
+++ b/server/src/api/modules/groups/services/RemoveMembersService.ts
@@ -73,7 +73,7 @@ async function removeMembers(payload: RemoveMembersService): Promise<{ count: nu
       throw new ServerError('Failed to remove members');
     });
 
-  return { count: count };
+  return { count };
 }
 
 export { removeMembers };

--- a/server/src/api/modules/groups/services/RemoveMembersService.ts
+++ b/server/src/api/modules/groups/services/RemoveMembersService.ts
@@ -18,6 +18,11 @@ type RemoveMembersService = z.infer<typeof inputSchema>;
 async function removeMembers(payload: RemoveMembersService): Promise<{ count: number }> {
   const params = inputSchema.parse(payload);
 
+  /*
+    TODO: Compare these players to players in the group
+    Right now it just assumes these players are members of the group
+    which leads to false member left activities
+  */
   const playersToRemove = await playerServices.findPlayers({
     usernames: params.usernames
   });
@@ -26,49 +31,49 @@ async function removeMembers(payload: RemoveMembersService): Promise<{ count: nu
     throw new BadRequestError('No valid tracked players were given.');
   }
 
-  const { count } = await prisma.membership.deleteMany({
-    where: {
-      groupId: params.id,
-      playerId: { in: playersToRemove.map(p => p.id) }
-    }
-  });
+  const count = await prisma
+    .$transaction(async transaction => {
+      const { count } = await transaction.membership.deleteMany({
+        where: {
+          groupId: params.id,
+          playerId: { in: playersToRemove.map(p => p.id) }
+        }
+      });
 
-  if (!count) {
-    throw new BadRequestError('None of the players given were members of that group.');
-  }
+      if (!count) {
+        throw new BadRequestError('None of the players given were members of that group.');
+      }
 
-  try {
-    await prisma.group.update({
-      where: { id: params.id },
-      data: { updatedAt: new Date() }
-    });
-  } catch (error) {
-    throw new ServerError('Failed to remove members.');
-  }
+      await transaction.group.update({
+        where: { id: params.id },
+        data: { updatedAt: new Date() }
+      });
 
-  const newActivites = playersToRemove.map(player => {
-    return {
-      groupId: params.id,
-      playerId: player.id,
-      type: ActivityType.LEFT
-    };
-  });
+      const newActivites = playersToRemove.map(player => {
+        return {
+          groupId: params.id,
+          playerId: player.id,
+          type: ActivityType.LEFT
+        };
+      });
 
-  try {
-    await prisma.memberActivity.createMany({ data: newActivites }).then(
-      async () =>
-        await groupEvents.onMembersLeft(
+      await transaction.memberActivity.createMany({ data: newActivites }).then(() =>
+        groupEvents.onMembersLeft(
           params.id,
           playersToRemove.map(p => p.id)
         )
-    );
-  } catch (error) {
-    throw new ServerError('Failed to create left member activities');
-  }
+      );
 
-  logger.moderation(`[Group:${params.id}] (${playersToRemove.map(p => p.id)}) removed`);
+      logger.moderation(`[Group:${params.id}] (${playersToRemove.map(p => p.id)}) removed`);
 
-  return { count };
+      return count;
+    })
+    .catch(error => {
+      logger.error('Failed to remove members', error);
+      throw new ServerError('Failed to remove members');
+    });
+
+  return { count: count };
 }
 
 export { removeMembers };

--- a/server/src/api/services/external/discord.service.ts
+++ b/server/src/api/services/external/discord.service.ts
@@ -41,7 +41,7 @@ function dispatch(type: string, payload: unknown) {
   }
 
   axios.post(env.DISCORD_BOT_API_URL, { type, data: payload }).catch(e => {
-    logger.error(e);
+    logger.error('Error sending discord event.', e);
   });
 }
 

--- a/server/src/api/services/external/discord.service.ts
+++ b/server/src/api/services/external/discord.service.ts
@@ -3,13 +3,14 @@ import { WebhookClient } from 'discord.js';
 import { omit } from 'lodash';
 import env, { isTesting } from '../../../env';
 import { FlaggedPlayerReviewContext } from '../../../utils';
-import prisma, { Achievement, Player, Competition } from '../../../prisma';
+import prisma, { Achievement, Player, Competition, MemberActivity } from '../../../prisma';
 import logger from '../../util/logging';
 import {
   CompetitionDetails,
   CompetitionWithParticipations
 } from '../../modules/competitions/competition.types';
 import * as playerServices from '../../modules/players/player.services';
+import { ActivityType, GroupRole } from '../../../prisma/enum-adapter';
 
 export interface EventPeriodDelay {
   hours?: number;
@@ -40,7 +41,7 @@ function dispatch(type: string, payload: unknown) {
   }
 
   axios.post(env.DISCORD_BOT_API_URL, { type, data: payload }).catch(e => {
-    logger.error('Error sending discord event.', e);
+    logger.error(e);
   });
 }
 
@@ -111,6 +112,10 @@ async function dispatchNameChanged(player: Player, previousDisplayName: string) 
   memberships.forEach(({ groupId }) => {
     dispatch('MEMBER_NAME_CHANGED', { groupId, player, previousName: previousDisplayName });
   });
+}
+
+async function dispatchMemberRoleChanged(memberActivity: MemberActivity, previousRole: GroupRole) {
+  dispatch(ActivityType.CHANGED_ROLE, { memberActivity, previousRole });
 }
 
 /**
@@ -217,5 +222,6 @@ export {
   dispatchCompetitionStarted,
   dispatchCompetitionEnded,
   dispatchCompetitionStarting,
-  dispatchCompetitionEnding
+  dispatchCompetitionEnding,
+  dispatchMemberRoleChanged
 };

--- a/server/src/prisma/enum-adapter.ts
+++ b/server/src/prisma/enum-adapter.ts
@@ -742,3 +742,11 @@ export const Country = {
 } as const;
 
 export type Country = typeof Country[keyof typeof Country];
+
+export const ActivityType = {
+  JOINED: 'joined',
+  LEFT: 'left',
+  CHANGED_ROLE: 'changed_role'
+} as const;
+
+export type ActivityType = typeof ActivityType[keyof typeof ActivityType];

--- a/server/src/prisma/hooks.ts
+++ b/server/src/prisma/hooks.ts
@@ -19,26 +19,6 @@ export function routeAfterHook(params: Prisma.MiddlewareParams, result: any) {
     return;
   }
 
-  if (params.model === 'Membership') {
-    if (params.action === 'createMany') {
-      const newMemberships = params.args.data;
-
-      if (newMemberships?.length > 0) {
-        groupEvents.onMembersJoined(newMemberships);
-      }
-      return;
-    }
-
-    if (params.action === 'deleteMany' && params.args?.where) {
-      const removedPlayerIds = params.args.where.playerId.in;
-
-      if (removedPlayerIds?.length > 0 && result?.count > 0) {
-        groupEvents.onMembersLeft(params.args.where.groupId, removedPlayerIds);
-      }
-      return;
-    }
-  }
-
   if (params.model === 'Group' && params.action === 'create') {
     const newMemberships = result?.memberships;
 

--- a/server/src/prisma/index.ts
+++ b/server/src/prisma/index.ts
@@ -12,7 +12,8 @@ import {
   Group,
   Membership,
   Prisma,
-  Country
+  Country,
+  MemberActivity
 } from '@prisma/client';
 import { DenyContext, SkipContext, isComputedMetric } from '../utils';
 import { NameChangeStatus } from './enum-adapter';
@@ -127,6 +128,7 @@ export {
   Record,
   Snapshot,
   Achievement,
+  MemberActivity,
   // Enums
   Country,
   NameChangeStatus,


### PR DESCRIPTION
**This PR is being broken down in several smaller PRs. Starting here: #1186. It will be closed once everything has been implemented in smaller steps.**

**Adds**
- Members Activity database table
- Notification trigger for role change in `ChangeMemberRoleService`
- `GET /groups/:id/activity` endpoint to API and docs.

**Changes**
- Move members joined and left notification triggers to `AddMembersService` and `RemoveMembersService`

**To Do**
- ~~Add a `GET /groups/:id/activity` endpoint to expose the `MemberActivity` data.~~
- ~~Make sure the players being removed are actually a part of the group being removed from. https://github.com/wise-old-man/wise-old-man/blob/0795624bff3f7e078d8adf799f8fd5db0b6a05e3/server/src/api/modules/groups/services/RemoveMembersService.ts#L22~~
- Make the edit group endpoint work with the new members activity table. The website and RuneLite plugin use this endpoint.
- Add tests