### PR TITLE
[api] Group members activity (pt 1)

### DIFF
--- a/client-js/prisma-models.d.ts
+++ b/client-js/prisma-models.d.ts
@@ -11,6 +11,14 @@ type Prisma_Base_Achievement = {
   createdAt: Date;
 };
 
+export type MemberActivity = {
+  groupId: number;
+  playerId: number;
+  type: ActivityType;
+  role?: GroupRole;
+  createdAt: Date;
+};
+
 export type Membership = {
   playerId: number;
   groupId: number;

--- a/server/__tests__/suites/integration/groups.test.ts
+++ b/server/__tests__/suites/integration/groups.test.ts
@@ -556,13 +556,15 @@ describe('Group API', () => {
       expect(onMembersRolesChangedEvent).toHaveBeenCalledWith(expect.objectContaining({ length: 1 }));
 
       const roleChangeEvent = onMembersRolesChangedEvent.mock.calls[0][0][0];
+      const player = response.body.memberships.find(m => m.player.username === 'zezima');
 
       expect(roleChangeEvent).toEqual({
         groupId: globalData.testGroupOneLeader.id,
-        playerId: response.body.memberships.find(m => m.player.username === 'zezima').playerId,
+        playerId: player.playerId,
         role: 'firemaker',
         previousRole: 'member',
-        type: 'changed_role'
+        type: 'changed_role',
+        displayName: player.displayName
       });
 
       const latestActivities = await prisma.memberActivity.findMany({
@@ -615,11 +617,13 @@ describe('Group API', () => {
         type: 'joined'
       });
 
+      const playerZezima = response.body.memberships.find(m => m.player.username === 'zezima');
       expect(latestActivities[5]).toMatchObject({
         groupId: globalData.testGroupOneLeader.id,
-        playerId: response.body.memberships.find(m => m.player.username === 'zezima').playerId,
+        playerId: playerZezima.playerId,
         role: 'firemaker',
-        type: 'changed_role'
+        type: 'changed_role',
+        displayName: playerZezima.displayName
       });
     });
 
@@ -816,20 +820,24 @@ describe('Group API', () => {
 
       const { id, memberships } = editResponse.body;
 
+      const playerPsikoi = memberships.find(m => m.player.username === 'psikoi');
       expect(changedRoleEvents[0]).toEqual({
         groupId: id,
         role: 'owner',
         previousRole: 'member',
-        playerId: memberships.find(m => m.player.username === 'psikoi').playerId,
-        type: 'changed_role'
+        playerId: playerPsikoi.playerId,
+        type: 'changed_role',
+        displayName: playerPsikoi.displayName
       });
 
+      const playerCookmeplox = memberships.find(m => m.player.username === 'cookmeplox');
       expect(changedRoleEvents[1]).toEqual({
         groupId: id,
         role: 'cook',
         previousRole: 'owner',
-        playerId: memberships.find(m => m.player.username === 'cookmeplox').playerId,
-        type: 'changed_role'
+        playerId: playerCookmeplox.playerId,
+        type: 'changed_role',
+        displayName: playerCookmeplox.displayName
       });
 
       expect(onMembersJoinedEvent).not.toHaveBeenCalled();
@@ -1265,17 +1273,18 @@ describe('Group API', () => {
         player: { username: 'sethmare' }
       });
 
-      const playerId = (await prisma.player.findFirst({ where: { username: 'sethmare' } })).id;
+      const playerSethmare = await prisma.player.findFirst({ where: { username: 'sethmare' } });
 
       expect(onMembersRolesChangedEvent).toHaveBeenCalledWith(expect.objectContaining({ length: 1 }));
       const event = onMembersRolesChangedEvent.mock.calls[0][0][0];
 
       expect(event).toEqual({
         groupId: globalData.testGroupNoLeaders.id,
-        playerId,
+        playerId: playerSethmare.id,
         type: 'changed_role',
         role: 'dragon',
-        previousRole: 'magician'
+        previousRole: 'magician',
+        displayName: playerSethmare.displayName
       });
 
       const latestActivity = await prisma.memberActivity.findFirst({
@@ -1285,7 +1294,7 @@ describe('Group API', () => {
 
       expect(latestActivity.type).toBe('changed_role');
       expect(latestActivity.role).toBe('dragon');
-      expect(latestActivity.playerId).toBe(playerId);
+      expect(latestActivity.playerId).toBe(playerSethmare.id);
 
       const after = await api.get(`/groups/${globalData.testGroupNoLeaders.id}`);
       expect(after.status).toBe(200);

--- a/server/__tests__/suites/integration/groups.test.ts
+++ b/server/__tests__/suites/integration/groups.test.ts
@@ -563,6 +563,63 @@ describe('Group API', () => {
         previousRole: 'member',
         type: 'changed_role'
       });
+
+      const latestActivities = await prisma.memberActivity.findMany({
+        where: { groupId: globalData.testGroupOneLeader.id },
+        orderBy: { createdAt: 'desc' },
+        take: 6
+      });
+
+      expect(latestActivities.map(a => a.type)).toEqual([
+        'left',
+        'left',
+        'joined',
+        'joined',
+        'joined',
+        'changed_role'
+      ]);
+
+      expect(latestActivities[0]).toMatchObject({
+        groupId: globalData.testGroupOneLeader.id,
+        playerId: before.body.memberships.find(m => m.player.username === 'test player').playerId,
+        role: null,
+        type: 'left'
+      });
+
+      expect(latestActivities[1]).toMatchObject({
+        groupId: globalData.testGroupOneLeader.id,
+        playerId: before.body.memberships.find(m => m.player.username === 'alt player').playerId,
+        role: null,
+        type: 'left'
+      });
+
+      expect(latestActivities[2]).toMatchObject({
+        groupId: globalData.testGroupOneLeader.id,
+        playerId: response.body.memberships.find(m => m.player.username === 'psikoi').playerId,
+        role: null,
+        type: 'joined'
+      });
+
+      expect(latestActivities[3]).toMatchObject({
+        groupId: globalData.testGroupOneLeader.id,
+        playerId: response.body.memberships.find(m => m.player.username === 'alexsuperfly').playerId,
+        role: null,
+        type: 'joined'
+      });
+
+      expect(latestActivities[4]).toMatchObject({
+        groupId: globalData.testGroupOneLeader.id,
+        playerId: response.body.memberships.find(m => m.player.username === 'rorro').playerId,
+        role: null,
+        type: 'joined'
+      });
+
+      expect(latestActivities[5]).toMatchObject({
+        groupId: globalData.testGroupOneLeader.id,
+        playerId: response.body.memberships.find(m => m.player.username === 'zezima').playerId,
+        role: 'firemaker',
+        type: 'changed_role'
+      });
     });
 
     it('should edit name', async () => {

--- a/server/__tests__/suites/integration/groups.test.ts
+++ b/server/__tests__/suites/integration/groups.test.ts
@@ -503,10 +503,8 @@ describe('Group API', () => {
       expect(response.body.memberships.filter(m => m.role === 'leader').length).toBe(1);
 
       // 2 players removed
-      expect(onMembersLeftEvent).toHaveBeenCalledWith(
-        globalData.testGroupOneLeader.id,
-        expect.objectContaining({ length: 2 })
-      );
+      expect(onMembersLeftEvent).toHaveBeenCalledWith(expect.objectContaining({ length: 2 }));
+
       // 3 new players added
       expect(onMembersJoinedEvent).toHaveBeenCalledWith(expect.objectContaining({ length: 3 }));
     });
@@ -1205,10 +1203,7 @@ describe('Group API', () => {
         message: 'Successfully removed 2 members.'
       });
 
-      expect(onMembersLeftEvent).toHaveBeenCalledWith(
-        globalData.testGroupNoLeaders.id,
-        expect.objectContaining({ length: 2 })
-      );
+      expect(onMembersLeftEvent).toHaveBeenCalledWith(expect.objectContaining({ length: 2 }));
 
       const latestActivities = await prisma.memberActivity.findMany({
         where: { groupId: globalData.testGroupNoLeaders.id },
@@ -1260,10 +1255,7 @@ describe('Group API', () => {
         message: 'Successfully removed 1 members.'
       });
 
-      expect(onMembersLeftEvent).toHaveBeenCalledWith(
-        createResponse.body.group.id,
-        expect.objectContaining({ length: 1 })
-      );
+      expect(onMembersLeftEvent).toHaveBeenCalledWith(expect.objectContaining({ length: 1 }));
 
       const after = await api.get(`/groups/${createResponse.body.group.id}`);
       expect(after.status).toBe(200);

--- a/server/__tests__/suites/integration/groups.test.ts
+++ b/server/__tests__/suites/integration/groups.test.ts
@@ -22,7 +22,7 @@ const axiosMock = new MockAdapter(axios, { onNoMatch: 'passthrough' });
 
 const onMembersLeftEvent = jest.spyOn(groupEvents, 'onMembersLeft');
 const onMembersJoinedEvent = jest.spyOn(groupEvents, 'onMembersJoined');
-const onMemberRoleChangedEvent = jest.spyOn(groupEvents, 'onMemberRoleChanged');
+// const onMemberRoleChangedEvent = jest.spyOn(groupEvents, 'onMemberRoleChanged');
 
 const P_HISCORES_FILE_PATH = `${__dirname}/../../data/hiscores/psikoi_hiscores.txt`;
 const LT_HISCORES_FILE_PATH = `${__dirname}/../../data/hiscores/lynx_titan_hiscores.txt`;
@@ -844,7 +844,7 @@ describe('Group API', () => {
       expect(response.status).toBe(404);
       expect(response.body.message).toBe('Group not found.');
 
-      expect(onMemberRoleChangedEvent).not.toHaveBeenCalled();
+      // expect(onMemberRoleChangedEvent).not.toHaveBeenCalled();
     });
 
     it('should not change role (invalid verification code)', async () => {
@@ -856,7 +856,7 @@ describe('Group API', () => {
       expect(response.status).toBe(400);
       expect(response.body.message).toBe("Parameter 'verificationCode' is required.");
 
-      expect(onMemberRoleChangedEvent).not.toHaveBeenCalled();
+      // expect(onMemberRoleChangedEvent).not.toHaveBeenCalled();
     });
 
     it('should not change role (incorrect verification code)', async () => {
@@ -869,7 +869,7 @@ describe('Group API', () => {
       expect(response.status).toBe(403);
       expect(response.body.message).toBe('Incorrect verification code.');
 
-      expect(onMemberRoleChangedEvent).not.toHaveBeenCalled();
+      // expect(onMemberRoleChangedEvent).not.toHaveBeenCalled();
     });
 
     it('should not change role (undefined username)', async () => {
@@ -880,7 +880,7 @@ describe('Group API', () => {
       expect(response.status).toBe(400);
       expect(response.body.message).toBe("Parameter 'username' is undefined.");
 
-      expect(onMemberRoleChangedEvent).not.toHaveBeenCalled();
+      // expect(onMemberRoleChangedEvent).not.toHaveBeenCalled();
     });
 
     it('should not change role (undefined role)', async () => {
@@ -891,7 +891,7 @@ describe('Group API', () => {
       expect(response.status).toBe(400);
       expect(response.body.message).toBe("Invalid enum value for 'role'.");
 
-      expect(onMemberRoleChangedEvent).not.toHaveBeenCalled();
+      // expect(onMemberRoleChangedEvent).not.toHaveBeenCalled();
     });
 
     it('should not change role (empty role)', async () => {
@@ -904,7 +904,7 @@ describe('Group API', () => {
       expect(response.status).toBe(400);
       expect(response.body.message).toBe("Invalid enum value for 'role'.");
 
-      expect(onMemberRoleChangedEvent).not.toHaveBeenCalled();
+      // expect(onMemberRoleChangedEvent).not.toHaveBeenCalled();
     });
 
     it('should not change role (invalid role)', async () => {
@@ -917,7 +917,7 @@ describe('Group API', () => {
       expect(response.status).toBe(400);
       expect(response.body.message).toBe("Invalid enum value for 'role'.");
 
-      expect(onMemberRoleChangedEvent).not.toHaveBeenCalled();
+      // expect(onMemberRoleChangedEvent).not.toHaveBeenCalled();
     });
 
     it('should not change role (not a member)', async () => {
@@ -930,7 +930,7 @@ describe('Group API', () => {
       expect(response.status).toBe(400);
       expect(response.body.message).toBe(`usbc is not a member of ${globalData.testGroupNoLeaders.name}.`);
 
-      expect(onMemberRoleChangedEvent).not.toHaveBeenCalled();
+      // expect(onMemberRoleChangedEvent).not.toHaveBeenCalled();
     });
 
     it('should not change role (already has role)', async () => {
@@ -943,7 +943,7 @@ describe('Group API', () => {
       expect(response.status).toBe(400);
       expect(response.body.message).toBe('sethmare is already a magician.');
 
-      expect(onMemberRoleChangedEvent).not.toHaveBeenCalled();
+      // expect(onMemberRoleChangedEvent).not.toHaveBeenCalled();
     });
 
     it('should change role', async () => {
@@ -964,15 +964,15 @@ describe('Group API', () => {
 
       const playerId = (await prisma.player.findFirst({ where: { username: 'sethmare' } })).id;
 
-      expect(onMemberRoleChangedEvent).toHaveBeenCalledWith(
-        expect.objectContaining({
-          role: 'dragon',
-          type: 'changed_role',
-          playerId,
-          groupId: globalData.testGroupNoLeaders.id
-        }),
-        'magician'
-      );
+      // expect(onMemberRoleChangedEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        role: 'dragon',
+        type: 'changed_role',
+        playerId,
+        groupId: globalData.testGroupNoLeaders.id
+      }),
+        'magician';
+      // );
 
       const latestActivity = await prisma.memberActivity.findFirst({
         where: { groupId: globalData.testGroupNoLeaders.id },

--- a/server/__tests__/suites/integration/groups.test.ts
+++ b/server/__tests__/suites/integration/groups.test.ts
@@ -1108,11 +1108,11 @@ describe('Group API', () => {
     it('should not remove members (no valid players found)', async () => {
       const response = await api.delete(`/groups/${globalData.testGroupNoLeaders.id}/members`).send({
         verificationCode: globalData.testGroupNoLeaders.verificationCode,
-        members: ['boom_']
+        members: ['boom_'] // does not exist on WOM
       });
 
       expect(response.status).toBe(400);
-      expect(response.body.message).toBe('No valid tracked players were given.');
+      expect(response.body.message).toBe('None of the players given were members of that group.');
 
       expect(onMembersLeftEvent).not.toHaveBeenCalled();
     });
@@ -1120,7 +1120,7 @@ describe('Group API', () => {
     it('should not remove members (not members)', async () => {
       const response = await api.delete(`/groups/${globalData.testGroupNoLeaders.id}/members`).send({
         verificationCode: globalData.testGroupNoLeaders.verificationCode,
-        members: ['swampletics']
+        members: ['swampletics'] // exists on WOM, but not a member of the group
       });
 
       expect(response.status).toBe(400);
@@ -1135,7 +1135,9 @@ describe('Group API', () => {
 
       const response = await api.delete(`/groups/${globalData.testGroupNoLeaders.id}/members`).send({
         verificationCode: globalData.testGroupNoLeaders.verificationCode,
-        members: ['SETHmare  ', 'ZEZIMA', '__BOOM'] // boom should get ignored
+        members: ['SETHmare  ', 'ZEZIMA', '__BOOM', 'psikoi']
+        // "boom" should get ignored because it's not tracked yet
+        // "psikoi" should get ignored because it's not a member
       });
 
       expect(response.status).toBe(200);

--- a/server/__tests__/suites/integration/groups.test.ts
+++ b/server/__tests__/suites/integration/groups.test.ts
@@ -563,8 +563,7 @@ describe('Group API', () => {
         playerId: changedMembershipZezima.playerId,
         role: 'firemaker',
         previousRole: 'member',
-        type: 'changed_role',
-        displayName: changedMembershipZezima.player.displayName
+        type: 'changed_role'
       });
 
       const latestActivities = await prisma.memberActivity.findMany({
@@ -824,8 +823,7 @@ describe('Group API', () => {
         role: 'owner',
         previousRole: 'member',
         playerId: changedMembershipPsikoi.playerId,
-        type: 'changed_role',
-        displayName: changedMembershipPsikoi.player.displayName
+        type: 'changed_role'
       });
 
       const changedMembershipCookmeplox = memberships.find(m => m.player.username === 'cookmeplox');
@@ -834,8 +832,7 @@ describe('Group API', () => {
         role: 'cook',
         previousRole: 'owner',
         playerId: changedMembershipCookmeplox.playerId,
-        type: 'changed_role',
-        displayName: changedMembershipCookmeplox.player.displayName
+        type: 'changed_role'
       });
 
       expect(onMembersJoinedEvent).not.toHaveBeenCalled();
@@ -1356,8 +1353,7 @@ describe('Group API', () => {
         playerId: playerSethmare.id,
         type: 'changed_role',
         role: 'dragon',
-        previousRole: 'magician',
-        displayName: playerSethmare.displayName
+        previousRole: 'magician'
       });
 
       const latestActivity = await prisma.memberActivity.findFirst({

--- a/server/__tests__/suites/integration/groups.test.ts
+++ b/server/__tests__/suites/integration/groups.test.ts
@@ -556,15 +556,15 @@ describe('Group API', () => {
       expect(onMembersRolesChangedEvent).toHaveBeenCalledWith(expect.objectContaining({ length: 1 }));
 
       const roleChangeEvent = onMembersRolesChangedEvent.mock.calls[0][0][0];
-      const player = response.body.memberships.find(m => m.player.username === 'zezima');
+      const changedMembershipZezima = response.body.memberships.find(m => m.player.username === 'zezima');
 
       expect(roleChangeEvent).toEqual({
         groupId: globalData.testGroupOneLeader.id,
-        playerId: player.playerId,
+        playerId: changedMembershipZezima.playerId,
         role: 'firemaker',
         previousRole: 'member',
         type: 'changed_role',
-        displayName: player.displayName
+        displayName: changedMembershipZezima.player.displayName
       });
 
       const latestActivities = await prisma.memberActivity.findMany({
@@ -617,13 +617,11 @@ describe('Group API', () => {
         type: 'joined'
       });
 
-      const playerZezima = response.body.memberships.find(m => m.player.username === 'zezima');
       expect(latestActivities[5]).toMatchObject({
         groupId: globalData.testGroupOneLeader.id,
-        playerId: playerZezima.playerId,
+        playerId: response.body.memberships.find(m => m.player.username === 'zezima').playerId,
         role: 'firemaker',
-        type: 'changed_role',
-        displayName: playerZezima.displayName
+        type: 'changed_role'
       });
     });
 
@@ -820,24 +818,24 @@ describe('Group API', () => {
 
       const { id, memberships } = editResponse.body;
 
-      const playerPsikoi = memberships.find(m => m.player.username === 'psikoi');
+      const changedMembershipPsikoi = memberships.find(m => m.player.username === 'psikoi');
       expect(changedRoleEvents[0]).toEqual({
         groupId: id,
         role: 'owner',
         previousRole: 'member',
-        playerId: playerPsikoi.playerId,
+        playerId: changedMembershipPsikoi.playerId,
         type: 'changed_role',
-        displayName: playerPsikoi.displayName
+        displayName: changedMembershipPsikoi.player.displayName
       });
 
-      const playerCookmeplox = memberships.find(m => m.player.username === 'cookmeplox');
+      const changedMembershipCookmeplox = memberships.find(m => m.player.username === 'cookmeplox');
       expect(changedRoleEvents[1]).toEqual({
         groupId: id,
         role: 'cook',
         previousRole: 'owner',
-        playerId: playerCookmeplox.playerId,
+        playerId: changedMembershipCookmeplox.playerId,
         type: 'changed_role',
-        displayName: playerCookmeplox.displayName
+        displayName: changedMembershipCookmeplox.player.displayName
       });
 
       expect(onMembersJoinedEvent).not.toHaveBeenCalled();
@@ -1273,10 +1271,9 @@ describe('Group API', () => {
         player: { username: 'sethmare' }
       });
 
-      const playerSethmare = await prisma.player.findFirst({ where: { username: 'sethmare' } });
-
       expect(onMembersRolesChangedEvent).toHaveBeenCalledWith(expect.objectContaining({ length: 1 }));
       const event = onMembersRolesChangedEvent.mock.calls[0][0][0];
+      const playerSethmare = await prisma.player.findFirst({ where: { username: 'sethmare' } });
 
       expect(event).toEqual({
         groupId: globalData.testGroupNoLeaders.id,

--- a/server/__tests__/suites/integration/snapshots.test.ts
+++ b/server/__tests__/suites/integration/snapshots.test.ts
@@ -594,6 +594,9 @@ describe('Snapshots API', () => {
       const trackResponse = await api.post(`/players/jakesterwars`);
       expect(trackResponse.status).toBe(201);
 
+      // Reset the timers to the current (REAL) time
+      jest.useRealTimers();
+
       globalData.secondaryPlayerId = trackResponse.body.id;
 
       const addToGroupResponse = await api.post(`/groups/${globalData.testGroupId}/members`).send({
@@ -601,9 +604,6 @@ describe('Snapshots API', () => {
         members: [{ username: 'jakesterwars' }]
       });
       expect(addToGroupResponse.status).toBe(200);
-
-      // Reset the timers to the current (REAL) time
-      jest.useRealTimers();
 
       const result = await services.findGroupSnapshots({
         groupId: globalData.testGroupId,

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.3.26",
+  "version": "2.3.27",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.3.26",
+      "version": "2.3.27",
       "license": "ISC",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.3.26",
+  "version": "2.3.27",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/prisma/migrations/20230714124446_add_members_activity_table/migration.sql
+++ b/server/prisma/migrations/20230714124446_add_members_activity_table/migration.sql
@@ -1,0 +1,16 @@
+-- CreateEnum
+CREATE TYPE "activity_type" AS ENUM ('joined', 'left', 'changed_role');
+
+-- CreateTable
+CREATE TABLE "member_activity" (
+    "groupId" INTEGER NOT NULL,
+    "playerId" INTEGER NOT NULL,
+    "type" "activity_type" NOT NULL,
+    "role" "group_role",
+    "createdAt" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "member_activity_pkey" PRIMARY KEY ("groupId","playerId","createdAt")
+);
+
+-- CreateIndex
+CREATE INDEX "member_activity_group_id_created_at" ON "member_activity"("groupId", "createdAt" DESC);

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -549,6 +549,21 @@ model Snapshot {
   @@map("snapshots")
 }
 
+model MemberActivity {
+  groupId   Int
+  playerId  Int
+  type      ActivityType
+  role      GroupRole?
+  createdAt DateTime     @default(now()) @db.Timestamptz(6)
+
+  // Constraints
+  @@id([groupId, playerId, createdAt])
+  // Indices
+  @@index([groupId, createdAt(sort: Desc)], map: "member_activity_group_id_created_at")
+  // Map
+  @@map("member_activity")
+}
+
 enum NameChangeStatus {
   pending
   denied
@@ -1235,4 +1250,12 @@ enum Metric {
   guardians_of_the_rift
 
   @@map("metric")
+}
+
+enum ActivityType {
+  joined
+  left
+  changed_role
+
+  @@map("activity_type")
 }

--- a/server/src/api/modules/groups/group.events.ts
+++ b/server/src/api/modules/groups/group.events.ts
@@ -23,7 +23,7 @@ async function onMembersJoined(events: MemberJoinedEvent[]) {
   if (!players || players.length === 0) return;
 
   // Dispatch this event to the discord service
-  await metrics.trackEffect(discordService.dispatchMembersJoined, groupId, players);
+  await metrics.trackEffect(discordService.dispatchMembersJoined, groupId, events, players);
 
   // Request updates for any new players
   players.forEach(({ username, type, registeredAt }) => {

--- a/server/src/api/modules/groups/group.events.ts
+++ b/server/src/api/modules/groups/group.events.ts
@@ -1,9 +1,13 @@
-import { Membership, PlayerType } from '../../../utils';
+import { GroupRole, MemberActivity, Membership, PlayerType } from '../../../utils';
 import { jobManager, JobType } from '../../jobs';
 import metrics from '../../services/external/metrics.service';
 import * as discordService from '../../services/external/discord.service';
 import * as playerServices from '../players/player.services';
 import * as competitionServices from '../competitions/competition.services';
+
+async function onMemberRoleChanged(memberActivity: MemberActivity, previousRole: GroupRole) {
+  await metrics.trackEffect(discordService.dispatchMemberRoleChanged, memberActivity, previousRole);
+}
 
 async function onMembersJoined(memberships: Pick<Membership, 'playerId' | 'groupId' | 'role'>[]) {
   const groupId = memberships[0].groupId;
@@ -36,4 +40,4 @@ async function onMembersLeft(groupId: number, playerIds: number[]) {
   await metrics.trackEffect(discordService.dispatchMembersLeft, groupId, playerIds);
 }
 
-export { onMembersJoined, onMembersLeft };
+export { onMembersJoined, onMembersLeft, onMemberRoleChanged };

--- a/server/src/api/modules/groups/group.events.ts
+++ b/server/src/api/modules/groups/group.events.ts
@@ -5,7 +5,7 @@ import * as discordService from '../../services/external/discord.service';
 import * as playerServices from '../players/player.services';
 import * as competitionServices from '../competitions/competition.services';
 
-async function onMembersJoined(memberships: Membership[]) {
+async function onMembersJoined(memberships: Pick<Membership, 'playerId' | 'groupId' | 'role'>[]) {
   const groupId = memberships[0].groupId;
   const playerIds = memberships.map(m => m.playerId);
 

--- a/server/src/api/modules/groups/group.events.ts
+++ b/server/src/api/modules/groups/group.events.ts
@@ -6,8 +6,7 @@ import * as playerServices from '../players/player.services';
 import * as competitionServices from '../competitions/competition.services';
 
 async function onMembersRolesChanged(events: MemberRoleChangeEvent[]) {
-  // await metrics.trackEffect(discordService.dispatchMemberRoleChanged, memberActivity, previousRole);
-  console.log(events);
+  await metrics.trackEffect(discordService.dispatchMembersRolesChanged, events);
 }
 
 async function onMembersJoined(events: MemberJoinedEvent[]) {

--- a/server/src/api/modules/groups/group.events.ts
+++ b/server/src/api/modules/groups/group.events.ts
@@ -1,4 +1,4 @@
-import { MemberRoleChangeEvent, Membership, PlayerType } from '../../../utils';
+import { MemberJoinedEvent, MemberLeftEvent, MemberRoleChangeEvent, PlayerType } from '../../../utils';
 import { jobManager, JobType } from '../../jobs';
 import metrics from '../../services/external/metrics.service';
 import * as discordService from '../../services/external/discord.service';
@@ -10,9 +10,9 @@ async function onMembersRolesChanged(events: MemberRoleChangeEvent[]) {
   console.log(events);
 }
 
-async function onMembersJoined(memberships: Pick<Membership, 'playerId' | 'groupId' | 'role'>[]) {
-  const groupId = memberships[0].groupId;
-  const playerIds = memberships.map(m => m.playerId);
+async function onMembersJoined(events: MemberJoinedEvent[]) {
+  const groupId = events[0].groupId;
+  const playerIds = events.map(m => m.playerId);
 
   // Add these new members to all upcoming and ongoing competitions
   await metrics.trackEffect(competitionServices.addToGroupCompetitions, { groupId, playerIds });
@@ -33,7 +33,10 @@ async function onMembersJoined(memberships: Pick<Membership, 'playerId' | 'group
   });
 }
 
-async function onMembersLeft(groupId: number, playerIds: number[]) {
+async function onMembersLeft(events: MemberLeftEvent[]) {
+  const groupId = events[0].groupId;
+  const playerIds = events.map(m => m.playerId);
+
   // Remove these players from ongoing/upcoming group competitions
   await metrics.trackEffect(competitionServices.removeFromGroupCompetitions, { groupId, playerIds });
 

--- a/server/src/api/modules/groups/group.events.ts
+++ b/server/src/api/modules/groups/group.events.ts
@@ -1,12 +1,13 @@
-import { GroupRole, MemberActivity, Membership, PlayerType } from '../../../utils';
+import { MemberRoleChangeEvent, Membership, PlayerType } from '../../../utils';
 import { jobManager, JobType } from '../../jobs';
 import metrics from '../../services/external/metrics.service';
 import * as discordService from '../../services/external/discord.service';
 import * as playerServices from '../players/player.services';
 import * as competitionServices from '../competitions/competition.services';
 
-async function onMemberRoleChanged(memberActivity: MemberActivity, previousRole: GroupRole) {
-  await metrics.trackEffect(discordService.dispatchMemberRoleChanged, memberActivity, previousRole);
+async function onMembersRolesChanged(events: MemberRoleChangeEvent[]) {
+  // await metrics.trackEffect(discordService.dispatchMemberRoleChanged, memberActivity, previousRole);
+  console.log(events);
 }
 
 async function onMembersJoined(memberships: Pick<Membership, 'playerId' | 'groupId' | 'role'>[]) {
@@ -40,4 +41,4 @@ async function onMembersLeft(groupId: number, playerIds: number[]) {
   await metrics.trackEffect(discordService.dispatchMembersLeft, groupId, playerIds);
 }
 
-export { onMembersJoined, onMembersLeft, onMemberRoleChanged };
+export { onMembersJoined, onMembersLeft, onMembersRolesChanged };

--- a/server/src/api/modules/groups/group.types.ts
+++ b/server/src/api/modules/groups/group.types.ts
@@ -83,4 +83,8 @@ export type MemberRoleChangeEvent = Omit<MemberActivity, 'createdAt'> & {
   previousRole: GroupRole;
 };
 
+export type MemberJoinedEvent = Omit<MemberActivity, 'createdAt'>;
+
+export type MemberLeftEvent = Omit<MemberActivity, 'createdAt' | 'role'>;
+
 export { Group, Membership, MemberActivity };

--- a/server/src/api/modules/groups/group.types.ts
+++ b/server/src/api/modules/groups/group.types.ts
@@ -1,5 +1,5 @@
 import { GroupRole } from '../../../utils';
-import { Group, Membership, Player } from '../../../prisma';
+import { Group, Membership, Player, MemberActivity } from '../../../prisma';
 import { MetricLeaders, FormattedSnapshot } from '../snapshots/snapshot.types';
 
 export { ActivityType } from '../../../prisma/enum-adapter';
@@ -79,4 +79,4 @@ export interface TempleGroupData {
   leaders: string[];
 }
 
-export { Group, Membership };
+export { Group, Membership, MemberActivity };

--- a/server/src/api/modules/groups/group.types.ts
+++ b/server/src/api/modules/groups/group.types.ts
@@ -2,6 +2,8 @@ import { GroupRole } from '../../../utils';
 import { Group, Membership, Player } from '../../../prisma';
 import { MetricLeaders, FormattedSnapshot } from '../snapshots/snapshot.types';
 
+export { ActivityType } from '../../../prisma/enum-adapter';
+
 export interface GroupListItem extends Omit<Group, 'verificationHash'> {
   memberCount: number;
 }

--- a/server/src/api/modules/groups/group.types.ts
+++ b/server/src/api/modules/groups/group.types.ts
@@ -81,6 +81,7 @@ export interface TempleGroupData {
 
 export type MemberRoleChangeEvent = Omit<MemberActivity, 'createdAt'> & {
   previousRole: GroupRole;
+  displayName: string;
 };
 
 export type MemberJoinedEvent = Omit<MemberActivity, 'createdAt'>;

--- a/server/src/api/modules/groups/group.types.ts
+++ b/server/src/api/modules/groups/group.types.ts
@@ -81,7 +81,6 @@ export interface TempleGroupData {
 
 export type MemberRoleChangeEvent = Omit<MemberActivity, 'createdAt'> & {
   previousRole: GroupRole;
-  displayName: string;
 };
 
 export type MemberJoinedEvent = Omit<MemberActivity, 'createdAt'>;

--- a/server/src/api/modules/groups/group.types.ts
+++ b/server/src/api/modules/groups/group.types.ts
@@ -79,4 +79,8 @@ export interface TempleGroupData {
   leaders: string[];
 }
 
+export type MemberRoleChangeEvent = Omit<MemberActivity, 'createdAt'> & {
+  previousRole: GroupRole;
+};
+
 export { Group, Membership, MemberActivity };

--- a/server/src/api/modules/groups/services/AddMembersService.ts
+++ b/server/src/api/modules/groups/services/AddMembersService.ts
@@ -92,9 +92,9 @@ async function addMembers(payload: AddMembersService): Promise<{ count: number }
         data: { updatedAt: new Date() }
       });
 
-      await transaction.memberActivity
-        .createMany({ data: newActivites })
-        .then(() => groupEvents.onMembersJoined(newMemberships));
+      await transaction.memberActivity.createMany({ data: newActivites });
+
+      groupEvents.onMembersJoined(newMemberships.map(m => ({ ...m, type: ActivityType.JOINED })));
 
       return count;
     })

--- a/server/src/api/modules/groups/services/AddMembersService.ts
+++ b/server/src/api/modules/groups/services/AddMembersService.ts
@@ -5,6 +5,8 @@ import logger from '../../../util/logging';
 import { BadRequestError, ServerError } from '../../../errors';
 import { isValidUsername, standardize } from '../../players/player.utils';
 import * as playerServices from '../../players/player.services';
+import * as groupEvents from '../group.events';
+import { ActivityType } from '../group.types';
 
 const MEMBER_INPUT_SCHEMA = z.object(
   {
@@ -65,22 +67,45 @@ async function addMembers(payload: AddMembersService): Promise<{ count: number }
     return { groupId: params.id, playerId: player.id, role };
   });
 
-  const { count } = await prisma.membership.createMany({
-    data: newMemberships
+  const newActivites = newMemberships.map(membership => {
+    return {
+      groupId: membership.groupId,
+      playerId: membership.playerId,
+      type: ActivityType.JOINED
+    };
   });
 
-  try {
-    await prisma.group.update({
-      where: { id: params.id },
-      data: { updatedAt: new Date() }
+  const addedCount = await prisma
+    .$transaction(async transaction => {
+      const { count } = await transaction.membership.createMany({
+        data: newMemberships
+      });
+
+      // This shouldn't ever happen since these get validated before entering the transaction,
+      // but on the off chance that they do, throw a generic error to be caught by the catch block.
+      if (count === 0) {
+        throw new Error();
+      }
+
+      await transaction.group.update({
+        where: { id: params.id },
+        data: { updatedAt: new Date() }
+      });
+
+      await transaction.memberActivity
+        .createMany({ data: newActivites })
+        .then(() => groupEvents.onMembersJoined(newMemberships));
+
+      return count;
+    })
+    .catch(error => {
+      logger.error('Failed to add members', error);
+      throw new ServerError('Failed to add members.');
     });
-  } catch (error) {
-    throw new ServerError('Failed to add members.');
-  }
 
   logger.moderation(`[Group:${params.id}] (${newMemberships.map(m => m.playerId)}) joined`);
 
-  return { count };
+  return { count: addedCount };
 }
 
 export { addMembers };

--- a/server/src/api/modules/groups/services/ChangeMemberRoleService.ts
+++ b/server/src/api/modules/groups/services/ChangeMemberRoleService.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import prisma from '../../../../prisma';
 import { GroupRole } from '../../../../utils';
 import logger from '../../../util/logging';
+import { omit } from '../../../util/objects';
 import { BadRequestError, ServerError } from '../../../errors';
 import { ActivityType, MembershipWithPlayer } from '../group.types';
 import { standardize } from '../../players/player.utils';
@@ -72,7 +73,7 @@ async function changeMemberRole(payload: ChangeMemberRoleService): Promise<Membe
         }
       });
 
-      groupEvents.onMembersRolesChanged([{ ...activity, previousRole: membership.role }]);
+      groupEvents.onMembersRolesChanged([omit({ ...activity, previousRole: membership.role }, 'createdAt')]);
 
       return updatedMembership;
     })

--- a/server/src/api/modules/groups/services/ChangeMemberRoleService.ts
+++ b/server/src/api/modules/groups/services/ChangeMemberRoleService.ts
@@ -72,7 +72,7 @@ async function changeMemberRole(payload: ChangeMemberRoleService): Promise<Membe
         }
       });
 
-      groupEvents.onMemberRoleChanged(activity, membership.role);
+      groupEvents.onMembersRolesChanged([{ ...activity, previousRole: membership.role }]);
 
       return updatedMembership;
     })

--- a/server/src/api/modules/groups/services/ChangeMemberRoleService.ts
+++ b/server/src/api/modules/groups/services/ChangeMemberRoleService.ts
@@ -1,9 +1,11 @@
 import { z } from 'zod';
 import prisma from '../../../../prisma';
 import { GroupRole } from '../../../../utils';
+import logger from '../../../util/logging';
 import { BadRequestError, ServerError } from '../../../errors';
-import { MembershipWithPlayer } from '../group.types';
+import { ActivityType, MembershipWithPlayer } from '../group.types';
 import { standardize } from '../../players/player.utils';
+import * as groupEvents from '../group.events';
 
 const inputSchema = z.object({
   id: z.number().positive(),
@@ -39,27 +41,47 @@ async function changeMemberRole(payload: ChangeMemberRoleService): Promise<Membe
     throw new BadRequestError(`${params.username} is already a ${membership.role}.`);
   }
 
-  const updatedMembership = await prisma.membership.update({
-    where: {
-      playerId_groupId: {
-        playerId: membership.playerId,
-        groupId: membership.groupId
-      }
-    },
-    data: {
-      role: params.role,
-      group: {
-        update: {
-          updatedAt: new Date()
+  const result = await prisma
+    .$transaction(async transaction => {
+      const updatedMembership = await transaction.membership.update({
+        where: {
+          playerId_groupId: {
+            playerId: membership.playerId,
+            groupId: membership.groupId
+          }
+        },
+        data: {
+          role: params.role,
+          group: {
+            update: {
+              updatedAt: new Date()
+            }
+          }
+        },
+        include: {
+          player: true
         }
-      }
-    },
-    include: {
-      player: true
-    }
-  });
+      });
 
-  return updatedMembership;
+      const activity = await transaction.memberActivity.create({
+        data: {
+          groupId: membership.groupId,
+          playerId: membership.playerId,
+          type: ActivityType.CHANGED_ROLE,
+          role: params.role
+        }
+      });
+
+      groupEvents.onMemberRoleChanged(activity, membership.role);
+
+      return updatedMembership;
+    })
+    .catch(error => {
+      logger.error('Failed to change member role', error);
+      throw new ServerError('Failed to change member role.');
+    });
+
+  return result;
 }
 
 export { changeMemberRole };

--- a/server/src/api/modules/groups/services/ChangeMemberRoleService.ts
+++ b/server/src/api/modules/groups/services/ChangeMemberRoleService.ts
@@ -73,7 +73,12 @@ async function changeMemberRole(payload: ChangeMemberRoleService): Promise<Membe
         }
       });
 
-      groupEvents.onMembersRolesChanged([omit({ ...activity, previousRole: membership.role }, 'createdAt')]);
+      groupEvents.onMembersRolesChanged([
+        omit(
+          { ...activity, previousRole: membership.role, displayName: updatedMembership.player.displayName },
+          'createdAt'
+        )
+      ]);
 
       return updatedMembership;
     })

--- a/server/src/api/modules/groups/services/ChangeMemberRoleService.ts
+++ b/server/src/api/modules/groups/services/ChangeMemberRoleService.ts
@@ -73,12 +73,7 @@ async function changeMemberRole(payload: ChangeMemberRoleService): Promise<Membe
         }
       });
 
-      groupEvents.onMembersRolesChanged([
-        omit(
-          { ...activity, previousRole: membership.role, displayName: updatedMembership.player.displayName },
-          'createdAt'
-        )
-      ]);
+      groupEvents.onMembersRolesChanged([omit({ ...activity, previousRole: membership.role }, 'createdAt')]);
 
       return updatedMembership;
     })

--- a/server/src/api/modules/groups/services/EditGroupService.ts
+++ b/server/src/api/modules/groups/services/EditGroupService.ts
@@ -265,7 +265,8 @@ async function executeUpdate(params: EditGroupParams, updatedGroupFields: Prisma
             groupId: params.id,
             role,
             type: ActivityType.CHANGED_ROLE,
-            previousRole: currentRoleMap.get(id)
+            previousRole: currentRoleMap.get(id),
+            displayName: keptPlayers.find(p => p.id === id).displayName
           }))
         );
       }

--- a/server/src/api/modules/groups/services/EditGroupService.ts
+++ b/server/src/api/modules/groups/services/EditGroupService.ts
@@ -211,15 +211,6 @@ async function executeUpdate(params: EditGroupParams, updatedGroupFields: Prisma
         }
       }
 
-      await transaction.membership.deleteMany({
-        where: {
-          groupId: params.id,
-          playerId: {
-            in: excessMemberships.map(m => m.playerId)
-          }
-        }
-      });
-
       // Register "player left" events
       leftEvents.push(
         ...excessMemberships

--- a/server/src/api/modules/groups/services/EditGroupService.ts
+++ b/server/src/api/modules/groups/services/EditGroupService.ts
@@ -227,7 +227,7 @@ async function executeUpdate(params: EditGroupParams, updatedGroupFields: Prisma
             role,
             type: ActivityType.CHANGED_ROLE,
             previousRole: currentRoleMap.get(id),
-            displayName: keptPlayers.filter(p => p.id === id)[0].displayName
+            displayName: keptPlayers.find(p => p.id === id).displayName
           }))
         );
       }

--- a/server/src/api/modules/groups/services/EditGroupService.ts
+++ b/server/src/api/modules/groups/services/EditGroupService.ts
@@ -265,8 +265,7 @@ async function executeUpdate(params: EditGroupParams, updatedGroupFields: Prisma
             groupId: params.id,
             role,
             type: ActivityType.CHANGED_ROLE,
-            previousRole: currentRoleMap.get(id),
-            displayName: keptPlayers.find(p => p.id === id).displayName
+            previousRole: currentRoleMap.get(id)
           }))
         );
       }
@@ -275,7 +274,7 @@ async function executeUpdate(params: EditGroupParams, updatedGroupFields: Prisma
         data: [
           ...leftEvents,
           ...joinedEvents.map(a => ({ ...a, role: null })),
-          ...changedRoleEvents.map(p => omit(p, 'previousRole', 'displayName'))
+          ...changedRoleEvents.map(p => omit(p, 'previousRole'))
         ]
       });
 

--- a/server/src/api/modules/groups/services/EditGroupService.ts
+++ b/server/src/api/modules/groups/services/EditGroupService.ts
@@ -255,9 +255,9 @@ async function executeUpdate(params: EditGroupParams, updatedGroupFields: Prisma
     });
 
   // If no error was thrown by this point, dispatch all events
-  onMembersLeft(leftEvents);
-  onMembersJoined(joinedEvents);
-  onMembersRolesChanged(changedRoleEvents);
+  if (leftEvents.length > 0) onMembersLeft(leftEvents);
+  if (joinedEvents.length > 0) onMembersJoined(joinedEvents);
+  if (changedRoleEvents.length > 0) onMembersRolesChanged(changedRoleEvents);
 }
 
 async function removeExcessMemberships(

--- a/server/src/api/modules/groups/services/EditGroupService.ts
+++ b/server/src/api/modules/groups/services/EditGroupService.ts
@@ -226,7 +226,8 @@ async function executeUpdate(params: EditGroupParams, updatedGroupFields: Prisma
             groupId: params.id,
             role,
             type: ActivityType.CHANGED_ROLE,
-            previousRole: currentRoleMap.get(id)
+            previousRole: currentRoleMap.get(id),
+            displayName: keptPlayers.filter(p => p.id === id)[0].displayName
           }))
         );
       }
@@ -235,7 +236,7 @@ async function executeUpdate(params: EditGroupParams, updatedGroupFields: Prisma
         data: [
           ...leftEvents,
           ...joinedEvents.map(a => ({ ...a, role: null })),
-          ...changedRoleEvents.map(p => omit(p, 'previousRole'))
+          ...changedRoleEvents.map(p => omit(p, 'previousRole', 'displayName'))
         ]
       });
 

--- a/server/src/api/modules/groups/services/EditGroupService.ts
+++ b/server/src/api/modules/groups/services/EditGroupService.ts
@@ -275,7 +275,7 @@ async function executeUpdate(params: EditGroupParams, updatedGroupFields: Prisma
         data: [
           ...leftEvents,
           ...joinedEvents.map(a => ({ ...a, role: null })),
-          ...changedRoleEvents.map(p => omit(p, 'previousRole'))
+          ...changedRoleEvents.map(p => omit(p, 'previousRole', 'displayName'))
         ]
       });
 

--- a/server/src/api/modules/groups/services/RemoveMembersService.ts
+++ b/server/src/api/modules/groups/services/RemoveMembersService.ts
@@ -68,7 +68,7 @@ async function removeMembers(payload: RemoveMembersService): Promise<{ count: nu
       throw new ServerError('Failed to remove members');
     });
 
-  groupEvents.onMembersLeft(params.id, toRemovePlayerIds);
+  groupEvents.onMembersLeft(newActivites);
 
   logger.moderation(`[Group:${params.id}] (${toRemovePlayerIds}) removed`);
 

--- a/server/src/api/services/external/discord.service.ts
+++ b/server/src/api/services/external/discord.service.ts
@@ -1,8 +1,8 @@
 import axios from 'axios';
 import { WebhookClient } from 'discord.js';
 import env, { isTesting } from '../../../env';
-import { FlaggedPlayerReviewContext } from '../../../utils';
-import prisma, { Achievement, Player, Competition } from '../../../prisma';
+import { ActivityType, FlaggedPlayerReviewContext, GroupRole } from '../../../utils';
+import prisma, { Achievement, Competition, MemberActivity, Player } from '../../../prisma';
 import { omit } from '../../util/objects';
 import logger from '../../util/logging';
 import {
@@ -42,6 +42,10 @@ function dispatch(type: string, payload: unknown) {
   axios.post(env.DISCORD_BOT_API_URL, { type, data: payload }).catch(e => {
     logger.error('Error sending discord event.', e);
   });
+}
+
+async function dispatchMemberRoleChanged(memberActivity: MemberActivity, previousRole: GroupRole) {
+  dispatch(ActivityType.CHANGED_ROLE, { memberActivity, previousRole });
 }
 
 /**
@@ -219,5 +223,6 @@ export {
   dispatchCompetitionStarted,
   dispatchCompetitionEnded,
   dispatchCompetitionStarting,
-  dispatchCompetitionEnding
+  dispatchCompetitionEnding,
+  dispatchMemberRoleChanged
 };

--- a/server/src/api/services/external/discord.service.ts
+++ b/server/src/api/services/external/discord.service.ts
@@ -44,10 +44,6 @@ function dispatch(type: string, payload: unknown) {
   });
 }
 
-async function dispatchMembersRolesChanged(events: MemberRoleChangeEvent[]) {
-  dispatch('GROUP_MEMBERS_CHANGED_ROLES', { events });
-}
-
 /**
  * Select all new achievements and dispatch them to our discord API,
  * so that it can notify any relevant guilds/servers.
@@ -117,6 +113,10 @@ async function dispatchNameChanged(player: Player, previousDisplayName: string) 
   memberships.forEach(({ groupId }) => {
     dispatch('MEMBER_NAME_CHANGED', { groupId, player, previousName: previousDisplayName });
   });
+}
+
+async function dispatchMembersRolesChanged(events: MemberRoleChangeEvent[]) {
+  dispatch('GROUP_MEMBERS_CHANGED_ROLES', events);
 }
 
 /**

--- a/server/src/api/services/external/discord.service.ts
+++ b/server/src/api/services/external/discord.service.ts
@@ -1,8 +1,8 @@
 import axios from 'axios';
 import { WebhookClient } from 'discord.js';
 import env, { isTesting } from '../../../env';
-import { ActivityType, FlaggedPlayerReviewContext, GroupRole } from '../../../utils';
-import prisma, { Achievement, Competition, MemberActivity, Player } from '../../../prisma';
+import prisma, { Achievement, Competition, Player } from '../../../prisma';
+import { FlaggedPlayerReviewContext, MemberRoleChangeEvent } from '../../../utils';
 import { omit } from '../../util/objects';
 import logger from '../../util/logging';
 import {
@@ -44,8 +44,8 @@ function dispatch(type: string, payload: unknown) {
   });
 }
 
-async function dispatchMemberRoleChanged(memberActivity: MemberActivity, previousRole: GroupRole) {
-  dispatch(ActivityType.CHANGED_ROLE, { memberActivity, previousRole });
+async function dispatchMembersRolesChanged(events: MemberRoleChangeEvent[]) {
+  dispatch('GROUP_MEMBERS_CHANGED_ROLES', { events });
 }
 
 /**
@@ -224,5 +224,5 @@ export {
   dispatchCompetitionEnded,
   dispatchCompetitionStarting,
   dispatchCompetitionEnding,
-  dispatchMemberRoleChanged
+  dispatchMembersRolesChanged
 };

--- a/server/src/prisma/enum-adapter.ts
+++ b/server/src/prisma/enum-adapter.ts
@@ -747,3 +747,11 @@ export const Country = {
 } as const;
 
 export type Country = typeof Country[keyof typeof Country];
+
+export const ActivityType = {
+  JOINED: 'joined',
+  LEFT: 'left',
+  CHANGED_ROLE: 'changed_role'
+} as const;
+
+export type ActivityType = typeof ActivityType[keyof typeof ActivityType];

--- a/server/src/prisma/hooks.ts
+++ b/server/src/prisma/hooks.ts
@@ -18,26 +18,6 @@ export function routeAfterHook(params: Prisma.MiddlewareParams, result: any) {
     return;
   }
 
-  if (params.model === 'Membership') {
-    if (params.action === 'createMany') {
-      const newMemberships = params.args.data;
-
-      if (newMemberships?.length > 0) {
-        groupEvents.onMembersJoined(newMemberships);
-      }
-      return;
-    }
-
-    if (params.action === 'deleteMany' && params.args?.where) {
-      const removedPlayerIds = params.args.where.playerId.in;
-
-      if (removedPlayerIds?.length > 0 && result?.count > 0) {
-        groupEvents.onMembersLeft(params.args.where.groupId, removedPlayerIds);
-      }
-      return;
-    }
-  }
-
   if (params.model === 'Group' && params.action === 'create') {
     const newMemberships = result?.memberships;
 

--- a/server/src/prisma/hooks.ts
+++ b/server/src/prisma/hooks.ts
@@ -3,6 +3,7 @@ import * as groupEvents from '../api/modules/groups/group.events';
 import * as playerUtils from '../api/modules/players/player.utils';
 import * as competitionEvents from '../api/modules/competitions/competition.events';
 import * as achievementEvents from '../api/modules/achievements/achievement.events';
+import { ActivityType } from './enum-adapter';
 
 // Some events need to be dispatched on this hook because (some) bulk creates depend
 // on "skipDuplicates" which can't be easily predicted at the service level.
@@ -22,7 +23,7 @@ export function routeAfterHook(params: Prisma.MiddlewareParams, result: any) {
     const newMemberships = result?.memberships;
 
     if (newMemberships?.length > 0) {
-      groupEvents.onMembersJoined(newMemberships);
+      groupEvents.onMembersJoined(newMemberships.map(m => ({ ...m, type: ActivityType.JOINED })));
     }
 
     return;

--- a/server/src/prisma/index.ts
+++ b/server/src/prisma/index.ts
@@ -12,7 +12,8 @@ import {
   Group,
   Membership,
   Prisma,
-  Country
+  Country,
+  MemberActivity
 } from '@prisma/client';
 import { DenyContext, SkipContext, isComputedMetric } from '../utils';
 import { NameChangeStatus } from './enum-adapter';
@@ -133,6 +134,7 @@ export {
   Record,
   Snapshot,
   Achievement,
+  MemberActivity,
   // Enums
   Country,
   NameChangeStatus,


### PR DESCRIPTION
Partial clone of #1185 

# TO-DO

- [x] Fixing incorrect event triggers (removed 3, group only had 2)
  - [x]  Tests
- [x] Add database table/enum and types
- [x] Triggering events
  - [x] AddMembersService
  - [x] RemoveMembersService
  - [x] ChangedMemberRoleService
  - [x] EditGroupService
  - [x] Integration tests
- [x] Inserting member activities into the database
  - [x] AddMembersService
  - [x] RemoveMembersService
  - [x] ChangedMemberRoleService
  - [x] EditGroupService
  - [x] Integration tests
- [x] Send "member role changed" event to Discord bot




