### PR TITLE
api: Recalculate achievements with suspicious timelines (-2 accuracy)

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.3.4",
+      "version": "2.3.5",
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^4.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/jobs/instances/FixAchievementsAccuracyJob.ts
+++ b/server/src/api/jobs/instances/FixAchievementsAccuracyJob.ts
@@ -1,5 +1,8 @@
 import prisma from '../../../prisma';
-import { fixAchievementsAccuracy } from '../../modules/achievements/achievement.services';
+import {
+  fixAchievementsAccuracy,
+  reevaluatePlayerAchievements
+} from '../../modules/achievements/achievement.services';
 import { JobType, JobDefinition } from '../job.types';
 import logger from '../../util/logging';
 
@@ -13,29 +16,70 @@ class FixAchievementsAccuracyJob implements JobDefinition<unknown> {
   }
 
   async execute() {
-    const start = Date.now();
-
-    // Find 5 players with achievements with missing "accuracy"
-    const uncheckedPlayerIds = (
-      await prisma.$queryRaw<Array<{ playerId: number }>>`
-        SELECT DISTINCT("playerId") FROM public.achievements
-        WHERE "accuracy" IS NULL
-        LIMIT ${CHECKS_PER_MINUTE}
-    `
-    ).map(p => p.playerId);
-
-    if (uncheckedPlayerIds.length === 0) return;
-
-    for (const playerId of uncheckedPlayerIds) {
-      await fixAchievementsAccuracy({ id: playerId });
-    }
-
-    logger.debug(
-      'Checked player achievements',
-      { playerIds: uncheckedPlayerIds, duration: Date.now() - start },
-      true
-    );
+    await fixNullAccuracy();
+    await fixInvalidAccuracy();
   }
+}
+
+async function fixInvalidAccuracy() {
+  const start = Date.now();
+
+  // Find 10 players with achievements with missing "accuracy"
+  const uncheckedPlayerIds = (
+    await prisma.$queryRaw<Array<{ playerId: number }>>`
+      SELECT DISTINCT("playerId") FROM public.achievements
+      WHERE "accuracy" = -2
+      LIMIT ${CHECKS_PER_MINUTE}
+  `
+  ).map(p => p.playerId);
+
+  if (uncheckedPlayerIds.length === 0) return;
+
+  for (const playerId of uncheckedPlayerIds) {
+    await prisma.achievement.updateMany({
+      where: {
+        accuracy: -2,
+        playerId
+      },
+      data: {
+        accuracy: null,
+        createdAt: new Date(0)
+      }
+    });
+
+    await reevaluatePlayerAchievements({ id: playerId });
+  }
+
+  logger.debug(
+    'Fixed invalid accuracy achievements',
+    { playerIds: uncheckedPlayerIds, duration: Date.now() - start },
+    true
+  );
+}
+
+async function fixNullAccuracy() {
+  const start = Date.now();
+
+  // Find 5 players with achievements with missing "accuracy"
+  const uncheckedPlayerIds = (
+    await prisma.$queryRaw<Array<{ playerId: number }>>`
+      SELECT DISTINCT("playerId") FROM public.achievements
+      WHERE "accuracy" IS NULL
+      LIMIT ${CHECKS_PER_MINUTE}
+  `
+  ).map(p => p.playerId);
+
+  if (uncheckedPlayerIds.length === 0) return;
+
+  for (const playerId of uncheckedPlayerIds) {
+    await fixAchievementsAccuracy({ id: playerId });
+  }
+
+  logger.debug(
+    'Fixed null accuracy achievements',
+    { playerIds: uncheckedPlayerIds, duration: Date.now() - start },
+    true
+  );
 }
 
 export default new FixAchievementsAccuracyJob();


### PR DESCRIPTION
A script has been running for the past month, analyzing people's achievements and their "achievement dates", any achievements that don't line up with a player's snapshot were marked as invalid by having `accuracy: -2`. All players have now been processed by this script.

This new script reconstructs these invalid achievements. 

Note: Most of these invalid achievement dates were created in the first few months of WOM as the achievement dating code was slightly inaccurate in some cases.