### PR TITLE
Improve EHP/EHB rank computation speeds

### DIFF
--- a/server/__tests__/suites/integration/efficiency.test.ts
+++ b/server/__tests__/suites/integration/efficiency.test.ts
@@ -329,7 +329,7 @@ describe('Efficiency API', () => {
         metric: 'ehp'
       });
 
-      expect(result).toBe(60);
+      expect(result).toBe(61);
     });
 
     it('should compute < top 50 rank', async () => {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.3.12",
+  "version": "2.3.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.3.12",
+      "version": "2.3.13",
       "license": "ISC",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.3.12",
+  "version": "2.3.13",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/prisma/migrations/20230816211943_add_player_ehp_ehb_indices/migration.sql
+++ b/server/prisma/migrations/20230816211943_add_player_ehp_ehb_indices/migration.sql
@@ -1,0 +1,8 @@
+-- DropIndex
+DROP INDEX "players_type";
+
+-- CreateIndex
+CREATE INDEX "players_type_ehp" ON "players"("type", "ehp" DESC);
+
+-- CreateIndex
+CREATE INDEX "players_type_ehb" ON "players"("type", "ehb" DESC);

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -293,10 +293,11 @@ model Player {
   archives       PlayerArchive[]
 
   // Indices
-  @@index([type], map: "players_type")
   @@index([build], map: "players_build")
   @@index([country], map: "players_country")
   @@index([latestSnapshotId], map: "players_latest_snapshot_id")
+  @@index([type, ehp(sort: Desc)], map: "players_type_ehp")
+  @@index([type, ehb(sort: Desc)], map: "players_type_ehb")
   // Map
   @@map("players")
 }

--- a/server/src/api/modules/efficiency/services/ComputeEfficiencyRankService.ts
+++ b/server/src/api/modules/efficiency/services/ComputeEfficiencyRankService.ts
@@ -18,17 +18,15 @@ async function computeEfficiencyRank(payload: ComputeEfficiencyRankParams): Prom
 
   const rank = await prisma.player.count({
     where: {
-      id: { not: params.player.id },
       type: params.player.type,
-      [params.metric]: { gte: params.value },
-      status: { not: PlayerStatus.ARCHIVED }
+      [params.metric]: { gte: params.value }
     }
   });
 
   // If player is not in the top 50, a quick COUNT(*) query gives an acceptable
   // rank approximation, this however won't work for players in the top of the
   // leaderboards, and we'll have to use their registration date as a tie breaker
-  if (rank > 50) return rank + 1;
+  if (rank > 50) return rank;
 
   const topPlayers = await prisma.player.findMany({
     where: {

--- a/server/src/api/modules/players/services/ArchivePlayerService.ts
+++ b/server/src/api/modules/players/services/ArchivePlayerService.ts
@@ -31,7 +31,12 @@ async function archivePlayer(player: Player): Promise<ArchivePlayerResult> {
         data: {
           username: archiveUsername,
           displayName: archiveUsername,
-          status: PlayerStatus.ARCHIVED
+          status: PlayerStatus.ARCHIVED,
+          exp: 0,
+          ehp: 0,
+          ehb: 0,
+          ttm: 0,
+          tt200m: 0
         }
       });
 


### PR DESCRIPTION
Surprisingly, computing a player's EHP and EHB ranks is taking about 53% of the database's execution time due to the lack of indices. These operations happen on every player update, so it runs around 100-150k times per day, so that's an easy performance win, yay.

This should also make player updates run maybe 300-400ms faster 🎉 

