### PR TITLE
Group snapshots fetching optimizations

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.3.14",
+  "version": "2.3.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.3.14",
+      "version": "2.3.15",
       "license": "ISC",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.3.14",
+  "version": "2.3.15",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",


### PR DESCRIPTION
As part of my ongoing effort to optimize the database's usage, I have found that fetching all snapshots for a group takes up about 41% of the compute time.

That operation happens most often in these two endpoints:
- Get group statistics
- Get group hiscores
- Get group deltas

So refactoring these to using the player.latestSnapshotId should improve this a fair bit.