### PR TITLE
[api] Fix EHP rates assignment for f2p_lvl3 & ironman accounts

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.3.19",
+  "version": "2.3.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.3.19",
+      "version": "2.3.20",
       "license": "ISC",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.3.19",
+  "version": "2.3.20",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/modules/efficiency/efficiency.utils.ts
+++ b/server/src/api/modules/efficiency/efficiency.utils.ts
@@ -111,7 +111,7 @@ export function getAlgorithm(player?: Pick<Player, 'type' | 'build'>): Efficienc
   const { type = PlayerType.REGULAR, build = PlayerBuild.MAIN } = player || {};
 
   if (
-    build === PlayerBuild.F2P &&
+    (build === PlayerBuild.F2P || build === PlayerBuild.F2P_LVL3) &&
     (type === PlayerType.ULTIMATE || type === PlayerType.IRONMAN || type === PlayerType.HARDCORE)
   ) {
     return ALGORITHMS[EfficiencyAlgorithmType.F2P_IRONMAN];


### PR DESCRIPTION
`f2p_ironman` rates were only being assigned to strictly `f2p` players, and not `f2p_lvl3` players.