### PR TITLE
Improve efficiency leaderboard ranking

### DIFF
--- a/app-v2/src/components/leaderboards/LeaderboardsFilters.tsx
+++ b/app-v2/src/components/leaderboards/LeaderboardsFilters.tsx
@@ -56,8 +56,14 @@ export function LeaderboardsFilters() {
 
   const metric = getMetricParam(searchParams.get("metric")) || Metric.OVERALL;
   const country = getCountryParam(searchParams.get("country"));
-  const playerType = getPlayerTypeParam(searchParams.get("playerType")) || PlayerType.REGULAR;
-  const playerBuild = getPlayerBuildParam(searchParams.get("playerBuild")) || PlayerBuild.MAIN;
+
+  let playerType = getPlayerTypeParam(searchParams.get("playerType"));
+  let playerBuild = getPlayerBuildParam(searchParams.get("playerBuild"));
+
+  if (isEfficiencyLeaderboard) {
+    if (!playerType) playerType = PlayerType.REGULAR;
+    if (!playerBuild) playerBuild = PlayerBuild.MAIN;
+  }
 
   // For efficiency leaderboards (it only accepts "ehp"/"ehb/"combined")
   const computedMetric = getComputedMetricParam(searchParams.get("metric")) || Metric.EHP;
@@ -306,7 +312,6 @@ function PlayerBuildSelect(props: PlayerBuildSelectProps) {
       <ComboboxContent>
         <ComboboxItemsContainer>
           <ComboboxItemGroup label="Player Build">
-            <ComboboxItem>Any player Build</ComboboxItem>
             {PLAYER_BUILDS.map((b) => (
               <ComboboxItem key={b} value={b}>
                 {PlayerBuildProps[b].name}
@@ -354,7 +359,6 @@ function CountrySelect(props: CountrySelectProps) {
         <ComboboxEmpty>No results were found</ComboboxEmpty>
         <ComboboxItemsContainer>
           <ComboboxItemGroup label="Countries">
-            <ComboboxItem>Any country</ComboboxItem>
             {COUNTRY_CODES.map((c) => (
               <ComboboxItem key={c} value={`${c}_${CountryProps[c].name}`}>
                 <CountryIcon country={c} />

--- a/app-v2/src/components/leaderboards/LeaderboardsFilters.tsx
+++ b/app-v2/src/components/leaderboards/LeaderboardsFilters.tsx
@@ -56,8 +56,8 @@ export function LeaderboardsFilters() {
 
   const metric = getMetricParam(searchParams.get("metric")) || Metric.OVERALL;
   const country = getCountryParam(searchParams.get("country"));
-  const playerType = getPlayerTypeParam(searchParams.get("playerType"));
-  const playerBuild = getPlayerBuildParam(searchParams.get("playerBuild"));
+  const playerType = getPlayerTypeParam(searchParams.get("playerType")) || PlayerType.REGULAR;
+  const playerBuild = getPlayerBuildParam(searchParams.get("playerBuild")) || PlayerBuild.MAIN;
 
   // For efficiency leaderboards (it only accepts "ehp"/"ehb/"combined")
   const computedMetric = getComputedMetricParam(searchParams.get("metric")) || Metric.EHP;

--- a/app/src/pages/Leaderboards/Leaderboards.jsx
+++ b/app/src/pages/Leaderboards/Leaderboards.jsx
@@ -109,7 +109,7 @@ function decodeURL(params, query) {
   return {
     metric: isValidMetric ? metric.toLowerCase() : 'ehp',
     type: isValidType ? type.toLowerCase() : 'regular',
-    build: isValidBuild ? build.toLowerCase() : null,
+    build: isValidBuild ? build.toLowerCase() : 'main',
     country: isValidCountry ? country.toUpperCase() : null
   };
 }

--- a/app/src/pages/Leaderboards/containers/Controls.jsx
+++ b/app/src/pages/Leaderboards/containers/Controls.jsx
@@ -20,7 +20,6 @@ const PLAYER_TYPES_OPTIONS = PLAYER_TYPES.filter(type => type !== PlayerType.UNK
 }));
 
 const PLAYER_BUILDS_OPTIONS = [
-  { label: 'All player builds', value: null },
   ...PLAYER_BUILDS.map(type => ({
     label: PlayerBuildProps[type].name,
     value: type

--- a/server/__tests__/suites/integration/efficiency.test.ts
+++ b/server/__tests__/suites/integration/efficiency.test.ts
@@ -43,22 +43,43 @@ beforeAll(async () => {
     })
   );
 
-  // Add one HCIM lvl3 for later filtering checks
+  // Add one HCIM for later filtering checks
   await prisma.player.create({
     data: {
       username: `player hcim`,
       displayName: `player hcim`,
+      type: 'hardcore',
+      build: 'main',
+      ehp: 2
+    }
+  });
+
+  // Add one HCIM lvl3 for later filtering checks
+  await prisma.player.create({
+    data: {
+      username: `player hcim2`,
+      displayName: `player hcim2`,
       type: 'hardcore',
       build: 'lvl3',
       ehp: 2
     }
   });
 
-  // Add one Ultimate lvl3 for later filtering checks
+  // Add one Ultimate for later filtering checks
   await prisma.player.create({
     data: {
       username: `player ult`,
       displayName: `player ult`,
+      type: 'ultimate',
+      build: 'main'
+    }
+  });
+
+  // Add one Ultimate lvl3 for later filtering checks
+  await prisma.player.create({
+    data: {
+      username: `player ult2`,
+      displayName: `player ult2`,
       type: 'ultimate',
       build: 'lvl3'
     }
@@ -407,12 +428,17 @@ describe('Efficiency API', () => {
       expect(response.body.length).toBe(12);
 
       const includedPlayerTypes = [...new Set(response.body.map(r => r.type))];
+      const includedPlayerBuilds = [...new Set(response.body.map(r => r.build))];
 
       // Hardcores and Ultimates should be included in the leaderboards for "ironman"
       expect(includedPlayerTypes.length).toBe(3);
       expect(includedPlayerTypes.includes('ironman')).toBe(true);
       expect(includedPlayerTypes.includes('hardcore')).toBe(true);
       expect(includedPlayerTypes.includes('ultimate')).toBe(true);
+
+      // Should only have the "main" player build
+      expect(includedPlayerBuilds.length).toBe(1);
+      expect(includedPlayerBuilds.includes('main')).toBe(true);
 
       // The ironmen were inserted on indices 80-90
       for (let i = 0; i < 10; i++) {
@@ -440,7 +466,7 @@ describe('Efficiency API', () => {
       expect(firstResponse.body.length).toBe(1);
 
       expect(firstResponse.body[0]).toMatchObject({
-        username: 'player hcim',
+        username: 'player hcim2',
         type: 'hardcore',
         build: 'lvl3'
       });
@@ -474,7 +500,7 @@ describe('Efficiency API', () => {
       expect([...new Set(response.body.map(r => r.type))].length).toBe(2);
 
       expect(response.body[0]).toMatchObject({
-        username: 'player hcim',
+        username: 'player hcim2',
         type: 'hardcore',
         ehp: 2
       });

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.3.20",
+  "version": "2.3.21",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.3.20",
+      "version": "2.3.21",
       "license": "ISC",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.3.20",
+  "version": "2.3.21",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/modules/efficiency/services/FindEfficiencyLeaderboardsService.ts
+++ b/server/src/api/modules/efficiency/services/FindEfficiencyLeaderboardsService.ts
@@ -10,7 +10,7 @@ const inputSchema = z
     metric: z.enum([Metric.EHP, Metric.EHB, COMBINED_METRIC]),
     country: z.nativeEnum(Country).optional(),
     playerType: z.nativeEnum(PlayerType).optional().default(PlayerType.REGULAR),
-    playerBuild: z.nativeEnum(PlayerBuild).optional()
+    playerBuild: z.nativeEnum(PlayerBuild).optional().default(PlayerBuild.MAIN)
   })
   .merge(PAGINATION_SCHEMA);
 
@@ -37,6 +37,7 @@ async function fetchPlayersList(params: FindEfficiencyLeaderboardsParams) {
   if (params.metric !== COMBINED_METRIC) {
     const playerQuery: PrismaTypes.PlayerWhereInput = {
       type: params.playerType,
+      build: params.playerBuild,
       status: { not: PlayerStatus.ARCHIVED }
     };
 
@@ -46,7 +47,6 @@ async function fetchPlayersList(params: FindEfficiencyLeaderboardsParams) {
     }
 
     if (params.country) playerQuery.country = params.country;
-    if (params.playerBuild) playerQuery.build = params.playerBuild;
 
     const players = await prisma.player.findMany({
       where: { ...playerQuery },


### PR DESCRIPTION
- It now uses overallRank as a tie breaker for players with maximum EHP (all 200m skills)
  - This wasn't done before because it used to be slow to pull a group of players' snapshots, but not anymore.
- EHP ranks are now player type AND build based.
- Added a `(Special)` indicator for EHP and EHB in the player page

![image](https://github.com/wise-old-man/wise-old-man/assets/3278148/1fe7b600-85bf-401a-8252-60abd1f89963)
