### PR TITLE
Check for p2p xp, not just p2p lvls in isF2p function

### DIFF
--- a/server/__tests__/suites/unit/experience.test.ts
+++ b/server/__tests__/suites/unit/experience.test.ts
@@ -108,6 +108,15 @@ describe('Util - Experience', () => {
 
     expect(
       isF2p({
+        hitpointsExperience: SKILL_EXP_AT_99,
+        attackExperience: SKILL_EXP_AT_99,
+        strengthExperience: SKILL_EXP_AT_99,
+        thievingExperience: 50
+      } as Snapshot)
+    ).toBe(false);
+
+    expect(
+      isF2p({
         attackExperience: 1000,
         woodcuttingExperience: 1000,
         prayerExperience: 1000,

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.3.23",
+  "version": "2.3.24",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/modules/snapshots/snapshot.utils.ts
+++ b/server/src/api/modules/snapshots/snapshot.utils.ts
@@ -394,7 +394,7 @@ function getTotalLevel(snapshot: Snapshot) {
 }
 
 function isF2p(snapshot: Snapshot) {
-  const hasMemberStats = MEMBER_SKILLS.some(s => getLevel(snapshot[getMetricValueKey(s)]) > 1);
+  const hasMemberStats = MEMBER_SKILLS.some(s => snapshot[getMetricValueKey(s)] > 0);
   const hasBossKc = BOSSES.filter(b => !F2P_BOSSES.includes(b)).some(b => snapshot[getMetricValueKey(b)] > 0);
 
   return !hasMemberStats && !hasBossKc;


### PR DESCRIPTION
This function was returning true if a player had xp in a p2p skill but didn't have lvl 2, ex 50 thieving xp.