### PR TITLE
[app-v1 / app-v2] Fix competition export url encoding

### DIFF
--- a/app-v2/src/components/competitions/ExportCompetitionDialog.tsx
+++ b/app-v2/src/components/competitions/ExportCompetitionDialog.tsx
@@ -25,7 +25,7 @@ function buildExportUrl(competitionId: number, searchParams: URLSearchParams) {
     params.set("table", "teams");
   } else if (team) {
     params.set("table", "team");
-    params.set("teamName", team || "");
+    params.set("teamName", decodeURIComponent(team || ""));
   } else {
     params.set("table", "participants");
   }

--- a/app/src/modals/ExportTableModal/ExportTableModal.jsx
+++ b/app/src/modals/ExportTableModal/ExportTableModal.jsx
@@ -45,7 +45,7 @@ function getExportURL(exportConfig) {
 
   nextURL.appendSearchParam('table', type);
 
-  if (teamName) nextURL.appendSearchParam('teamName', teamName);
+  if (teamName) nextURL.appendSearchParam('teamName', encodeURIComponent(teamName));
   if (metric) nextURL.appendSearchParam('metric', metric);
 
   return `=IMPORTDATA("${nextURL.getPath()}")`;


### PR DESCRIPTION
Export URLs would not work for team names with special characters in them (`&`  for example) because the URL segment wasn't being encoded properly.