### PR TITLE
[v2-app] Add Efficiency leaderboard pagination

### DIFF
--- a/app-v2/src/app/leaderboards/efficiency/page.tsx
+++ b/app-v2/src/app/leaderboards/efficiency/page.tsx
@@ -15,14 +15,18 @@ import {
   getPlayerBuildParam,
   getComputedMetricParam,
   getCountryParam,
+  getPageParam,
 } from "~/utils/params";
+import { Pagination } from "~/components/Pagination";
 
 const COMBINED_METRIC = "combined";
+const RESULTS_PER_PAGE = 30;
 
 export const dynamic = "force-dynamic";
 
 interface PageProps {
   searchParams: {
+    page?: string;
     metric?: string;
     playerType?: string;
     playerBuild?: string;
@@ -54,6 +58,7 @@ export default async function EfficiencyLeaderboardsPage(props: PageProps) {
     country: getCountryParam(searchParams.country),
     playerType: getPlayerTypeParam(searchParams.playerType),
     playerBuild: getPlayerBuildParam(searchParams.playerBuild),
+    page: getPageParam(searchParams.page) || 1,
   };
 
   return <EfficiencyLeaderboard filters={filters} />;
@@ -62,52 +67,67 @@ export default async function EfficiencyLeaderboardsPage(props: PageProps) {
 interface EfficiencyLeaderboardProps {
   filters: {
     metric: ComputedMetric | typeof COMBINED_METRIC;
+    page?: string;
   } & Omit<EfficiencyLeaderboardsFilter, "metric">;
 }
 
 async function EfficiencyLeaderboard(props: EfficiencyLeaderboardProps) {
-  const { metric, ...filters } = props.filters;
+  const { metric, page, ...filters } = props.filters;
+  
+  const pageNumber = parseInt(page || "1");
 
   const data = await getEfficiencyLeaderboards(
     metric === COMBINED_METRIC ? "ehp+ehb" : metric,
+    RESULTS_PER_PAGE,
+    (pageNumber - 1) * RESULTS_PER_PAGE,
     filters.country,
     filters.playerType,
-    filters.playerBuild
+    filters.playerBuild,
   );
 
   return (
     <div className="col-span-3 mx-auto w-full max-w-lg">
       {data.length === 0 ? (
-        <div className="w-full rounded border border-gray-700 py-10 text-center text-sm text-gray-300">
-          No results were found
-        </div>
+        <>
+          <div className="w-full rounded border border-gray-700 py-10 text-center text-sm text-gray-300">
+            No results were found
+          </div>
+          <div className="mt-4">
+            <Pagination currentPage={pageNumber} hasMorePages={data.length >= RESULTS_PER_PAGE} />
+          </div>
+        </>
       ) : (
-        <ListTable>
-          {data.map((player, index) => (
-            <ListTableRow key={player.username}>
-              <ListTableCell className="w-1 pr-1">{index + 1}</ListTableCell>
-              <ListTableCell>
-                <PlayerIdentity player={player} caption={PlayerBuildProps[player.build].name} />
-              </ListTableCell>
-              <ListTableCell className="w-5 text-right font-medium">
-                {metric === COMBINED_METRIC ? (
-                  <>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <span>{formatNumber(player.ehp + player.ehb)}</span>
-                      </TooltipTrigger>
-                      <TooltipContent align="start">
-                        {formatNumber(player.ehp)} EHP + {formatNumber(player.ehb)} EHB
-                      </TooltipContent>
-                    </Tooltip>
-                  </>
-                ) : (
-                  <>{metric === Metric.EHP ? formatNumber(player.ehp) : formatNumber(player.ehb)}</>
-                )}
-              </ListTableCell>
-            </ListTableRow>
-          ))}
-        </ListTable>
+        <>
+          <ListTable>
+            {data.map((player, index) => (
+              <ListTableRow key={player.username}>
+                <ListTableCell className="w-1 pr-1">{pageNumber == 1 ? index + 1 : (index + 1) + ((pageNumber - 1) * RESULTS_PER_PAGE)}</ListTableCell>
+                <ListTableCell>
+                  <PlayerIdentity player={player} caption={PlayerBuildProps[player.build].name} />
+                </ListTableCell>
+                <ListTableCell className="w-5 text-right font-medium">
+                  {metric === COMBINED_METRIC ? (
+                    <>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span>{formatNumber(player.ehp + player.ehb)}</span>
+                        </TooltipTrigger>
+                        <TooltipContent align="start">
+                          {formatNumber(player.ehp)} EHP + {formatNumber(player.ehb)} EHB
+                        </TooltipContent>
+                      </Tooltip>
+                    </>
+                  ) : (
+                    <>{metric === Metric.EHP ? formatNumber(player.ehp) : formatNumber(player.ehb)}</>
+                  )}
+                </ListTableCell>
+              </ListTableRow>
+            ))}
+          </ListTable>
+          <div className="mt-4">
+            <Pagination currentPage={pageNumber} hasMorePages={data.length >= RESULTS_PER_PAGE} />
+          </div>
+        </>
       )}
     </div>
   );

--- a/app-v2/src/app/leaderboards/efficiency/page.tsx
+++ b/app-v2/src/app/leaderboards/efficiency/page.tsx
@@ -53,12 +53,14 @@ export function generateMetadata(props: PageProps) {
 export default async function EfficiencyLeaderboardsPage(props: PageProps) {
   const { searchParams } = props;
 
+  const pageNumber = getPageParam(searchParams.page) || 1;
+
   const filters = {
     metric: (getComputedMetricParam(searchParams.metric) || Metric.EHP) as ComputedMetric,
     country: getCountryParam(searchParams.country),
     playerType: getPlayerTypeParam(searchParams.playerType),
     playerBuild: getPlayerBuildParam(searchParams.playerBuild),
-    page: getPageParam(searchParams.page) || 1,
+    page: pageNumber.toString(),
   };
 
   return <EfficiencyLeaderboard filters={filters} />;
@@ -78,11 +80,11 @@ async function EfficiencyLeaderboard(props: EfficiencyLeaderboardProps) {
 
   const data = await getEfficiencyLeaderboards(
     metric === COMBINED_METRIC ? "ehp+ehb" : metric,
-    RESULTS_PER_PAGE,
-    (pageNumber - 1) * RESULTS_PER_PAGE,
     filters.country,
     filters.playerType,
     filters.playerBuild,
+    RESULTS_PER_PAGE,
+    (pageNumber - 1) * RESULTS_PER_PAGE,
   );
 
   return (

--- a/app-v2/src/app/leaderboards/efficiency/page.tsx
+++ b/app-v2/src/app/leaderboards/efficiency/page.tsx
@@ -1,6 +1,5 @@
 import {
   ComputedMetric,
-  EfficiencyLeaderboardsFilter,
   Metric,
   MetricProps,
   PlayerBuildProps,
@@ -20,7 +19,7 @@ import {
 import { Pagination } from "~/components/Pagination";
 
 const COMBINED_METRIC = "combined";
-const RESULTS_PER_PAGE = 30;
+const RESULTS_PER_PAGE = 20;
 
 export const dynamic = "force-dynamic";
 
@@ -53,84 +52,57 @@ export function generateMetadata(props: PageProps) {
 export default async function EfficiencyLeaderboardsPage(props: PageProps) {
   const { searchParams } = props;
 
-  const pageNumber = getPageParam(searchParams.page) || 1;
-
-  const filters = {
-    metric: (getComputedMetricParam(searchParams.metric) || Metric.EHP) as ComputedMetric,
-    country: getCountryParam(searchParams.country),
-    playerType: getPlayerTypeParam(searchParams.playerType),
-    playerBuild: getPlayerBuildParam(searchParams.playerBuild),
-    page: pageNumber.toString(),
-  };
-
-  return <EfficiencyLeaderboard filters={filters} />;
-}
-
-interface EfficiencyLeaderboardProps {
-  filters: {
-    metric: ComputedMetric | typeof COMBINED_METRIC;
-    page?: string;
-  } & Omit<EfficiencyLeaderboardsFilter, "metric">;
-}
-
-async function EfficiencyLeaderboard(props: EfficiencyLeaderboardProps) {
-  const { metric, page, ...filters } = props.filters;
-  
-  const pageNumber = parseInt(page || "1");
+  const metric = getComputedMetricParam(searchParams.metric) || Metric.EHP;
+  const page = getPageParam(searchParams.page) || 1;
 
   const data = await getEfficiencyLeaderboards(
     metric === COMBINED_METRIC ? "ehp+ehb" : metric,
-    filters.country,
-    filters.playerType,
-    filters.playerBuild,
+    getCountryParam(searchParams.country),
+    getPlayerTypeParam(searchParams.playerType),
+    getPlayerBuildParam(searchParams.playerBuild),
     RESULTS_PER_PAGE,
-    (pageNumber - 1) * RESULTS_PER_PAGE,
+    (page - 1) * RESULTS_PER_PAGE
   );
 
   return (
     <div className="col-span-3 mx-auto w-full max-w-lg">
       {data.length === 0 ? (
-        <>
-          <div className="w-full rounded border border-gray-700 py-10 text-center text-sm text-gray-300">
-            No results were found
-          </div>
-          <div className="mt-4">
-            <Pagination currentPage={pageNumber} hasMorePages={data.length >= RESULTS_PER_PAGE} />
-          </div>
-        </>
+        <div className="w-full rounded border border-gray-700 py-10 text-center text-sm text-gray-300">
+          No results were found
+        </div>
       ) : (
-        <>
-          <ListTable>
-            {data.map((player, index) => (
-              <ListTableRow key={player.username}>
-                <ListTableCell className="w-1 pr-1">{pageNumber == 1 ? index + 1 : (index + 1) + ((pageNumber - 1) * RESULTS_PER_PAGE)}</ListTableCell>
-                <ListTableCell>
-                  <PlayerIdentity player={player} caption={PlayerBuildProps[player.build].name} />
-                </ListTableCell>
-                <ListTableCell className="w-5 text-right font-medium">
-                  {metric === COMBINED_METRIC ? (
-                    <>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <span>{formatNumber(player.ehp + player.ehb)}</span>
-                        </TooltipTrigger>
-                        <TooltipContent align="start">
-                          {formatNumber(player.ehp)} EHP + {formatNumber(player.ehb)} EHB
-                        </TooltipContent>
-                      </Tooltip>
-                    </>
-                  ) : (
-                    <>{metric === Metric.EHP ? formatNumber(player.ehp) : formatNumber(player.ehb)}</>
-                  )}
-                </ListTableCell>
-              </ListTableRow>
-            ))}
-          </ListTable>
-          <div className="mt-4">
-            <Pagination currentPage={pageNumber} hasMorePages={data.length >= RESULTS_PER_PAGE} />
-          </div>
-        </>
+        <ListTable>
+          {data.map((player, index) => (
+            <ListTableRow key={player.username}>
+              <ListTableCell className="w-1 pr-1">
+                {page == 1 ? index + 1 : index + 1 + (page - 1) * RESULTS_PER_PAGE}
+              </ListTableCell>
+              <ListTableCell>
+                <PlayerIdentity player={player} caption={PlayerBuildProps[player.build].name} />
+              </ListTableCell>
+              <ListTableCell className="w-5 text-right font-medium">
+                {metric === COMBINED_METRIC ? (
+                  <>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span>{formatNumber(player.ehp + player.ehb)}</span>
+                      </TooltipTrigger>
+                      <TooltipContent align="start">
+                        {formatNumber(player.ehp)} EHP + {formatNumber(player.ehb)} EHB
+                      </TooltipContent>
+                    </Tooltip>
+                  </>
+                ) : (
+                  <>{metric === Metric.EHP ? formatNumber(player.ehp) : formatNumber(player.ehb)}</>
+                )}
+              </ListTableCell>
+            </ListTableRow>
+          ))}
+        </ListTable>
       )}
+      <div className="mt-4">
+        <Pagination currentPage={page} hasMorePages={data.length >= RESULTS_PER_PAGE} />
+      </div>
     </div>
   );
 }

--- a/app-v2/src/services/wiseoldman.ts
+++ b/app-v2/src/services/wiseoldman.ts
@@ -74,9 +74,12 @@ export const getEfficiencyLeaderboards = cache(
     playerType: PlayerType | undefined,
     playerBuild: PlayerBuild | undefined,
     limit: number,
-    offset: number,
+    offset: number
   ) => {
-    return apiClient.efficiency.getEfficiencyLeaderboards({ metric, country, playerType, playerBuild }, { limit, offset });
+    return apiClient.efficiency.getEfficiencyLeaderboards(
+      { metric, country, playerType, playerBuild },
+      { limit, offset }
+    );
   }
 );
 

--- a/app-v2/src/services/wiseoldman.ts
+++ b/app-v2/src/services/wiseoldman.ts
@@ -70,11 +70,11 @@ export const getDeltaLeaderboard = cache(
 export const getEfficiencyLeaderboards = cache(
   (
     metric: EfficiencyLeaderboardsFilter["metric"],
+    country: Country | undefined,
+    playerType: PlayerType | undefined,
+    playerBuild: PlayerBuild | undefined,
     limit: number,
     offset: number,
-    country?: Country,
-    playerType?: PlayerType,
-    playerBuild?: PlayerBuild,
   ) => {
     return apiClient.efficiency.getEfficiencyLeaderboards({ metric, country, playerType, playerBuild }, { limit, offset });
   }

--- a/app-v2/src/services/wiseoldman.ts
+++ b/app-v2/src/services/wiseoldman.ts
@@ -70,11 +70,13 @@ export const getDeltaLeaderboard = cache(
 export const getEfficiencyLeaderboards = cache(
   (
     metric: EfficiencyLeaderboardsFilter["metric"],
+    limit: number,
+    offset: number,
     country?: Country,
     playerType?: PlayerType,
-    playerBuild?: PlayerBuild
+    playerBuild?: PlayerBuild,
   ) => {
-    return apiClient.efficiency.getEfficiencyLeaderboards({ metric, country, playerType, playerBuild });
+    return apiClient.efficiency.getEfficiencyLeaderboards({ metric, country, playerType, playerBuild }, { limit, offset });
   }
 );
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.3.23",
+  "version": "2.3.25",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.3.23",
+      "version": "2.3.25",
       "license": "ISC",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.3.24",
+  "version": "2.3.25",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/modules/efficiency/services/FindEfficiencyLeaderboardsService.ts
+++ b/server/src/api/modules/efficiency/services/FindEfficiencyLeaderboardsService.ts
@@ -26,15 +26,17 @@ async function findEfficiencyLeaderboards(payload: FindEfficiencyLeaderboardsPar
     params.offset < 50 && params.metric === Metric.EHP && params.playerBuild === PlayerBuild.MAIN;
 
   if (requiresSorting) {
-    // Fetch top 50 players, and include their snapshots
-    const sortedPlayers = (await fetchSortedPlayersList({ ...params, limit: 50 })).sort(
+    // Fetch top 100 players, and include their snapshots
+    const sortedPlayers = (await fetchSortedPlayersList({ ...params, offset: 0, limit: 100 })).sort(
       (a, b) =>
         (a.latestSnapshot?.overallRank ?? Number.MAX_SAFE_INTEGER) -
         (b.latestSnapshot?.overallRank ?? Number.MAX_SAFE_INTEGER)
     );
 
     // Once we've used their snapshots to sort by rank, we can omit them from the response
-    return sortedPlayers.map(s => omit(s, 'latestSnapshot')).slice(0, params.limit);
+    return sortedPlayers
+      .map(s => omit(s, 'latestSnapshot'))
+      .slice(params.offset, params.offset + params.limit);
   }
 
   return await fetchPlayersList(params);


### PR DESCRIPTION
This should fix #1249

Ranks are currently hardcoded from the loop index. Not sure if there is a cleaner way.