### PR TITLE
[api] Change zerker build reqs

### DIFF
--- a/server/__tests__/suites/unit/experience.test.ts
+++ b/server/__tests__/suites/unit/experience.test.ts
@@ -213,9 +213,27 @@ describe('Util - Experience', () => {
 
     expect(
       isZerker({
+        defenceExperience: 37_200 // lvl 39, almost 40
+      } as Snapshot)
+    ).toBe(false);
+
+    expect(
+      isZerker({
+        defenceExperience: 50_000 // lvl 42, almost 43
+      } as Snapshot)
+    ).toBe(true);
+
+    expect(
+      isZerker({
         defenceExperience: 62_000
       } as Snapshot)
     ).toBe(true);
+
+    expect(
+      isZerker({
+        defenceExperience: 67_983 // lvl 46
+      } as Snapshot)
+    ).toBe(false);
   });
 
   test('get200msCount', () => {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.3.25",
+  "version": "2.3.26",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.3.25",
+      "version": "2.3.26",
       "license": "ISC",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.3.25",
+  "version": "2.3.26",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/modules/snapshots/snapshot.utils.ts
+++ b/server/src/api/modules/snapshots/snapshot.utils.ts
@@ -413,7 +413,8 @@ function is10HP(snapshot: Snapshot) {
 }
 
 function isZerker(snapshot: Snapshot) {
-  return getLevel(snapshot.defenceExperience) === 45;
+  const defLvl = getLevel(snapshot.defenceExperience);
+  return defLvl >= 40 && defLvl <= 45;
 }
 
 export {


### PR DESCRIPTION
Changing the reqs for the `zerker` build to be 40-45 defence, instead of only 45, as requested by zerker pures on our Discord server.