### PR TITLE
[v2 app] Filter metrics based on player build

### DIFF
--- a/app-v2/src/app/players/[username]/achievements/page.tsx
+++ b/app-v2/src/app/players/[username]/achievements/page.tsx
@@ -5,6 +5,7 @@ import {
   MetricMeasure,
   MetricProps,
   MetricType,
+  Player,
   REAL_SKILLS,
   formatNumber,
   getLevel,
@@ -20,6 +21,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "~/components/Tooltip";
 import { MetricIcon } from "~/components/Icon";
 import { QueryLink } from "~/components/QueryLink";
 import { AchievementAccuracyTooltip, IncompleteAchievementTooltip } from "~/components/AchievementDate";
+import { getBuildContextMetrics } from "~/utils/metrics";
 
 export const dynamic = "force-dynamic";
 
@@ -45,6 +47,8 @@ export default async function PlayerAchievements(props: PageProps) {
 
   const username = decodeURI(params.username);
   const metricType = convertMetricType(searchParams.view);
+
+  const player = await getPlayerDetails(username);
 
   const achievements = await getPlayerAchievementProgress(username);
   const completedAchievements = achievements.filter((a) => !!a.createdAt);
@@ -84,7 +88,7 @@ export default async function PlayerAchievements(props: PageProps) {
           <NearestAchievements achievements={achievements} metricType={metricType} />
         </div>
         <div className="col-span-12 xl:col-span-8">
-          <ProgressTable achievements={achievements} metricType={metricType} />
+          <ProgressTable player={player} achievements={achievements} metricType={metricType} />
         </div>
       </div>
     </div>
@@ -92,14 +96,17 @@ export default async function PlayerAchievements(props: PageProps) {
 }
 
 interface ProgressTableProps {
+  player: Player;
   achievements: AchievementProgress[];
   metricType?: MetricType;
 }
 
 function ProgressTable(props: ProgressTableProps) {
-  const { metricType, achievements } = props;
+  const { player, metricType, achievements } = props;
 
-  const groups = groupAchievementsByType(achievements).filter(
+  const filteredAchievements = getBuildContextMetrics(player, achievements);
+
+  const groups = groupAchievementsByType(filteredAchievements).filter(
     (g) => !metricType || MetricProps[g.metric].type === metricType
   );
 

--- a/app-v2/src/app/players/[username]/achievements/page.tsx
+++ b/app-v2/src/app/players/[username]/achievements/page.tsx
@@ -21,7 +21,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "~/components/Tooltip";
 import { MetricIcon } from "~/components/Icon";
 import { QueryLink } from "~/components/QueryLink";
 import { AchievementAccuracyTooltip, IncompleteAchievementTooltip } from "~/components/AchievementDate";
-import { getBuildContextMetrics } from "~/utils/metrics";
+import { getBuildHiddenMetrics } from "~/utils/metrics";
 
 export const dynamic = "force-dynamic";
 
@@ -104,7 +104,8 @@ interface ProgressTableProps {
 function ProgressTable(props: ProgressTableProps) {
   const { player, metricType, achievements } = props;
 
-  const filteredAchievements = getBuildContextMetrics(player, achievements);
+  const hiddenMetrics = getBuildHiddenMetrics(player.build);
+  const filteredAchievements = achievements.filter(achievement => !hiddenMetrics.includes(achievement.metric));
 
   const groups = groupAchievementsByType(filteredAchievements).filter(
     (g) => !metricType || MetricProps[g.metric].type === metricType

--- a/app-v2/src/app/players/[username]/achievements/page.tsx
+++ b/app-v2/src/app/players/[username]/achievements/page.tsx
@@ -45,12 +45,11 @@ export async function generateMetadata(props: PageProps) {
 export default async function PlayerAchievements(props: PageProps) {
   const { params, searchParams } = props;
 
-  const username = decodeURI(params.username);
   const metricType = convertMetricType(searchParams.view);
 
-  const player = await getPlayerDetails(username);
+  const player = await getPlayerDetails(decodeURI(params.username));
 
-  const achievements = await getPlayerAchievementProgress(username);
+  const achievements = await getPlayerAchievementProgress(player.username);
   const completedAchievements = achievements.filter((a) => !!a.createdAt);
 
   const skillAchievements = completedAchievements.filter((a) => isSkill(a.metric));
@@ -105,7 +104,7 @@ function ProgressTable(props: ProgressTableProps) {
   const { player, metricType, achievements } = props;
 
   const hiddenMetrics = getBuildHiddenMetrics(player.build);
-  const filteredAchievements = achievements.filter(achievement => !hiddenMetrics.includes(achievement.metric));
+  const filteredAchievements = achievements.filter((a) => !hiddenMetrics.includes(a.metric));
 
   const groups = groupAchievementsByType(filteredAchievements).filter(
     (g) => !metricType || MetricProps[g.metric].type === metricType

--- a/app-v2/src/app/players/[username]/page.tsx
+++ b/app-v2/src/app/players/[username]/page.tsx
@@ -45,7 +45,7 @@ export default async function PlayerPage(props: PageProps) {
           <Suspense fallback={<LoadingSkeleton />}>
             <PlayerOverviewCompetition username={username} />
             <PlayerOverviewMemberships username={username} />
-            <PlayerOverviewAchievements username={player.username} />
+            <PlayerOverviewAchievements player={player} />
           </Suspense>
         </div>
         <div className="col-span-12 mt-8 flex flex-col gap-y-4 lg:col-span-8">

--- a/app-v2/src/components/players/PlayerGainedTable.tsx
+++ b/app-v2/src/components/players/PlayerGainedTable.tsx
@@ -13,6 +13,7 @@ import {
   PERIODS,
   Period,
   PeriodProps,
+  Player,
   PlayerDeltasMap,
   PlayerDetails,
   SkillDelta,
@@ -33,6 +34,7 @@ import { FormattedNumber } from "../FormattedNumber";
 import { MetricIconSmall } from "../Icon";
 import { TableSortButton } from "../Table";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../Tooltip";
+import { getBuildContextMetrics } from "~/utils/metrics";
 
 interface PlayerGainedTableProps {
   player: PlayerDetails;
@@ -131,7 +133,7 @@ export function PlayerGainedTable(props: PropsWithChildren<PlayerGainedTableProp
       </div>
       <div className="grid grid-cols-12 gap-y-5">
         <div className="col-span-12 -mb-1.5 xl:col-span-6">
-          <PlayerGainsTable gains={gains} onRowSelected={handleMetricSelected} selectedMetric={metric} />
+          <PlayerGainsTable player={player} gains={gains} onRowSelected={handleMetricSelected} selectedMetric={metric} />
         </div>
         <div className="col-span-12 -ml-px rounded-xl border border-gray-500 bg-gray-800 xl:col-span-6 xl:rounded-t-none">
           {children}
@@ -142,13 +144,14 @@ export function PlayerGainedTable(props: PropsWithChildren<PlayerGainedTableProp
 }
 
 interface PlayerGainsTableProps {
+  player: Player;
   gains: PlayerDeltasMap;
   selectedMetric: Metric;
   onRowSelected: (metric: Metric) => void;
 }
 
 function PlayerGainsTable(props: PlayerGainsTableProps) {
-  const { gains, onRowSelected, selectedMetric } = props;
+  const { player, gains, onRowSelected, selectedMetric } = props;
   const metricType = MetricProps[selectedMetric].type;
 
   function handleRowSelected(row: Row<SkillDelta | BossDelta | ActivityDelta>) {
@@ -166,7 +169,7 @@ function PlayerGainsTable(props: PlayerGainsTableProps) {
       } as unknown as BossDelta,
       ...Object.values(gains.bosses),
     ];
-
+    
     const selectedRowId = String(rows.findIndex((g) => g.metric === selectedMetric));
 
     return (
@@ -207,12 +210,14 @@ function PlayerGainsTable(props: PlayerGainsTableProps) {
     ...Object.values(gains.skills),
   ];
 
-  const selectedRowId = String(rows.findIndex((g) => g.metric === selectedMetric));
+  const filteredRows = getBuildContextMetrics(player, rows) as unknown as SkillDelta[];
+
+  const selectedRowId = String(filteredRows.findIndex((g) => g.metric === selectedMetric));
 
   return (
     <DataTable
       columns={SKILL_COLUMN_DEFS}
-      data={rows}
+      data={filteredRows}
       containerClassName="rounded-t-none"
       onRowClick={handleRowSelected}
       selectedRowId={selectedRowId}

--- a/app-v2/src/components/players/PlayerGainedTable.tsx
+++ b/app-v2/src/components/players/PlayerGainedTable.tsx
@@ -34,7 +34,7 @@ import { FormattedNumber } from "../FormattedNumber";
 import { MetricIconSmall } from "../Icon";
 import { TableSortButton } from "../Table";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../Tooltip";
-import { getBuildContextMetrics } from "~/utils/metrics";
+import { getBuildHiddenMetrics } from "~/utils/metrics";
 
 interface PlayerGainedTableProps {
   player: PlayerDetails;
@@ -210,7 +210,8 @@ function PlayerGainsTable(props: PlayerGainsTableProps) {
     ...Object.values(gains.skills),
   ];
 
-  const filteredRows = getBuildContextMetrics(player, rows) as unknown as SkillDelta[];
+  const hiddenMetrics = getBuildHiddenMetrics(player.build);
+  const filteredRows = rows.filter(row => !hiddenMetrics.includes(row.metric));
 
   const selectedRowId = String(filteredRows.findIndex((g) => g.metric === selectedMetric));
 

--- a/app-v2/src/components/players/PlayerGainedTable.tsx
+++ b/app-v2/src/components/players/PlayerGainedTable.tsx
@@ -21,6 +21,7 @@ import {
 } from "@wise-old-man/utils";
 import { formatDatetime } from "~/utils/dates";
 import { TimeRangeFilter } from "~/services/wiseoldman";
+import { getBuildHiddenMetrics } from "~/utils/metrics";
 import {
   Combobox,
   ComboboxButton,
@@ -34,7 +35,6 @@ import { FormattedNumber } from "../FormattedNumber";
 import { MetricIconSmall } from "../Icon";
 import { TableSortButton } from "../Table";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../Tooltip";
-import { getBuildHiddenMetrics } from "~/utils/metrics";
 
 interface PlayerGainedTableProps {
   player: PlayerDetails;
@@ -133,7 +133,12 @@ export function PlayerGainedTable(props: PropsWithChildren<PlayerGainedTableProp
       </div>
       <div className="grid grid-cols-12 gap-y-5">
         <div className="col-span-12 -mb-1.5 xl:col-span-6">
-          <PlayerGainsTable player={player} gains={gains} onRowSelected={handleMetricSelected} selectedMetric={metric} />
+          <PlayerGainsTable
+            player={player}
+            gains={gains}
+            onRowSelected={handleMetricSelected}
+            selectedMetric={metric}
+          />
         </div>
         <div className="col-span-12 -ml-px rounded-xl border border-gray-500 bg-gray-800 xl:col-span-6 xl:rounded-t-none">
           {children}
@@ -169,7 +174,7 @@ function PlayerGainsTable(props: PlayerGainsTableProps) {
       } as unknown as BossDelta,
       ...Object.values(gains.bosses),
     ];
-    
+
     const selectedRowId = String(rows.findIndex((g) => g.metric === selectedMetric));
 
     return (
@@ -211,7 +216,7 @@ function PlayerGainsTable(props: PlayerGainsTableProps) {
   ];
 
   const hiddenMetrics = getBuildHiddenMetrics(player.build);
-  const filteredRows = rows.filter(row => !hiddenMetrics.includes(row.metric));
+  const filteredRows = rows.filter((row) => !hiddenMetrics.includes(row.metric));
 
   const selectedRowId = String(filteredRows.findIndex((g) => g.metric === selectedMetric));
 

--- a/app-v2/src/components/players/PlayerOverviewAchievements.tsx
+++ b/app-v2/src/components/players/PlayerOverviewAchievements.tsx
@@ -13,17 +13,19 @@ export async function PlayerOverviewAchievements(props: PlayerOverviewAchievemen
   const { player } = props;
 
   const achievementsProgress = await getPlayerAchievementProgress(player.username);
-  
-  //Filter achievement skills
-  const achivementProgressSkills = achievementsProgress.filter((a) => isSkill(a.metric));
 
-  //Filter achievement skills based on player build
+  // Filter achievement skills based on player build
   const hiddenMetrics = getBuildHiddenMetrics(player.build);
-  const filteredAchivementProgressSkills = achivementProgressSkills.filter(achievementSkill => !hiddenMetrics.includes(achievementSkill.metric));
 
-  //Compute nearest 99s
-  const nearest99s = filteredAchivementProgressSkills
-    .filter((a) => a.threshold === SKILL_EXP_AT_99 && !a.createdAt)
+  // Compute nearest 99s
+  const nearest99s = achievementsProgress
+    .filter(
+      (a) =>
+        isSkill(a.metric) &&
+        !hiddenMetrics.includes(a.metric) &&
+        a.threshold === SKILL_EXP_AT_99 &&
+        !a.createdAt
+    )
     .sort((a, b) => b.absoluteProgress - a.absoluteProgress)
     .slice(0, 3);
 

--- a/app-v2/src/components/players/PlayerOverviewAchievements.tsx
+++ b/app-v2/src/components/players/PlayerOverviewAchievements.tsx
@@ -1,20 +1,28 @@
-import { SKILL_EXP_AT_99, isSkill } from "@wise-old-man/utils";
+import { Player, SKILL_EXP_AT_99, isSkill } from "@wise-old-man/utils";
 import Link from "next/link";
 import { Label } from "../Label";
 import { AchievementListItem } from "../AchievementListItem";
 import { getPlayerAchievementProgress } from "~/services/wiseoldman";
+import { getBuildContextMetrics } from "~/utils/metrics";
 
 interface PlayerOverviewAchievementsProps {
-  username: string;
+  player: Player;
 }
 
 export async function PlayerOverviewAchievements(props: PlayerOverviewAchievementsProps) {
-  const { username } = props;
+  const { player } = props;
 
-  const achievementsProgress = await getPlayerAchievementProgress(username);
+  const achievementsProgress = await getPlayerAchievementProgress(player.username);
+  
+  //Filter achievement skills
+  const achivementProgressSkills = achievementsProgress.filter((a) => isSkill(a.metric));
 
-  const nearest99s = achievementsProgress
-    .filter((a) => isSkill(a.metric) && a.threshold === SKILL_EXP_AT_99 && !a.createdAt)
+  //Filter achievement skills based on player build
+  const filteredAchivementProgressSkills = getBuildContextMetrics(player, achivementProgressSkills);
+
+  //Compute nearest 99s
+  const nearest99s = filteredAchivementProgressSkills
+    .filter((a) => a.threshold === SKILL_EXP_AT_99 && !a.createdAt)
     .sort((a, b) => b.absoluteProgress - a.absoluteProgress)
     .slice(0, 3);
 
@@ -35,7 +43,7 @@ export async function PlayerOverviewAchievements(props: PlayerOverviewAchievemen
           </div>
           <div className="mt-3 flex justify-end">
             <Link
-              href={`/players/${username}/achievements`}
+              href={`/players/${player.username}/achievements`}
               className="text-xs font-medium text-gray-200 hover:underline"
             >
               View all
@@ -53,7 +61,7 @@ export async function PlayerOverviewAchievements(props: PlayerOverviewAchievemen
           </div>
           <div className="mt-3 flex justify-end">
             <Link
-              href={`/players/${username}/achievements`}
+              href={`/players/${player.username}/achievements`}
               className="text-xs font-medium text-gray-200 hover:underline"
             >
               View all

--- a/app-v2/src/components/players/PlayerOverviewAchievements.tsx
+++ b/app-v2/src/components/players/PlayerOverviewAchievements.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { Label } from "../Label";
 import { AchievementListItem } from "../AchievementListItem";
 import { getPlayerAchievementProgress } from "~/services/wiseoldman";
-import { getBuildContextMetrics } from "~/utils/metrics";
+import { getBuildHiddenMetrics } from "~/utils/metrics";
 
 interface PlayerOverviewAchievementsProps {
   player: Player;
@@ -18,7 +18,8 @@ export async function PlayerOverviewAchievements(props: PlayerOverviewAchievemen
   const achivementProgressSkills = achievementsProgress.filter((a) => isSkill(a.metric));
 
   //Filter achievement skills based on player build
-  const filteredAchivementProgressSkills = getBuildContextMetrics(player, achivementProgressSkills);
+  const hiddenMetrics = getBuildHiddenMetrics(player.build);
+  const filteredAchivementProgressSkills = achivementProgressSkills.filter(achievementSkill => !hiddenMetrics.includes(achievementSkill.metric));
 
   //Compute nearest 99s
   const nearest99s = filteredAchivementProgressSkills

--- a/app-v2/src/components/players/PlayerStatsTable.tsx
+++ b/app-v2/src/components/players/PlayerStatsTable.tsx
@@ -7,8 +7,6 @@ import {
   ActivityValue,
   Boss,
   BossValue,
-  COMBAT_SKILLS,
-  MEMBER_SKILLS,
   Metric,
   MetricProps,
   MetricType,

--- a/app-v2/src/components/players/PlayerStatsTable.tsx
+++ b/app-v2/src/components/players/PlayerStatsTable.tsx
@@ -46,7 +46,7 @@ import {
 } from "../Dropdown";
 
 import TableCogIcon from "~/assets/table_cog.svg";
-import { getBuildContextMetrics } from "~/utils/metrics";
+import { getBuildHiddenMetrics } from "~/utils/metrics";
 
 interface PlayerStatsTableProps {
   player: PlayerDetails;
@@ -162,7 +162,8 @@ function PlayerSkillsTable(
   ];
 
   //Filter out skills based on player build
-  const filteredRows = getBuildContextMetrics(player, rows);
+  const hiddenMetrics = getBuildHiddenMetrics(player.build);
+  const filteredRows = rows.filter(row => !hiddenMetrics.includes(row.metric));
 
   const columnDefs = useMemo(
     () => getSkillColumnDefinitions(player, showVirtualLevels),

--- a/app-v2/src/components/players/PlayerStatsTable.tsx
+++ b/app-v2/src/components/players/PlayerStatsTable.tsx
@@ -7,6 +7,8 @@ import {
   ActivityValue,
   Boss,
   BossValue,
+  COMBAT_SKILLS,
+  MEMBER_SKILLS,
   Metric,
   MetricProps,
   MetricType,
@@ -46,6 +48,7 @@ import {
 } from "../Dropdown";
 
 import TableCogIcon from "~/assets/table_cog.svg";
+import { getBuildContextMetrics } from "~/utils/metrics";
 
 interface PlayerStatsTableProps {
   player: PlayerDetails;
@@ -160,12 +163,15 @@ function PlayerSkillsTable(
     ...Object.values(player.latestSnapshot.data.skills),
   ];
 
+  //Filter out skills based on player build
+  const filteredRows = getBuildContextMetrics(player, rows);
+
   const columnDefs = useMemo(
     () => getSkillColumnDefinitions(player, showVirtualLevels),
     [player, showVirtualLevels]
   );
 
-  return <DataTable columns={columnDefs} data={rows} headerSlot={<TableTitle>{children}</TableTitle>} />;
+  return <DataTable columns={columnDefs} data={filteredRows} headerSlot={<TableTitle>{children}</TableTitle>} />;
 }
 
 function getSkillColumnDefinitions(player: Player, showVirtualLevels: boolean): ColumnDef<SkillValue>[] {

--- a/app-v2/src/components/players/PlayerStatsTable.tsx
+++ b/app-v2/src/components/players/PlayerStatsTable.tsx
@@ -21,6 +21,7 @@ import {
   getLevel,
 } from "@wise-old-man/utils";
 import { formatDatetime, timeago } from "~/utils/dates";
+import { getBuildHiddenMetrics } from "~/utils/metrics";
 import { Label } from "../Label";
 import { Button } from "../Button";
 import { Checkbox } from "../Checkbox";
@@ -46,7 +47,6 @@ import {
 } from "../Dropdown";
 
 import TableCogIcon from "~/assets/table_cog.svg";
-import { getBuildHiddenMetrics } from "~/utils/metrics";
 
 interface PlayerStatsTableProps {
   player: PlayerDetails;
@@ -161,16 +161,22 @@ function PlayerSkillsTable(
     ...Object.values(player.latestSnapshot.data.skills),
   ];
 
-  //Filter out skills based on player build
+  // Filter out skills based on player build
   const hiddenMetrics = getBuildHiddenMetrics(player.build);
-  const filteredRows = rows.filter(row => !hiddenMetrics.includes(row.metric));
+  const filteredRows = rows.filter((row) => !hiddenMetrics.includes(row.metric));
 
   const columnDefs = useMemo(
     () => getSkillColumnDefinitions(player, showVirtualLevels),
     [player, showVirtualLevels]
   );
 
-  return <DataTable columns={columnDefs} data={filteredRows} headerSlot={<TableTitle>{children}</TableTitle>} />;
+  return (
+    <DataTable
+      columns={columnDefs}
+      data={filteredRows}
+      headerSlot={<TableTitle>{children}</TableTitle>}
+    />
+  );
 }
 
 function getSkillColumnDefinitions(player: Player, showVirtualLevels: boolean): ColumnDef<SkillValue>[] {

--- a/app-v2/src/utils/metrics.ts
+++ b/app-v2/src/utils/metrics.ts
@@ -1,0 +1,19 @@
+import { COMBAT_SKILLS, MEMBER_SKILLS, Player } from "@wise-old-man/utils";
+
+export function getBuildContextMetrics(player: Player, metrics: any[]) {
+    let filteredMetrics = metrics;
+  
+    switch(player.build) {
+        case 'f2p':
+        filteredMetrics = metrics.filter(item => !MEMBER_SKILLS.includes(item.metric));
+        break;
+        case 'f2p_lvl3':
+        filteredMetrics = metrics.filter(item => ![...MEMBER_SKILLS, ...COMBAT_SKILLS].includes(item.metric));
+        break;
+        case 'lvl3':
+        filteredMetrics = metrics.filter(item => !COMBAT_SKILLS.includes(item.metric));
+        break;
+    }
+
+    return filteredMetrics;
+}

--- a/app-v2/src/utils/metrics.ts
+++ b/app-v2/src/utils/metrics.ts
@@ -1,14 +1,14 @@
-import { COMBAT_SKILLS, MEMBER_SKILLS, Player } from "@wise-old-man/utils";
+import { COMBAT_SKILLS, MEMBER_SKILLS, Metric, PlayerBuild } from "@wise-old-man/utils";
 
-export function getBuildContextMetrics(player: Player, metrics: any[]) {
-    switch(player.build) {
+export function getBuildHiddenMetrics(build: PlayerBuild): Metric[] {
+    switch(build) {
         case 'f2p':
-        return metrics.filter(item => !MEMBER_SKILLS.includes(item.metric));
+        return MEMBER_SKILLS;
         case 'f2p_lvl3':
-        return metrics.filter(item => ![...MEMBER_SKILLS, ...COMBAT_SKILLS].includes(item.metric));
+        return [...MEMBER_SKILLS, ...COMBAT_SKILLS];
         case 'lvl3':
-        return metrics.filter(item => !COMBAT_SKILLS.includes(item.metric));
+        return COMBAT_SKILLS;
     }
 
-    return metrics;
+    return [];
 }

--- a/app-v2/src/utils/metrics.ts
+++ b/app-v2/src/utils/metrics.ts
@@ -1,19 +1,14 @@
 import { COMBAT_SKILLS, MEMBER_SKILLS, Player } from "@wise-old-man/utils";
 
 export function getBuildContextMetrics(player: Player, metrics: any[]) {
-    let filteredMetrics = metrics;
-  
     switch(player.build) {
         case 'f2p':
-        filteredMetrics = metrics.filter(item => !MEMBER_SKILLS.includes(item.metric));
-        break;
+        return metrics.filter(item => !MEMBER_SKILLS.includes(item.metric));
         case 'f2p_lvl3':
-        filteredMetrics = metrics.filter(item => ![...MEMBER_SKILLS, ...COMBAT_SKILLS].includes(item.metric));
-        break;
+        return metrics.filter(item => ![...MEMBER_SKILLS, ...COMBAT_SKILLS].includes(item.metric));
         case 'lvl3':
-        filteredMetrics = metrics.filter(item => !COMBAT_SKILLS.includes(item.metric));
-        break;
+        return metrics.filter(item => !COMBAT_SKILLS.includes(item.metric));
     }
 
-    return filteredMetrics;
+    return metrics;
 }

--- a/app-v2/src/utils/metrics.ts
+++ b/app-v2/src/utils/metrics.ts
@@ -1,14 +1,14 @@
 import { COMBAT_SKILLS, MEMBER_SKILLS, Metric, PlayerBuild } from "@wise-old-man/utils";
 
 export function getBuildHiddenMetrics(build: PlayerBuild): Metric[] {
-    switch(build) {
-        case 'f2p':
-        return MEMBER_SKILLS;
-        case 'f2p_lvl3':
-        return [...MEMBER_SKILLS, ...COMBAT_SKILLS];
-        case 'lvl3':
-        return COMBAT_SKILLS;
-    }
+  switch (build) {
+    case "f2p":
+      return MEMBER_SKILLS;
+    case "f2p_lvl3":
+      return [...MEMBER_SKILLS, ...COMBAT_SKILLS];
+    case "lvl3":
+      return COMBAT_SKILLS;
+  }
 
-    return [];
+  return [];
 }


### PR DESCRIPTION
## Filter metrics based on player build

This PR's purpose is to hide P2P skills on the F2P page (#892) and combat skills on Level 3s builds. The changes are applied to the Overview, Gained, and Achievements page components. These modifications are implemented client-side.

Some potential enhancements could include:

- Directly filtering the metrics from the API.
- Modifying the "Base Stats" achievement to exclude unwanted metrics based on the build type (P2P or combat skills).
- Excluding P2P bosses from F2P boss achievements.
