### PR TITLE
[api] Fix close achievements having 100 percent completition

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.3.27",
+  "version": "2.3.28",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.3.27",
+      "version": "2.3.28",
       "license": "ISC",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.3.27",
+  "version": "2.3.28",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/modules/achievements/services/FindPlayerAchievementProgressService.ts
+++ b/server/src/api/modules/achievements/services/FindPlayerAchievementProgressService.ts
@@ -41,14 +41,21 @@ async function findPlayerAchievementProgress(payload: FindProgressParams): Promi
 
     const existingAchievement = currentAchievementMap.get(d.name);
 
+    let absoluteProgress = clamp((currentValue - startValue) / (d.threshold - startValue));
+    let relativeProgress = clamp((currentValue - prevThreshold) / (d.threshold - prevThreshold));
+
+    // Prevent rounding progress to 1.0 if the player has not yet reached the threshold
+    if (absoluteProgress === 1 && currentValue < d.threshold) absoluteProgress = 0.9999;
+    if (relativeProgress === 1 && currentValue < d.threshold) relativeProgress = 0.9999;
+
     return {
       ...d,
       playerId: params.id,
       createdAt: existingAchievement?.createdAt || null,
       accuracy: existingAchievement?.accuracy || null,
       currentValue,
-      absoluteProgress: clamp((currentValue - startValue) / (d.threshold - startValue)),
-      relativeProgress: clamp((currentValue - prevThreshold) / (d.threshold - prevThreshold))
+      absoluteProgress,
+      relativeProgress
     };
   });
 }


### PR DESCRIPTION
An achievement's relative/absolute is clamped and rounded, but this meant that sometimes it would round up to 1 even though it wasn't truly completed (just very close to being completed)

This forces it to round down to `0.9999` if the player's current value is below the achievement's threshold.