### PR TITLE
api: Expose group activity data

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 *.js text eol=lf
 *.sh text eol=lf
 *.ts text eol=lf
+*.txt text eol=lf

--- a/client-js/package-lock.json
+++ b/client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wise-old-man/utils",
-      "version": "3.0.3",
+      "version": "3.0.4",
       "license": "ISC",
       "dependencies": {
         "dayjs": "^1.11.5"

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "description": "A JavaScript/TypeScript client that interfaces and consumes the Wise Old Man API, an API that tracks and measures players' progress in Old School Runescape.",
   "keywords": [
     "wiseoldman",

--- a/client-js/src/clients/GroupsClient.ts
+++ b/client-js/src/clients/GroupsClient.ts
@@ -9,7 +9,8 @@ import {
   GroupStatistics,
   RecordLeaderboardEntry,
   ExtendedAchievementWithPlayer,
-  DeltaGroupLeaderboardEntry
+  DeltaGroupLeaderboardEntry,
+  MemberActivityWithPlayer
 } from '../../../server/src/utils';
 import type {
   CreateGroupPayload,
@@ -170,5 +171,13 @@ export default class GroupsClient extends BaseAPIClient {
    */
   getGroupStatistics(id: number) {
     return this.getRequest<GroupStatistics>(`/groups/${id}/statistics`);
+  }
+
+  /**
+   * Fetches a group's activity.
+   * @returns A list of a group's (join, leave and role changed) activity.
+   */
+  getGroupActivity(id: number, pagination?: PaginationOptions) {
+    return this.getRequest<MemberActivityWithPlayer>(`/groups/${id}/activity`, { ...pagination });
   }
 }

--- a/docs/docs/groups-api/group-endpoints.mdx
+++ b/docs/docs/groups-api/group-endpoints.mdx
@@ -1770,3 +1770,109 @@ const statistics = await client.groups.getGroupStatistics(123);
   }
 }
 ```
+
+---
+
+## Get Group Activities
+
+<Endpoint verb="GET" path="/groups/:id/activities" />
+<br />
+
+Fetches a group's activities. Returns an array of [GroupActivity](/groups-api/group-type-definitions#object-group-activity) objects.
+
+<br />
+
+**Request Params**
+
+| Field | Type    | Required | Description     |
+| ----- | ------- | -------- | --------------- |
+| id    | integer | `true`   | The group's ID. |
+
+<br />
+
+**Query Params**
+
+| Field  | Type    | Required | Description                                           |
+| ------ | ------- | -------- | ----------------------------------------------------- |
+| limit  | integer | `false`  | The pagination limit. See [Pagination](/#pagination)  |
+| offset | integer | `false`  | The pagination offset. See [Pagination](/#pagination) |
+
+<br />
+
+**Example Request**
+
+<TabbedCodeBlock>
+
+```curl
+curl -X GET https://api.wiseoldman.net/v2/groups/123/activities?limit=5 \
+ -H "Content-type: application/json"
+```
+
+```javascript
+const { WOMClient } = require('@wise-old-man/utils');
+
+const client = new WOMClient();
+
+const activity = await client.groups.getGroupActivity(123);
+```
+
+</TabbedCodeBlock>
+
+<br />
+
+**Example Response**
+
+```json
+[
+  {
+    "groupId": 139,
+    "playerId": 4156,
+    "type": "changed_role",
+    "role": "iron",
+    "createdAt": "2023-10-23T20:39:45.104Z",
+    "player": {
+      "id": 4156,
+      "username": "rro",
+      "displayName": "Rro",
+      "type": "regular",
+      "build": "main",
+      "status": "active",
+      "country": "SE",
+      "exp": 694156199,
+      "ehp": 1635.832120000001,
+      "ehb": 1160.30569,
+      "ttm": 0,
+      "tt200m": 11177.97617,
+      "registeredAt": "2020-05-03T16:55:16.933Z",
+      "updatedAt": "2023-10-23T20:23:24.508Z",
+      "lastChangedAt": "2023-10-18T23:54:41.785Z",
+      "lastImportedAt": "2023-06-26T22:03:44.480Z"
+    }
+  },
+  {
+    "groupId": 139,
+    "playerId": 9899,
+    "type": "joined",
+    "role": null,
+    "createdAt": "2023-10-16T13:20:50.273Z",
+    "player": {
+      "id": 9899,
+      "username": "jakesterwars",
+      "displayName": "jakesterwars",
+      "type": "regular",
+      "build": "main",
+      "status": "active",
+      "country": "US",
+      "exp": 79040233,
+      "ehp": 261.2681500000017,
+      "ehb": 0,
+      "ttm": 703.17317,
+      "tt200m": 12552.54014,
+      "registeredAt": "2020-05-18T02:54:10.427Z",
+      "updatedAt": "2023-10-11T05:22:14.355Z",
+      "lastChangedAt": "2023-07-08T19:11:51.285Z",
+      "lastImportedAt": "2022-11-07T11:54:20.482Z"
+    }
+  }
+]
+```

--- a/docs/docs/groups-api/group-endpoints.mdx
+++ b/docs/docs/groups-api/group-endpoints.mdx
@@ -1773,12 +1773,12 @@ const statistics = await client.groups.getGroupStatistics(123);
 
 ---
 
-## Get Group Activities
+## Get Group Activity
 
-<Endpoint verb="GET" path="/groups/:id/activities" />
+<Endpoint verb="GET" path="/groups/:id/activity" />
 <br />
 
-Fetches a group's activities. Returns an array of [GroupActivity](/groups-api/group-type-definitions#object-group-activity) objects.
+Fetches a group's activity. Returns an array of [GroupActivity](/groups-api/group-type-definitions#object-group-activity) objects.
 
 <br />
 
@@ -1804,7 +1804,7 @@ Fetches a group's activities. Returns an array of [GroupActivity](/groups-api/gr
 <TabbedCodeBlock>
 
 ```curl
-curl -X GET https://api.wiseoldman.net/v2/groups/123/activities?limit=5 \
+curl -X GET https://api.wiseoldman.net/v2/groups/139/activity?limit=5 \
  -H "Content-type: application/json"
 ```
 
@@ -1813,7 +1813,7 @@ const { WOMClient } = require('@wise-old-man/utils');
 
 const client = new WOMClient();
 
-const activity = await client.groups.getGroupActivity(123);
+const activity = await client.groups.getGroupActivity(139);
 ```
 
 </TabbedCodeBlock>

--- a/docs/docs/groups-api/group-type-definitions.md
+++ b/docs/docs/groups-api/group-type-definitions.md
@@ -278,8 +278,8 @@ Used as an input for group modification endpoints (create, edit, add members, et
 | Field     | Type                                                                  | Description                                |
 | :-------- | :-------------------------------------------------------------------- | :----------------------------------------- |
 | groupId   | integer                                                               | The group's ID.                            |
-| playerId  | integer                                                               | The players's ID.                          |
-| type      | [ActivityType](/groups-api/group-type-definitions#enum-activity-type) | The type of activity                       |
+| playerId  | integer                                                               | The player's ID.                           |
+| type      | [ActivityType](/groups-api/group-type-definitions#enum-activity-type) | The type of activity.                      |
 | role      | [GroupRole](/groups-api/group-type-definitions#enum-group-role)?      | The player's role (rank) in the group.     |
 | createdAt | date                                                                  | The date at which the activity happened.   |
 | player    | [Player](/players-api/player-type-definitions#object-player)          | The activity entry's parent player object. |

--- a/docs/docs/groups-api/group-type-definitions.md
+++ b/docs/docs/groups-api/group-type-definitions.md
@@ -275,13 +275,13 @@ Used as an input for group modification endpoints (create, edit, add members, et
 
 ### `(Object)` Group Activity
 
-| Field     | Type                                                                  | Description                              |
-| :-------- | :-------------------------------------------------------------------- | :--------------------------------------- |
-| groupId   | integer                                                               | The group's ID.                          |
-| playerId  | integer                                                               | The players's ID.                        |
-| type      | [ActivityType](/groups-api/group-type-definitions#enum-activity-type) | The type of activity                     |
-| role      | [GroupRole](/groups-api/group-type-definitions#enum-group-role)?      | The player's role (rank) in the group.   |
-| createdAt | date                                                                  | The date at which the activity happened. |
-| player    | [Player](/players-api/player-type-definitions#object-player)          | The activity entry's parent player ID.   |
+| Field     | Type                                                                  | Description                                |
+| :-------- | :-------------------------------------------------------------------- | :----------------------------------------- |
+| groupId   | integer                                                               | The group's ID.                            |
+| playerId  | integer                                                               | The players's ID.                          |
+| type      | [ActivityType](/groups-api/group-type-definitions#enum-activity-type) | The type of activity                       |
+| role      | [GroupRole](/groups-api/group-type-definitions#enum-group-role)?      | The player's role (rank) in the group.     |
+| createdAt | date                                                                  | The date at which the activity happened.   |
+| player    | [Player](/players-api/player-type-definitions#object-player)          | The activity entry's parent player object. |
 
 <br />

--- a/docs/docs/groups-api/group-type-definitions.md
+++ b/docs/docs/groups-api/group-type-definitions.md
@@ -15,6 +15,14 @@ sidebar_position: 1
 
 <br />
 
+### (`Enum`) Activity Type
+
+```bash
+'joined', 'left', 'changed_role'
+```
+
+<br />
+
 ### `(Object)` Group
 
 | Field       | Type    | Description                              |
@@ -264,5 +272,16 @@ Used as an input for group modification endpoints (create, edit, add members, et
   }
 }
 ```
+
+### `(Object)` Group Activity
+
+| Field     | Type                                                                  | Description                              |
+| :-------- | :-------------------------------------------------------------------- | :--------------------------------------- |
+| groupId   | integer                                                               | The group's ID.                          |
+| playerId  | integer                                                               | The players's ID.                        |
+| type      | [ActivityType](/groups-api/group-type-definitions#enum-activity-type) | The type of activity                     |
+| role      | [GroupRole](/groups-api/group-type-definitions#enum-group-role)?      | The player's role (rank) in the group.   |
+| createdAt | date                                                                  | The date at which the activity happened. |
+| player    | [Player](/players-api/player-type-definitions#object-player)          | The activity entry's parent player ID.   |
 
 <br />

--- a/server/__tests__/suites/integration/groups.test.ts
+++ b/server/__tests__/suites/integration/groups.test.ts
@@ -1993,7 +1993,97 @@ describe('Group API', () => {
     });
   });
 
-  describe('11 - View Statistics', () => {
+  describe('11 - View Group Activity', () => {
+    it('should not view group activity (group not found)', async () => {
+      const response = await api.get(`/groups/100000/activity`);
+
+      expect(response.status).toBe(404);
+      expect(response.body.message).toBe('Group not found.');
+    });
+
+    it('should view group activity (empty)', async () => {
+      const response = await api.get(`/groups/${globalData.testGroupNoMembers.id}/activity`);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual([]);
+    });
+
+    it('should view group activity', async () => {
+      const response = await api.get(`/groups/${globalData.testGroupOneLeader.id}/activity`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.length).toBe(6);
+
+      // These activities where previously created during the "should edit members list" step
+
+      expect(response.body[0]).toMatchObject({
+        player: { username: 'test player' },
+        role: null,
+        type: 'left'
+      });
+
+      expect(response.body[1]).toMatchObject({
+        player: { username: 'alt player' },
+        role: null,
+        type: 'left'
+      });
+
+      expect(response.body[2]).toMatchObject({
+        player: { username: 'psikoi' },
+        role: null,
+        type: 'joined'
+      });
+
+      expect(response.body[3]).toMatchObject({
+        player: { username: 'alexsuperfly' },
+        role: null,
+        type: 'joined'
+      });
+
+      expect(response.body[4]).toMatchObject({
+        player: { username: 'rorro' },
+        role: null,
+        type: 'joined'
+      });
+
+      expect(response.body[5]).toMatchObject({
+        player: { username: 'zezima' },
+        role: 'firemaker',
+        type: 'changed_role'
+      });
+    });
+
+    it('should view group activity (w/ pagination)', async () => {
+      const response = await api
+        .get(`/groups/${globalData.testGroupOneLeader.id}/activity`)
+        .query({ limit: 3, offset: 2 });
+
+      expect(response.status).toBe(200);
+      expect(response.body.length).toBe(3);
+
+      // These activities where previously created during the "should edit members list" step
+
+      expect(response.body[0]).toMatchObject({
+        player: { username: 'psikoi' },
+        role: null,
+        type: 'joined'
+      });
+
+      expect(response.body[1]).toMatchObject({
+        player: { username: 'alexsuperfly' },
+        role: null,
+        type: 'joined'
+      });
+
+      expect(response.body[2]).toMatchObject({
+        player: { username: 'rorro' },
+        role: null,
+        type: 'joined'
+      });
+    });
+  });
+
+  describe('12 - View Statistics', () => {
     it('should not view statistics (group not found)', async () => {
       const response = await api.get(`/groups/100000/statistics`);
 
@@ -2085,7 +2175,7 @@ describe('Group API', () => {
     });
   });
 
-  describe('12 - Update All', () => {
+  describe('13 - Update All', () => {
     it('should not update all (invalid verification code)', async () => {
       const response = await api.post(`/groups/123456789/update-all`);
 
@@ -2140,7 +2230,7 @@ describe('Group API', () => {
     });
   });
 
-  describe('13 - Reset Verification Code', () => {
+  describe('14 - Reset Verification Code', () => {
     it('should not reset code (invalid admin password)', async () => {
       const response = await api.put(`/groups/100000/reset-code`);
 
@@ -2194,7 +2284,7 @@ describe('Group API', () => {
     });
   });
 
-  describe('14 - Verify', () => {
+  describe('15 - Verify', () => {
     it('should not verify group (invalid admin password)', async () => {
       const response = await api.put(`/groups/100000/verify`);
 
@@ -2234,7 +2324,7 @@ describe('Group API', () => {
     });
   });
 
-  describe('15 - Migrate from Temple', () => {
+  describe('16 - Migrate from Temple', () => {
     it('should not migrate from temple (404 error)', async () => {
       // Setup the TempleOSRS request to return our mock raw data
       registerTempleMock(axiosMock, 404);
@@ -2266,7 +2356,7 @@ describe('Group API', () => {
     });
   });
 
-  describe('16 - Migrate from CML', () => {
+  describe('17 - Migrate from CML', () => {
     it('should not migrate from cml (404 error)', async () => {
       // Setup the CML request to return our mock raw data
       registerCMLMock(axiosMock, 404);

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.3.29",
+  "version": "2.4.0",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/prisma/migrations/20231024131326_add_member_activity_foreign_keys/migration.sql
+++ b/server/prisma/migrations/20231024131326_add_member_activity_foreign_keys/migration.sql
@@ -1,0 +1,5 @@
+-- AddForeignKey
+ALTER TABLE "member_activity" ADD CONSTRAINT "member_activity_groupId_fkey" FOREIGN KEY ("groupId") REFERENCES "groups"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE "member_activity" ADD CONSTRAINT "member_activity_playerId_fkey" FOREIGN KEY ("playerId") REFERENCES "players"("id") ON DELETE CASCADE ON UPDATE NO ACTION;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -190,6 +190,7 @@ model Group {
   // Relations
   competitions Competition[]
   memberships  Membership[]
+  memberActivity MemberActivity[]
 
   // Constraints
   @@unique([name], map: "groups_name_key")
@@ -291,6 +292,7 @@ model Player {
   records        Record[]
   snapshots      Snapshot[]
   archives       PlayerArchive[]
+  memberActivity MemberActivity[]
 
   // Indices
   @@index([build], map: "players_build")
@@ -555,6 +557,10 @@ model MemberActivity {
   type      ActivityType
   role      GroupRole?
   createdAt DateTime     @default(now()) @db.Timestamptz(6)
+
+  // Relations
+  group Group @relation(fields: [groupId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  player Player @relation(fields: [playerId], references: [id], onDelete: Cascade, onUpdate: NoAction)
 
   // Constraints
   @@id([groupId, playerId, createdAt])

--- a/server/src/api/modules/groups/group.controller.ts
+++ b/server/src/api/modules/groups/group.controller.ts
@@ -196,6 +196,17 @@ async function competitions(req: Request): Promise<ControllerResponse> {
   return { statusCode: 200, response: results };
 }
 
+// GET /groups/:id/activities
+async function activities(req: Request): Promise<ControllerResponse> {
+  const results = await groupServices.fetchGroupActivities({
+    groupId: getNumber(req.params.id),
+    limit: getNumber(req.query.limit),
+    offset: getNumber(req.query.offset)
+  });
+
+  return { statusCode: 200, response: results };
+}
+
 // GET /groups/:id/gained
 async function gained(req: Request): Promise<ControllerResponse> {
   const results = await deltaServices.findGroupDeltas({
@@ -302,6 +313,7 @@ export {
   nameChanges,
   statistics,
   competitions,
+  activities,
   addMembers,
   removeMembers,
   migrateTemple,

--- a/server/src/api/modules/groups/group.controller.ts
+++ b/server/src/api/modules/groups/group.controller.ts
@@ -196,9 +196,9 @@ async function competitions(req: Request): Promise<ControllerResponse> {
   return { statusCode: 200, response: results };
 }
 
-// GET /groups/:id/activities
-async function activities(req: Request): Promise<ControllerResponse> {
-  const results = await groupServices.fetchGroupActivities({
+// GET /groups/:id/activity
+async function activity(req: Request): Promise<ControllerResponse> {
+  const results = await groupServices.fetchGroupActivity({
     groupId: getNumber(req.params.id),
     limit: getNumber(req.query.limit),
     offset: getNumber(req.query.offset)
@@ -313,7 +313,7 @@ export {
   nameChanges,
   statistics,
   competitions,
-  activities,
+  activity,
   addMembers,
   removeMembers,
   migrateTemple,

--- a/server/src/api/modules/groups/group.routes.ts
+++ b/server/src/api/modules/groups/group.routes.ts
@@ -26,7 +26,7 @@ api.get('/:id/records', setupController(controller.records));
 api.get('/:id/hiscores', setupController(controller.hiscores));
 api.get('/:id/name-changes', setupController(controller.nameChanges));
 api.get('/:id/statistics', setupController(controller.statistics));
-api.get('/:id/activities', setupController(controller.activities));
+api.get('/:id/activity', setupController(controller.activity));
 
 api.get('/migrate/temple/:id', setupController(controller.migrateTemple));
 api.get('/migrate/cml/:id', setupController(controller.migrateCML));

--- a/server/src/api/modules/groups/group.routes.ts
+++ b/server/src/api/modules/groups/group.routes.ts
@@ -26,6 +26,7 @@ api.get('/:id/records', setupController(controller.records));
 api.get('/:id/hiscores', setupController(controller.hiscores));
 api.get('/:id/name-changes', setupController(controller.nameChanges));
 api.get('/:id/statistics', setupController(controller.statistics));
+api.get('/:id/activities', setupController(controller.activities));
 
 api.get('/migrate/temple/:id', setupController(controller.migrateTemple));
 api.get('/migrate/cml/:id', setupController(controller.migrateCML));

--- a/server/src/api/modules/groups/group.services.ts
+++ b/server/src/api/modules/groups/group.services.ts
@@ -13,4 +13,4 @@ export * from './services/ResetGroupCodeService';
 export * from './services/SearchGroupsService';
 export * from './services/UpdateAllMembersService';
 export * from './services/VerifyGroupService';
-export * from './services/FetchGroupActivitiesService';
+export * from './services/FetchGroupActivityService';

--- a/server/src/api/modules/groups/group.services.ts
+++ b/server/src/api/modules/groups/group.services.ts
@@ -13,3 +13,4 @@ export * from './services/ResetGroupCodeService';
 export * from './services/SearchGroupsService';
 export * from './services/UpdateAllMembersService';
 export * from './services/VerifyGroupService';
+export * from './services/FetchGroupActivitiesService';

--- a/server/src/api/modules/groups/group.types.ts
+++ b/server/src/api/modules/groups/group.types.ts
@@ -87,7 +87,7 @@ export type MemberJoinedEvent = Omit<MemberActivity, 'createdAt'>;
 
 export type MemberLeftEvent = Omit<MemberActivity, 'createdAt' | 'role'>;
 
-export type GroupActivityType = MemberActivity & {
+export type MemberActivityWithPlayer = MemberActivity & {
   player: Player;
 };
 

--- a/server/src/api/modules/groups/group.types.ts
+++ b/server/src/api/modules/groups/group.types.ts
@@ -87,4 +87,8 @@ export type MemberJoinedEvent = Omit<MemberActivity, 'createdAt'>;
 
 export type MemberLeftEvent = Omit<MemberActivity, 'createdAt' | 'role'>;
 
+export type GroupActivityType = MemberActivity & {
+  player: Player;
+};
+
 export { Group, Membership, MemberActivity };

--- a/server/src/api/modules/groups/services/FetchGroupActivitiesService.ts
+++ b/server/src/api/modules/groups/services/FetchGroupActivitiesService.ts
@@ -1,0 +1,55 @@
+import { z } from 'zod';
+import { PAGINATION_SCHEMA } from '../../../util/validation';
+import { GroupActivityType } from '../group.types';
+import prisma from '../../../../prisma';
+import { NotFoundError } from '../../../errors';
+import * as playerSevice from '../../players/player.services';
+
+const inputSchema = z
+  .object({
+    groupId: z.number().positive()
+  })
+  .merge(PAGINATION_SCHEMA);
+
+type FetchGroupActivitiesParams = z.infer<typeof inputSchema>;
+
+async function fetchGroupActivities(payload: FetchGroupActivitiesParams): Promise<GroupActivityType[]> {
+  const params = inputSchema.parse(payload);
+
+  const activities = await prisma.memberActivity.findMany({
+    where: { groupId: params.groupId },
+    orderBy: { createdAt: 'desc' },
+    take: params.limit,
+    skip: params.offset
+  });
+
+  if (!activities || activities.length === 0) {
+    const group = await prisma.group.findFirst({
+      where: { id: params.groupId }
+    });
+
+    if (!group) {
+      throw new NotFoundError('Group not found');
+    }
+    return [];
+  }
+
+  const players = await playerSevice.findPlayers({
+    ids: activities.map(activity => activity.playerId)
+  });
+
+  const result = activities.map(activity => {
+    return {
+      groupId: activity.groupId,
+      playerId: activity.playerId,
+      type: activity.type,
+      role: activity.role,
+      createdAt: activity.createdAt,
+      player: players.find(p => p.id === activity.playerId)
+    };
+  });
+
+  return result;
+}
+
+export { fetchGroupActivities };

--- a/server/src/api/modules/groups/services/FetchGroupActivityService.ts
+++ b/server/src/api/modules/groups/services/FetchGroupActivityService.ts
@@ -3,7 +3,6 @@ import { PAGINATION_SCHEMA } from '../../../util/validation';
 import { MemberActivityWithPlayer } from '../group.types';
 import prisma from '../../../../prisma';
 import { NotFoundError } from '../../../errors';
-import * as playerSevice from '../../players/player.services';
 
 const inputSchema = z
   .object({
@@ -18,6 +17,9 @@ async function fetchGroupActivity(payload: FetchGroupActivityParams): Promise<Me
 
   const activities = await prisma.memberActivity.findMany({
     where: { groupId: params.groupId },
+    include: {
+      player: true
+    },
     orderBy: { createdAt: 'desc' },
     take: params.limit,
     skip: params.offset
@@ -34,22 +36,7 @@ async function fetchGroupActivity(payload: FetchGroupActivityParams): Promise<Me
     return [];
   }
 
-  const players = await playerSevice.findPlayers({
-    ids: activities.map(activity => activity.playerId)
-  });
-
-  const result = activities.map(activity => {
-    return {
-      groupId: activity.groupId,
-      playerId: activity.playerId,
-      type: activity.type,
-      role: activity.role,
-      createdAt: activity.createdAt,
-      player: players.find(p => p.id === activity.playerId)
-    };
-  });
-
-  return result;
+  return activities;
 }
 
 export { fetchGroupActivity };

--- a/server/src/api/modules/groups/services/FetchGroupActivityService.ts
+++ b/server/src/api/modules/groups/services/FetchGroupActivityService.ts
@@ -31,7 +31,7 @@ async function fetchGroupActivity(payload: FetchGroupActivityParams): Promise<Me
     });
 
     if (!group) {
-      throw new NotFoundError('Group not found');
+      throw new NotFoundError('Group not found.');
     }
     return [];
   }

--- a/server/src/api/modules/groups/services/FetchGroupActivityService.ts
+++ b/server/src/api/modules/groups/services/FetchGroupActivityService.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { PAGINATION_SCHEMA } from '../../../util/validation';
-import { GroupActivityType } from '../group.types';
+import { MemberActivityWithPlayer } from '../group.types';
 import prisma from '../../../../prisma';
 import { NotFoundError } from '../../../errors';
 import * as playerSevice from '../../players/player.services';
@@ -11,9 +11,9 @@ const inputSchema = z
   })
   .merge(PAGINATION_SCHEMA);
 
-type FetchGroupActivitiesParams = z.infer<typeof inputSchema>;
+type FetchGroupActivityParams = z.infer<typeof inputSchema>;
 
-async function fetchGroupActivities(payload: FetchGroupActivitiesParams): Promise<GroupActivityType[]> {
+async function fetchGroupActivity(payload: FetchGroupActivityParams): Promise<MemberActivityWithPlayer[]> {
   const params = inputSchema.parse(payload);
 
   const activities = await prisma.memberActivity.findMany({
@@ -52,4 +52,4 @@ async function fetchGroupActivities(payload: FetchGroupActivitiesParams): Promis
   return result;
 }
 
-export { fetchGroupActivities };
+export { fetchGroupActivity };


### PR DESCRIPTION
### Need to add tests before merge!

Adds `GET /groups/:id/activity` to the API.

- [x] Endpoint
- [x] Documentation
- [x] client-js
- [x] Tests