### PR TITLE
[v2 App] Add RuneLite link redirects

### DIFF
--- a/app-v2/next.config.js
+++ b/app-v2/next.config.js
@@ -31,6 +31,12 @@ const nextConfig = withBundleAnalyzer(
           destination: "/ehb/main",
           permanent: true,
         },
+        // RuneLite link redirects (old app's url format -> new app's url format)
+        {
+          source: "/players/:username/gained/skilling",
+          destination: "/players/:username/gained",
+          permanent: true,
+        },
       ];
     },
   })


### PR DESCRIPTION
RuneLite's xp tracker plugin has a "Open Wise Old Man" option which links to

`/players/:username/gained/skilling?...`

That last segment no longer exists on the new app, so these links would be broken when v2 gets promoted to production. To ensure all links will continue to work on outdated clients, I've added a redirect from the old url format, to the new one.

It's now just

`/players/:username/gained?...`