### PR TITLE
Allow configurable base api url in client app

### DIFF
--- a/app/src/services/wiseoldman.ts
+++ b/app/src/services/wiseoldman.ts
@@ -21,6 +21,7 @@ import { notFound } from "next/navigation";
 export const apiClient = new WOMClient({
   userAgent: "Wise Old Man App (v2)",
   apiKey: process.env.APP_API_KEY,
+  baseAPIUrl: process.env.BASE_API_URL ?? "https://api.wiseoldman.net/v2",
 });
 
 export type TimeRangeFilter = { period: Period } | { startDate: Date; endDate: Date };


### PR DESCRIPTION
The `BASE_API_URL` env var was not being respected when sending requests to the back end.