### PR TITLE
[api] Add rank to snapshots timeline endpoint

### DIFF
--- a/client-js/package-lock.json
+++ b/client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wise-old-man/utils",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "license": "ISC",
       "dependencies": {
         "dayjs": "^1.11.5"

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "A JavaScript/TypeScript client that interfaces and consumes the Wise Old Man API, an API that tracks and measures players' progress in Old School Runescape.",
   "keywords": [
     "wiseoldman",

--- a/client-js/src/clients/PlayersClient.ts
+++ b/client-js/src/clients/PlayersClient.ts
@@ -147,13 +147,13 @@ export default class PlayersClient extends BaseAPIClient {
 
   /**
    * Fetches all of the player's past snapshots' timeline.
-   * @returns A list of timeseries data (value, date)
+   * @returns A list of timeseries data (value, rank, date)
    */
   getPlayerSnapshotTimeline(username: string, metric: Metric, options?: TimeRangeFilter) {
-    return this.getRequest<{ value: number; date: Date }[]>(`/players/${username}/snapshots/timeline`, {
-      ...options,
-      metric
-    });
+    return this.getRequest<{ value: number; rank: number; date: Date }[]>(
+      `/players/${username}/snapshots/timeline`,
+      { ...options, metric }
+    );
   }
 
   /**

--- a/docs/docs/players-api/player-endpoints.mdx
+++ b/docs/docs/players-api/player-endpoints.mdx
@@ -1332,14 +1332,17 @@ const snapshots = await client.players.getPlayerSnapshotTimeline('zezima', Metri
 [
   {
     "value": 19314798,
+    "rank": 804785,
     "date": "2023-06-15T06:45:08.867Z"
   },
   {
     "value": 19221704,
+    "rank": 803572,
     "date": "2023-06-14T11:13:36.000Z"
   },
   {
     "value": 19219580,
+    "rank": 802829,
     "date": "2023-06-13T23:58:48.000Z"
   }
 ]

--- a/docs/docs/players-api/player-type-definitions.md
+++ b/docs/docs/players-api/player-type-definitions.md
@@ -189,6 +189,7 @@ Although this type mostly extends from [Achievement](/players-api/player-type-de
 | Field | Type   | Description                                                            |
 | :---- | :----- | :--------------------------------------------------------------------- |
 | value | number | The player's value for a specific metric, at a specific point in time. |
+| rank  | number | The player's rank for a specific metric, at a specific point in time.  |
 | date  | date   | The date at which the datapoint was recorded.                          |
 
 <br />

--- a/server/__tests__/suites/integration/players.test.ts
+++ b/server/__tests__/suites/integration/players.test.ts
@@ -964,6 +964,7 @@ describe('Player API', () => {
         expect(snapshotsTimelineResponse.body[i].value).toBe(
           snapshotsResponse.body[i].data.skills.magic.experience
         );
+        expect(snapshotsTimelineResponse.body[i].rank).toBe(snapshotsResponse.body[i].data.skills.magic.rank);
         expect(snapshotsTimelineResponse.body[i].date).toBe(snapshotsResponse.body[i].createdAt);
       }
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.4.3",
+      "version": "2.4.4",
       "license": "ISC",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",


### PR DESCRIPTION
Adds `rank` to the `/players/:username/snapshots/timeline` endpoint.

```diff
[
  {
    "value": 19314798,
+   "rank": 804785,
    "date": "2023-06-15T06:45:08.867Z"
  },
  {
    "value": 19221704,
+   "rank": 803572,
    "date": "2023-06-14T11:13:36.000Z"
  },
  {
    "value": 19219580,
+   "rank": 802829,
    "date": "2023-06-13T23:58:48.000Z"
  }
]
```

@Jonxslays 