### PR TITLE
[api] Disable Patreon sync Discord webhooks

### DIFF
--- a/server/src/api/jobs/instances/SyncPatronsJob.ts
+++ b/server/src/api/jobs/instances/SyncPatronsJob.ts
@@ -1,7 +1,6 @@
 import env from '../../../env';
 import prisma, { Patron } from '../../../prisma';
 import { getPatrons } from '../../services/external/patreon.service';
-import { sendPatreonUpdateMessage } from '../../services/external/discord.service';
 import { JobType, JobDefinition } from '../job.types';
 
 class SyncPatronsJob implements JobDefinition<unknown> {
@@ -117,16 +116,6 @@ class SyncPatronsJob implements JobDefinition<unknown> {
           patron: false
         }
       });
-    });
-
-    toAdd.forEach(p => {
-      const discordTag = p.discordId ? `<@${p.discordId}>` : '';
-      sendPatreonUpdateMessage(`**🎉 New Patron:** ${p.name} (T${p.tier}) - ${discordTag}`);
-    });
-
-    toDelete.forEach(p => {
-      const discordTag = p.discordId ? `<@${p.discordId}>` : '';
-      sendPatreonUpdateMessage(`**😢 Patron canceled:** ${p.name} (T${p.tier}) - ${discordTag}`);
     });
   }
 }

--- a/server/src/api/services/external/discord.service.ts
+++ b/server/src/api/services/external/discord.service.ts
@@ -24,19 +24,7 @@ function sendMonitoringMessage(text: string, tagAdmin?: boolean) {
   }
 
   const webhookClient = new WebhookClient({ url: env.DISCORD_MONITORING_WEBHOOK_URL });
-  return webhookClient.send({ content: `${text} ${tagAdmin ? '<@329256344798494773>' : ''}` });
-}
-
-function sendPatreonUpdateMessage(text: string) {
-  if (isTesting()) return;
-
-  if (!env.DISCORD_PATREON_WEBHOOK_URL) {
-    logger.error('Missing Discord Patreon Webhook URL.');
-    return;
-  }
-
-  const webhookClient = new WebhookClient({ url: env.DISCORD_PATREON_WEBHOOK_URL });
-  return webhookClient.send({ content: text });
+  return webhookClient.send({ content: `(League) ${text} ${tagAdmin ? '<@329256344798494773>' : ''}` });
 }
 
 /**
@@ -244,7 +232,6 @@ function dispatchCompetitionEnding(competition: Competition, period: EventPeriod
 
 export {
   sendMonitoringMessage,
-  sendPatreonUpdateMessage,
   dispatch,
   dispatchAchievements,
   dispatchHardcoreDied,


### PR DESCRIPTION
The patreon webhook is sending duplicate messages to our Discord (from both APIs), this disables the messages from the League API.