### PR TITLE
[api] Add levels diff to competition details api

### DIFF
--- a/client-js/package-lock.json
+++ b/client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wise-old-man/utils",
-      "version": "3.1.3",
+      "version": "3.1.4",
       "license": "ISC",
       "dependencies": {
         "dayjs": "^1.11.5"

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "A JavaScript/TypeScript client that interfaces and consumes the Wise Old Man API, an API that tracks and measures players' progress in Old School Runescape.",
   "keywords": [
     "wiseoldman",

--- a/docs/docs/competitions-api/competition-type-definitions.md
+++ b/docs/docs/competitions-api/competition-type-definitions.md
@@ -33,6 +33,16 @@ sidebar_position: 1
 
 <br />
 
+### `(Object)` Competition Levels Progress
+
+| Field  | Type    | Description                                            |
+| :----- | :------ | :----------------------------------------------------- |
+| start  | integer | A player's start level for the competition's metric.   |
+| end    | integer | A player's end level for the competition's metric.     |
+| gained | integer | A player's gained levels for the competition's metric. |
+
+<br />
+
 ### `(Object)` Competition
 
 | Field            | Type                                                                                    | Description                                     |
@@ -92,18 +102,20 @@ Returned in player-centric endpoints.
 
 > extends [PlayerParticipation](/competitions-api/competition-type-definitions#object-player-participation)
 
-| Field    | Type                                                                                                     | Description                               |
-| :------- | :------------------------------------------------------------------------------------------------------- | :---------------------------------------- |
-| progress | [CompetitionProgress](/competitions-api/competition-type-definitions#object-competition-player-progress) | The player's progress in the competition. |
-| rank     | number                                                                                                   | The player's rank in the competition.     |
+| Field    | Type                                                                                                           | Description                                                                             |
+| :------- | :------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------- |
+| progress | [CompetitionProgress](/competitions-api/competition-type-definitions#object-competition-player-progress)       | The player's progress in the competition.                                               |
+| levels   | [CompetitionLevelProgress](/competitions-api/competition-type-definitions#object-competition-levels-progress)? | The player's levels progress in the competition. (Only exists in skilling competitions) |
+| rank     | number                                                                                                         | The player's rank in the competition.                                                   |
 
 ### `(Object)` Competition Participation Details
 
 > extends [CompetitionParticipation](/competitions-api/competition-type-definitions#object-competition-participation)
 
-| Field    | Type                                                                                                     | Description                               |
-| :------- | :------------------------------------------------------------------------------------------------------- | :---------------------------------------- |
-| progress | [CompetitionProgress](/competitions-api/competition-type-definitions#object-competition-player-progress) | The player's progress in the competition. |
+| Field    | Type                                                                                                           | Description                                                                             |
+| :------- | :------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------- |
+| progress | [CompetitionProgress](/competitions-api/competition-type-definitions#object-competition-player-progress)       | The player's progress in the competition.                                               |
+| levels   | [CompetitionLevelProgress](/competitions-api/competition-type-definitions#object-competition-levels-progress)? | The player's levels progress in the competition. (Only exists in skilling competitions) |
 
 <br />
 

--- a/server/__tests__/suites/integration/competitions.test.ts
+++ b/server/__tests__/suites/integration/competitions.test.ts
@@ -2421,26 +2421,31 @@ describe('Competition API', () => {
         player: { username: 'rorro' },
         progress: { start: 500, end: 557, gained: 57 }
       });
+      expect(response.body.participations[0].levels).toBeUndefined(); // shouldn't exist on a zulrah competition
 
       expect(response.body.participations[1]).toMatchObject({
         player: { username: 'usbc' },
         progress: { start: -1, end: 60, gained: 56 } // we start counting at 4 kc (min kc is 5)
       });
+      expect(response.body.participations[1].levels).toBeUndefined(); // shouldn't exist on a zulrah competition
 
       expect(response.body.participations[2]).toMatchObject({
         player: { username: 'lynx titan' },
         progress: { start: 1646, end: 1646, gained: 0 }
       });
+      expect(response.body.participations[2].levels).toBeUndefined(); // shouldn't exist on a zulrah competition
 
       expect(response.body.participations[3]).toMatchObject({
         player: { username: 'psikoi' },
         progress: { start: 1000, end: 1000, gained: 0 }
       });
+      expect(response.body.participations[3].levels).toBeUndefined(); // shouldn't exist on a zulrah competition
 
       expect(response.body.participations[4]).toMatchObject({
         player: { username: 'zulu' },
         progress: { start: -1, end: -1, gained: 0 }
       });
+      expect(response.body.participations[4].levels).toBeUndefined(); // shouldn't exist on a zulrah competition
     });
 
     it('should view details (other metric)', async () => {
@@ -2462,22 +2467,26 @@ describe('Competition API', () => {
 
       expect(response.body.participations[0]).toMatchObject({
         player: { username: 'psikoi' },
-        progress: { start: 500_000, end: 750_000, gained: 250_000 }
+        progress: { start: 500_000, end: 750_000, gained: 250_000 },
+        levels: { start: 66, end: 70, gained: 4 }
       });
 
       expect(response.body.participations[1]).toMatchObject({
         player: { username: 'rorro' },
-        progress: { start: 100_000, end: 110_000, gained: 10_000 }
+        progress: { start: 100_000, end: 110_000, gained: 10_000 },
+        levels: { start: 49, end: 50, gained: 1 }
       });
 
       expect(response.body.participations[2]).toMatchObject({
         player: { username: 'lynx titan' },
-        progress: { start: 5346679, end: 5346679, gained: 0 }
+        progress: { start: 5346679, end: 5346679, gained: 0 },
+        levels: { start: 90, end: 90, gained: 0 }
       });
 
       expect(response.body.participations[3]).toMatchObject({
         player: { username: 'usbc' },
-        progress: { start: 50_000, end: 50_000, gained: 0 }
+        progress: { start: 50_000, end: 50_000, gained: 0 },
+        levels: { start: 42, end: 42, gained: 0 }
       });
 
       expect(response.body.participations[4]).toMatchObject({

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.4.4",
+      "version": "2.4.5",
       "license": "ISC",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/modules/competitions/competition.types.ts
+++ b/server/src/api/modules/competitions/competition.types.ts
@@ -31,10 +31,12 @@ export interface ParticipationWithPlayer extends CleanParticipation {
 
 export interface ParticipationWithPlayerAndProgress extends ParticipationWithPlayer {
   progress: MeasuredDeltaProgress;
+  levels?: MeasuredDeltaProgress;
 }
 
 export interface ParticipationWithCompetitionAndStandings extends ParticipationWithCompetition {
   progress: MeasuredDeltaProgress;
+  levels?: MeasuredDeltaProgress;
   rank: number;
 }
 

--- a/server/src/api/modules/competitions/services/FindPlayerParticipationsStandingsService.ts
+++ b/server/src/api/modules/competitions/services/FindPlayerParticipationsStandingsService.ts
@@ -44,7 +44,8 @@ async function findPlayerParticipationsStandings(
       ...omit(participation, 'player'),
       competition: c.competition,
       rank: playerIndex + 1,
-      progress: participation.progress
+      progress: participation.progress,
+      levels: participation.levels
     };
   });
 

--- a/server/src/api/modules/deltas/delta.utils.ts
+++ b/server/src/api/modules/deltas/delta.utils.ts
@@ -161,7 +161,7 @@ function calculateEHBDiff(startSnapshot: Snapshot, endSnapshot: Snapshot, player
  * If the given skill is "overall", then it will calculate total levels from both snapshots,
  * by summing the levels of each individual skill.
  */
-function calculateLevelDiff(
+export function calculateLevelDiff(
   metric: Metric,
   startSnapshot: Snapshot,
   endSnapshot: Snapshot,

--- a/server/src/api/util/routing.ts
+++ b/server/src/api/util/routing.ts
@@ -7,7 +7,7 @@ interface ControllerResponse {
 }
 
 interface ControllerOptions {
-  logErrors?: false;
+  logErrors?: boolean;
   returnAsText?: boolean;
 }
 


### PR DESCRIPTION
Previously competitions couldn't show a "levels gained" for Overall exp because unlike other skills, total level cannot be computed from the exp alone, it needed to also fetch data for all other skills to compute levels.

This does that work and adds a new **optional** `levels` field in the competition details response.

**Example**

```diff
"participations": [
    {
      "playerId": 152210,
      "competitionId": 3000,
      "teamName": null,
      "createdAt": "2021-05-18T17:53:53.738Z",
      "updatedAt": "2021-05-26T02:17:45.183Z",
      "player": {
        "id": 152210,
        "username": "shneeb",
        "displayName": "Shneeb",
        "type": "regular",
        "build": "main",
        "status": "active",
        "country": null,
        "patron": false,
        "exp": 574657773,
        "ehp": 1000.23214,
        "ehb": 1515.45713,
        "ttm": 48.78496000000086,
        "tt200m": 11813.57615,
        "registeredAt": "2021-01-30T06:22:43.737Z",
        "updatedAt": "2023-09-20T17:42:34.552Z",
        "lastChangedAt": "2023-09-20T17:42:34.552Z",
        "lastImportedAt": "2022-02-16T17:38:47.036Z"
      },
      "progress": {
        "gained": 589116,
        "start": 668076,
        "end": 1257192
      },
+     "levels": {
+       "gained": 6,
+       "start": 69,
+       "end": 75
+     }
    }
]
```