### PR TITLE
[api] Duplicate new name changes and players on regular API

### DIFF
--- a/server/src/api/modules/name-changes/name-change.events.ts
+++ b/server/src/api/modules/name-changes/name-change.events.ts
@@ -1,7 +1,12 @@
+import axios from 'axios';
 import { NameChange } from '../../../prisma';
 
-async function onNameChangeSubmitted(_nameChange: NameChange) {
-  console.log('No auto-reviews during leagues.');
+async function onNameChangeSubmitted(nameChange: NameChange) {
+  // Submit this name on the regular API instead
+  await axios.post(`https://api.wiseoldman.net/v2/names`, {
+    oldName: nameChange.oldName,
+    newName: nameChange.newName
+  });
 }
 
 export { onNameChangeSubmitted };

--- a/server/src/api/modules/players/player.events.ts
+++ b/server/src/api/modules/players/player.events.ts
@@ -1,3 +1,4 @@
+import axios from 'axios';
 import { Snapshot, Player } from '../../../prisma';
 import { FlaggedPlayerReviewContext } from '../../../utils';
 import { jobManager, JobType } from '../../jobs';
@@ -49,9 +50,21 @@ async function onPlayerUpdated(
   await metrics.trackEffect(deltaServices.syncPlayerDeltas, player, current);
 }
 
+async function onPlayerRegistered(player: Player) {
+  // Track this player on the regular API too (useful for name change and flagged checks)
+  await axios.post(`https://api.wiseoldman.net/v2/players/${player.displayName}`);
+}
+
 async function onPlayerImported(playerId: number) {
   // Reevaluate this player's achievements to try and find earlier completion dates
   await metrics.trackEffect(achievementServices.reevaluatePlayerAchievements, { id: playerId });
 }
 
-export { onPlayerFlagged, onPlayerArchived, onPlayerNameChanged, onPlayerUpdated, onPlayerImported };
+export {
+  onPlayerRegistered,
+  onPlayerFlagged,
+  onPlayerArchived,
+  onPlayerNameChanged,
+  onPlayerUpdated,
+  onPlayerImported
+};

--- a/server/src/api/modules/players/services/UpdatePlayerService.ts
+++ b/server/src/api/modules/players/services/UpdatePlayerService.ts
@@ -34,6 +34,10 @@ async function updatePlayer(payload: UpdatePlayerParams): Promise<UpdatePlayerRe
   // Find a player with the given username or create a new one if needed
   const [player, isNew] = await findOrCreate(username);
 
+  if (isNew) {
+    playerEvents.onPlayerRegistered(player);
+  }
+
   if (player.status === PlayerStatus.ARCHIVED) {
     throw new BadRequestError('Failed to update: Player is archived.');
   }


### PR DESCRIPTION
Name changes can't be reliably verified on the league API since the exp modifiers are all over the place, so instead, whenever a name change is submitted on the league API, we'll re-submit it on the regular API, and have the regular API verify it.

Whenever the regular API approves or denies the name change, it'll send a request back to the league API with the decision, this way both versions of the API should have name changes duplicated and synced. (This part is coming in the next PR)