### PR TITLE
[api] Add ranking score boosting for patron groups

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.6",
+  "version": "2.4.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.4.6",
+      "version": "2.4.7",
       "license": "ISC",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.6",
+  "version": "2.4.7",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/jobs/instances/UpdateGroupScoreJob.ts
+++ b/server/src/api/jobs/instances/UpdateGroupScoreJob.ts
@@ -88,6 +88,19 @@ async function calculateScore(group: GroupDetails): Promise<number> {
     score += 100;
   }
 
+  // If is a patreon supporter
+  if (group.patron) {
+    score += 50;
+
+    if (group.profileImage) {
+      score += 20;
+    }
+
+    if (group.bannerImage) {
+      score += 10;
+    }
+  }
+
   // If has atleast one ongoing competition
   if (competitions.filter(c => c.startsAt <= now && c.endsAt >= now).length >= 1) {
     score += 50;


### PR DESCRIPTION
Adds 50 to 80 extra score points to patron groups. This score is used to sort groups on the "Groups" list page.