### PR TITLE
Add logic to enable official hiscore link to point to correct leaderboard (#1334)

### DIFF
--- a/app/src/app/players/[username]/layout.tsx
+++ b/app/src/app/players/[username]/layout.tsx
@@ -313,21 +313,14 @@ function PlayerAttributes(props: PlayerDetails) {
 }
 
 function getHiscoresURL(displayName: string, playerType: PlayerType) {
-  let url: string;
-
   switch (playerType) {
     case PlayerType.HARDCORE:
-      url = `https://secure.runescape.com/m=hiscore_oldschool_hardcore_ironman/hiscorepersonal.ws?user1=${displayName}`;
-      break;
+      return `https://secure.runescape.com/m=hiscore_oldschool_hardcore_ironman/hiscorepersonal.ws?user1=${displayName}`;
     case PlayerType.IRONMAN:
-      url = `https://secure.runescape.com/m=hiscore_oldschool_ironman/hiscorepersonal.ws?user1=${displayName}`;
-      break;
+      return `https://secure.runescape.com/m=hiscore_oldschool_ironman/hiscorepersonal.ws?user1=${displayName}`;
     case PlayerType.ULTIMATE:
-      url = `https://secure.runescape.com/m=hiscore_oldschool_ultimate/hiscorepersonal.ws?user1=${displayName}`;
-      break;
+      return `https://secure.runescape.com/m=hiscore_oldschool_ultimate/hiscorepersonal.ws?user1=${displayName}`;
     default:
-      url = `https://secure.runescape.com/m=hiscore_oldschool/hiscorepersonal.ws?user1=${displayName}`;
+      return `https://secure.runescape.com/m=hiscore_oldschool/hiscorepersonal.ws?user1=${displayName}`;
   }
-
-  return url;
 }

--- a/app/src/app/players/[username]/layout.tsx
+++ b/app/src/app/players/[username]/layout.tsx
@@ -88,22 +88,6 @@ function Header(props: PlayerDetails) {
     icon = <PlayerTypeIcon playerType={type} className="scale-150 md:scale-[2]" />;
   }
 
-  let officialHiscoreUrl: string;
-
-  switch (type) {
-    case PlayerType.HARDCORE:
-      officialHiscoreUrl = `https://secure.runescape.com/m=hiscore_oldschool_hardcore_ironman/hiscorepersonal.ws?user1=${displayName}`;
-      break;
-    case PlayerType.IRONMAN:
-      officialHiscoreUrl = `https://secure.runescape.com/m=hiscore_oldschool_ironman/hiscorepersonal.ws?user1=${displayName}`;
-      break;
-    case PlayerType.ULTIMATE:
-      officialHiscoreUrl = `https://secure.runescape.com/m=hiscore_oldschool_ultimate/hiscorepersonal.ws?user1=${displayName}`;
-      break;
-    default:
-      officialHiscoreUrl = `https://secure.runescape.com/m=hiscore_oldschool/hiscorepersonal.ws?user1=${displayName}`;
-  }
-
   return (
     <div className="flex flex-col justify-between gap-y-7 md:flex-row-reverse md:items-end">
       <div className="flex shrink-0 items-center gap-x-2">
@@ -118,7 +102,7 @@ function Header(props: PlayerDetails) {
             <a
               target="_blank"
               rel="noopener noreferrer"
-              href={officialHiscoreUrl}
+              href={getHiscoresURL(displayName, type)}
             >
               <DropdownMenuItem>
                 Open Official Hiscores <ExternalIcon className="ml-2 h-4 w-4" />
@@ -326,4 +310,24 @@ function PlayerAttributes(props: PlayerDetails) {
       })}
     </>
   );
+}
+
+function getHiscoresURL(displayName: string, playerType: PlayerType) {
+  let url: string;
+
+  switch (playerType) {
+    case PlayerType.HARDCORE:
+      url = `https://secure.runescape.com/m=hiscore_oldschool_hardcore_ironman/hiscorepersonal.ws?user1=${displayName}`;
+      break;
+    case PlayerType.IRONMAN:
+      url = `https://secure.runescape.com/m=hiscore_oldschool_ironman/hiscorepersonal.ws?user1=${displayName}`;
+      break;
+    case PlayerType.ULTIMATE:
+      url = `https://secure.runescape.com/m=hiscore_oldschool_ultimate/hiscorepersonal.ws?user1=${displayName}`;
+      break;
+    default:
+      url = `https://secure.runescape.com/m=hiscore_oldschool/hiscorepersonal.ws?user1=${displayName}`;
+  }
+
+  return url;
 }

--- a/app/src/app/players/[username]/layout.tsx
+++ b/app/src/app/players/[username]/layout.tsx
@@ -6,6 +6,7 @@ import {
   PlayerBuildProps,
   PlayerDetails,
   PlayerStatus,
+  PlayerType,
   PlayerTypeProps,
 } from "@wise-old-man/utils";
 import { formatDatetime, timeago } from "~/utils/dates";
@@ -87,6 +88,22 @@ function Header(props: PlayerDetails) {
     icon = <PlayerTypeIcon playerType={type} className="scale-150 md:scale-[2]" />;
   }
 
+  let officialHiscoreUrl: string;
+
+  switch (type) {
+    case PlayerType.HARDCORE:
+      officialHiscoreUrl = `https://secure.runescape.com/m=hiscore_oldschool_hardcore_ironman/hiscorepersonal.ws?user1=${displayName}`;
+      break;
+    case PlayerType.IRONMAN:
+      officialHiscoreUrl = `https://secure.runescape.com/m=hiscore_oldschool_ironman/hiscorepersonal.ws?user1=${displayName}`;
+      break;
+    case PlayerType.ULTIMATE:
+      officialHiscoreUrl = `https://secure.runescape.com/m=hiscore_oldschool_ultimate/hiscorepersonal.ws?user1=${displayName}`;
+      break;
+    default:
+      officialHiscoreUrl = `https://secure.runescape.com/m=hiscore_oldschool/hiscorepersonal.ws?user1=${displayName}`;
+  }
+
   return (
     <div className="flex flex-col justify-between gap-y-7 md:flex-row-reverse md:items-end">
       <div className="flex shrink-0 items-center gap-x-2">
@@ -101,7 +118,7 @@ function Header(props: PlayerDetails) {
             <a
               target="_blank"
               rel="noopener noreferrer"
-              href={`https://secure.runescape.com/m=hiscore_oldschool/hiscorepersonal.ws?user1=${props.displayName}`}
+              href={officialHiscoreUrl}
             >
               <DropdownMenuItem>
                 Open Official Hiscores <ExternalIcon className="ml-2 h-4 w-4" />


### PR DESCRIPTION
This resolves #1334, just a small change but thought I may as well check it off while looking at the codebase.

It's worth noting that the official hiscore link will also need updating for the league branch as well.