### PR TITLE
[api] Remove "lost too much" player check

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.9",
+  "version": "2.4.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.4.9",
+      "version": "2.4.10",
       "license": "ISC",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.9",
+  "version": "2.4.10",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",


### PR DESCRIPTION
This check wasn't working as expected, it caused some people to get archived instead of flagged on a recent hiscores rollback, which means I'll have to manually unarchive, great.
 