### PR TITLE
[api] Auto update group score on edit

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.10",
+  "version": "2.4.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.4.10",
+      "version": "2.4.11",
       "license": "ISC",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.10",
+  "version": "2.4.11",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/jobs/instances/SyncPatronsJob.ts
+++ b/server/src/api/jobs/instances/SyncPatronsJob.ts
@@ -1,8 +1,9 @@
-import env from '../../../env';
+import env, { isDevelopment } from '../../../env';
 import prisma, { Patron } from '../../../prisma';
 import { getPatrons } from '../../services/external/patreon.service';
 import { sendPatreonUpdateMessage } from '../../services/external/discord.service';
 import { JobType, JobDefinition } from '../job.types';
+import { onGroupUpdated } from '../../modules/groups/group.events';
 
 class SyncPatronsJob implements JobDefinition<unknown> {
   type: JobType;
@@ -12,7 +13,7 @@ class SyncPatronsJob implements JobDefinition<unknown> {
   }
 
   async execute() {
-    if (!env.PATREON_BEARER_TOKEN) {
+    if (!env.PATREON_BEARER_TOKEN || isDevelopment()) {
       return;
     }
 
@@ -113,6 +114,13 @@ async function syncBenefits() {
   const patronGroupIds = updatedPatrons.map(p => p.groupId).filter((id): id is number => id !== null);
   const patronPlayerIds = updatedPatrons.map(p => p.playerId).filter((id): id is number => id !== null);
 
+  const newPatronGroups = await prisma.group.findMany({
+    where: {
+      id: { in: patronGroupIds },
+      patron: false
+    }
+  });
+
   await prisma.$transaction(async transaction => {
     // Every player who wasn't a patron and should be, becomes a patron
     await transaction.player.updateMany({
@@ -166,6 +174,10 @@ async function syncBenefits() {
         groupId: { notIn: patronGroupIds }
       }
     });
+  });
+
+  newPatronGroups.forEach(group => {
+    onGroupUpdated(group.id);
   });
 }
 

--- a/server/src/api/modules/groups/group.events.ts
+++ b/server/src/api/modules/groups/group.events.ts
@@ -5,6 +5,14 @@ import * as discordService from '../../services/external/discord.service';
 import * as playerServices from '../players/player.services';
 import * as competitionServices from '../competitions/competition.services';
 
+function onGroupUpdated(groupId: number) {
+  jobManager.add({ type: JobType.UPDATE_GROUP_SCORE, payload: { groupId } });
+}
+
+function onGroupCreated(groupId: number) {
+  jobManager.add({ type: JobType.UPDATE_GROUP_SCORE, payload: { groupId } });
+}
+
 async function onMembersRolesChanged(events: MemberRoleChangeEvent[]) {
   await metrics.trackEffect(discordService.dispatchMembersRolesChanged, events);
 }
@@ -43,4 +51,4 @@ async function onMembersLeft(events: MemberLeftEvent[]) {
   await metrics.trackEffect(discordService.dispatchMembersLeft, groupId, playerIds);
 }
 
-export { onMembersJoined, onMembersLeft, onMembersRolesChanged };
+export { onGroupCreated, onGroupUpdated, onMembersJoined, onMembersLeft, onMembersRolesChanged };

--- a/server/src/api/modules/groups/services/AddMembersService.ts
+++ b/server/src/api/modules/groups/services/AddMembersService.ts
@@ -103,6 +103,8 @@ async function addMembers(payload: AddMembersService): Promise<{ count: number }
       throw new ServerError('Failed to add members.');
     });
 
+  groupEvents.onGroupUpdated(params.id);
+
   logger.moderation(`[Group:${params.id}] (${newMemberships.map(m => m.playerId)}) joined`);
 
   return { count: addedCount };

--- a/server/src/api/modules/groups/services/CreateGroupService.ts
+++ b/server/src/api/modules/groups/services/CreateGroupService.ts
@@ -8,6 +8,7 @@ import { GroupDetails } from '../group.types';
 import { isValidUsername, sanitize, standardize } from '../../players/player.utils';
 import * as playerServices from '../../players/player.services';
 import { sanitizeName } from '../group.utils';
+import { onGroupCreated } from '../group.events';
 
 const MIN_NAME_ERROR = 'Group name must have at least one character.';
 
@@ -97,6 +98,8 @@ async function createGroup(payload: CreateGroupParams): Promise<CreateGroupResul
       }
     }
   });
+
+  onGroupCreated(createdGroup.id);
 
   const priorities = PRIVELEGED_GROUP_ROLES.reverse();
 

--- a/server/src/api/modules/groups/services/EditGroupService.ts
+++ b/server/src/api/modules/groups/services/EditGroupService.ts
@@ -14,7 +14,7 @@ import {
 import { isValidUsername, sanitize, standardize } from '../../players/player.utils';
 import * as playerServices from '../../players/player.services';
 import { sanitizeName } from '../group.utils';
-import { onMembersRolesChanged, onMembersJoined, onMembersLeft } from '../group.events';
+import { onMembersRolesChanged, onMembersJoined, onMembersLeft, onGroupUpdated } from '../group.events';
 
 const MIN_NAME_ERROR = 'Group name must have at least one character.';
 
@@ -111,6 +111,8 @@ async function editGroup(payload: EditGroupParams): Promise<GroupDetails> {
       socialLinks: true
     }
   });
+
+  onGroupUpdated(params.id);
 
   if (!updatedGroup) {
     throw new ServerError('Failed to edit group. (EditGroupService)');

--- a/server/src/api/modules/groups/services/RemoveMembersService.ts
+++ b/server/src/api/modules/groups/services/RemoveMembersService.ts
@@ -68,6 +68,7 @@ async function removeMembers(payload: RemoveMembersService): Promise<{ count: nu
       throw new ServerError('Failed to remove members');
     });
 
+  groupEvents.onGroupUpdated(params.id);
   groupEvents.onMembersLeft(newActivites);
 
   logger.moderation(`[Group:${params.id}] (${toRemovePlayerIds}) removed`);

--- a/server/src/api/modules/groups/services/VerifyGroupService.ts
+++ b/server/src/api/modules/groups/services/VerifyGroupService.ts
@@ -4,6 +4,7 @@ import { NotFoundError } from '../../../errors';
 import { omit } from '../../../util/objects';
 import logger from '../../../util/logging';
 import { GroupListItem } from '../group.types';
+import { onGroupUpdated } from '../group.events';
 
 const inputSchema = z.object({
   id: z.number().int().positive()
@@ -28,6 +29,8 @@ async function verifyGroup(payload: VerifyGroupService): Promise<GroupListItem> 
     });
 
     logger.moderation(`[Group:${params.id}] Verified`);
+
+    onGroupUpdated(params.id);
 
     return {
       ...omit(updatedGroup, '_count', 'verificationHash'),


### PR DESCRIPTION
When a group is edited (or verified, or becomes a patron), we now trigger a recalc of their score, which influences their ranking on the groups page.

So they should see their ranking change pretty much instantly if they become verified or become a patron, and that's nice.