### PR TITLE
[api] Add image and social link editing for patron groups

### DIFF
--- a/client-js/package-lock.json
+++ b/client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "3.1.7",
+  "version": "3.1.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wise-old-man/utils",
-      "version": "3.1.7",
+      "version": "3.1.8",
       "license": "ISC",
       "dependencies": {
         "dayjs": "^1.11.5"

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "3.1.7",
+  "version": "3.1.8",
   "description": "A JavaScript/TypeScript client that interfaces and consumes the Wise Old Man API, an API that tracks and measures players' progress in Old School Runescape.",
   "keywords": [
     "wiseoldman",

--- a/client-js/src/api-types.ts
+++ b/client-js/src/api-types.ts
@@ -1,3 +1,4 @@
+import { GroupSocialLinks } from '../../server/src/prisma';
 import {
   PlayerDeltasArray,
   PlayerDeltasMap,
@@ -58,7 +59,11 @@ export interface CreateGroupPayload {
   members: Array<GroupMemberFragment>;
 }
 
-export type EditGroupPayload = Partial<CreateGroupPayload>;
+export type EditGroupPayload = Partial<CreateGroupPayload> & {
+  bannerImage?: string;
+  profileImage?: string;
+  socialLinks?: Partial<GroupSocialLinks>;
+};
 
 export interface CreateGroupResponse {
   group: GroupDetails;

--- a/docs/docs/groups-api/group-endpoints.mdx
+++ b/docs/docs/groups-api/group-endpoints.mdx
@@ -401,17 +401,24 @@ Edit an existing group. Returns the updated [GroupDetails](/groups-api/group-typ
 
 **Body Params**
 
-| Field            | Type                                                                                       | Required | Description                    |
-| ---------------- | ------------------------------------------------------------------------------------------ | -------- | ------------------------------ |
-| name             | string?                                                                                    | `false`  | The group's name.              |
-| clanChat         | string?                                                                                    | `false`  | The group's clanChat.          |
-| description      | string?                                                                                    | `false`  | The group's description.       |
-| homeworld        | number?                                                                                    | `false`  | The group's homeworld.         |
-| members          | [GroupMemberFragment](/groups-api/group-type-definitions#object-group-member-fragment)[] ? | `false`  | The group's new members list.  |
-| verificationCode | string                                                                                     | `true`   | The group's verification code. |
+| Field            | Type                                                                                       | Required | Description                                             |
+| ---------------- | ------------------------------------------------------------------------------------------ | -------- | ------------------------------------------------------- |
+| name             | string?                                                                                    | `false`  | The group's name.                                       |
+| clanChat         | string?                                                                                    | `false`  | The group's clanChat.                                   |
+| description      | string?                                                                                    | `false`  | The group's description.                                |
+| homeworld        | number?                                                                                    | `false`  | The group's homeworld.                                  |
+| members          | [GroupMemberFragment](/groups-api/group-type-definitions#object-group-member-fragment)[] ? | `false`  | The group's new members list.                           |
+| bannerImage      | string?                                                                                    | `false`  | The group's banner image URL **(only patron groups)**.  |
+| profileImage     | string?                                                                                    | `false`  | The group's profile image URL **(only patron groups)**. |
+| socialLinks      | [GroupSocialLinks](/groups-api/group-type-definitions#object-groupsociallinks)?            | `false`  | The group's social links **(only patron groups)**.      |
+| verificationCode | string                                                                                     | `true`   | The group's verification code.                          |
 
 :::info
 Only the fields provided in the body params are updated.
+:::
+
+:::info
+Image urls (for `bannerImage` and `profileImage`) must be uploaded to WOM's image server first. We highly recommend editing images on the website instead.
 :::
 
 :::caution

--- a/docs/docs/groups-api/group-type-definitions.md
+++ b/docs/docs/groups-api/group-type-definitions.md
@@ -59,10 +59,10 @@ sidebar_position: 1
 
 > extends [Group](/groups-api/group-type-definitions#object-group)
 
-| Field       | Type                                                                                  | Description                                   |
-| :---------- | :------------------------------------------------------------------------------------ | :-------------------------------------------- |
-| memberships | [GroupMembership](/groups-api/group-type-definitions#object-group-membership)[]       | The group's memberships.                      |
-| socialLinks | [GroupSocialLinks](/groups-api/group-type-definitions#object-group-groupsociallinks)? | The group's social links (Patreon exclusive). |
+| Field       | Type                                                                            | Description                                   |
+| :---------- | :------------------------------------------------------------------------------ | :-------------------------------------------- |
+| memberships | [GroupMembership](/groups-api/group-type-definitions#object-group-membership)[] | The group's memberships.                      |
+| socialLinks | [GroupSocialLinks](/groups-api/group-type-definitions#object-groupsociallinks)? | The group's social links (Patreon exclusive). |
 
 <br />
 

--- a/server/__tests__/suites/integration/groups.test.ts
+++ b/server/__tests__/suites/integration/groups.test.ts
@@ -459,6 +459,98 @@ describe('Group API', () => {
       expect(onMembersJoinedEvent).not.toHaveBeenCalled();
     });
 
+    it('should not edit (invalid banner image url)', async () => {
+      const response = await api.put(`/groups/${globalData.testGroupNoMembers.id}`).send({
+        verificationCode: globalData.testGroupNoMembers.verificationCode,
+        bannerImage: 'wrong'
+      });
+
+      expect(response.status).toBe(400);
+      expect(response.body.message).toMatch('Invalid image URL.');
+
+      expect(onMembersLeftEvent).not.toHaveBeenCalled();
+      expect(onMembersJoinedEvent).not.toHaveBeenCalled();
+    });
+
+    it('should not edit (over max length for banner image url)', async () => {
+      let str = '';
+      for (let i = 0; i < 300; i++) {
+        str += '.';
+      }
+
+      const response = await api.put(`/groups/${globalData.testGroupNoMembers.id}`).send({
+        verificationCode: globalData.testGroupNoMembers.verificationCode,
+        bannerImage: str
+      });
+
+      expect(response.status).toBe(400);
+      expect(response.body.message).toMatch("Image URL can't be longer than 255 characters.");
+
+      expect(onMembersLeftEvent).not.toHaveBeenCalled();
+      expect(onMembersJoinedEvent).not.toHaveBeenCalled();
+    });
+
+    it('should not edit (invalid profile image url)', async () => {
+      const response = await api.put(`/groups/${globalData.testGroupNoMembers.id}`).send({
+        verificationCode: globalData.testGroupNoMembers.verificationCode,
+        profileImage: 'wrong'
+      });
+
+      expect(response.status).toBe(400);
+      expect(response.body.message).toMatch('Invalid image URL.');
+
+      expect(onMembersLeftEvent).not.toHaveBeenCalled();
+      expect(onMembersJoinedEvent).not.toHaveBeenCalled();
+    });
+
+    it('should not edit (over max length for profile image url)', async () => {
+      let str = '';
+      for (let i = 0; i < 300; i++) {
+        str += '.';
+      }
+
+      const response = await api.put(`/groups/${globalData.testGroupNoMembers.id}`).send({
+        verificationCode: globalData.testGroupNoMembers.verificationCode,
+        profileImage: str
+      });
+
+      expect(response.status).toBe(400);
+      expect(response.body.message).toMatch("Image URL can't be longer than 255 characters.");
+
+      expect(onMembersLeftEvent).not.toHaveBeenCalled();
+      expect(onMembersJoinedEvent).not.toHaveBeenCalled();
+    });
+
+    it('should not edit profile image (not a patron)', async () => {
+      const response = await api.put(`/groups/${globalData.testGroupNoMembers.id}`).send({
+        verificationCode: globalData.testGroupNoMembers.verificationCode,
+        profileImage: 'https://avatars.githubusercontent.com/u/65183441?s=200&v=4'
+      });
+
+      expect(response.status).toBe(400);
+      expect(response.body.message).toMatch(
+        'Banner or profile images can only be uploaded by patron groups.'
+      );
+
+      expect(onMembersLeftEvent).not.toHaveBeenCalled();
+      expect(onMembersJoinedEvent).not.toHaveBeenCalled();
+    });
+
+    it('should not edit banner image (not a patron)', async () => {
+      const response = await api.put(`/groups/${globalData.testGroupNoMembers.id}`).send({
+        verificationCode: globalData.testGroupNoMembers.verificationCode,
+        bannerImage: 'https://avatars.githubusercontent.com/u/65183441?s=200&v=4'
+      });
+
+      expect(response.status).toBe(400);
+      expect(response.body.message).toMatch(
+        'Banner or profile images can only be uploaded by patron groups.'
+      );
+
+      expect(onMembersLeftEvent).not.toHaveBeenCalled();
+      expect(onMembersJoinedEvent).not.toHaveBeenCalled();
+    });
+
     it('should not edit (invalid member name)', async () => {
       const response = await api.put(`/groups/${globalData.testGroupNoMembers.id}`).send({
         verificationCode: globalData.testGroupNoMembers.verificationCode,
@@ -918,6 +1010,54 @@ describe('Group API', () => {
         verificationCode: createResponse.body.verificationCode
       });
       expect(deleteResponse.status).toBe(200);
+    });
+
+    it('should edit profile image', async () => {
+      // Force this group to be a patron
+      await prisma.group.update({
+        where: {
+          id: globalData.testGroupOneLeader.id
+        },
+        data: {
+          patron: true
+        }
+      });
+
+      const response = await api.put(`/groups/${globalData.testGroupOneLeader.id}`).send({
+        verificationCode: globalData.testGroupOneLeader.verificationCode,
+        profileImage: 'https://avatars.githubusercontent.com/u/65183441?s=200&v=4'
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.body.profileImage).toBe('https://avatars.githubusercontent.com/u/65183441?s=200&v=4');
+
+      expect(onMembersLeftEvent).not.toHaveBeenCalled();
+      expect(onMembersJoinedEvent).not.toHaveBeenCalled();
+      expect(onMembersRolesChangedEvent).not.toHaveBeenCalled();
+    });
+
+    it('should edit banner image', async () => {
+      // Force this group to be a patron
+      await prisma.group.update({
+        where: {
+          id: globalData.testGroupOneLeader.id
+        },
+        data: {
+          patron: true
+        }
+      });
+
+      const response = await api.put(`/groups/${globalData.testGroupOneLeader.id}`).send({
+        verificationCode: globalData.testGroupOneLeader.verificationCode,
+        bannerImage: 'https://avatars.githubusercontent.com/u/65183441?s=200&v=4'
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.body.bannerImage).toBe('https://avatars.githubusercontent.com/u/65183441?s=200&v=4');
+
+      expect(onMembersLeftEvent).not.toHaveBeenCalled();
+      expect(onMembersJoinedEvent).not.toHaveBeenCalled();
+      expect(onMembersRolesChangedEvent).not.toHaveBeenCalled();
     });
   });
 

--- a/server/__tests__/suites/integration/groups.test.ts
+++ b/server/__tests__/suites/integration/groups.test.ts
@@ -600,6 +600,58 @@ describe('Group API', () => {
       expect(onMembersRolesChangedEvent).not.toHaveBeenCalled();
     });
 
+    it('should not edit profile image (unauthorized image source)', async () => {
+      // Force this group to be a patron
+      await prisma.group.update({
+        where: {
+          id: globalData.testGroupOneLeader.id
+        },
+        data: {
+          patron: true
+        }
+      });
+
+      const response = await api.put(`/groups/${globalData.testGroupOneLeader.id}`).send({
+        verificationCode: globalData.testGroupOneLeader.verificationCode,
+        profileImage: 'https://avatars.githubusercontent.com/u/65183441?s=200&v=4'
+      });
+
+      expect(response.status).toBe(400);
+      expect(response.body.message).toBe(
+        'Cannot upload images from external sources. Please upload an image via the website.'
+      );
+
+      expect(onMembersLeftEvent).not.toHaveBeenCalled();
+      expect(onMembersJoinedEvent).not.toHaveBeenCalled();
+      expect(onMembersRolesChangedEvent).not.toHaveBeenCalled();
+    });
+
+    it('should not edit banner image (unauthorized image source)', async () => {
+      // Force this group to be a patron
+      await prisma.group.update({
+        where: {
+          id: globalData.testGroupOneLeader.id
+        },
+        data: {
+          patron: true
+        }
+      });
+
+      const response = await api.put(`/groups/${globalData.testGroupOneLeader.id}`).send({
+        verificationCode: globalData.testGroupOneLeader.verificationCode,
+        bannerImage: 'https://avatars.githubusercontent.com/u/65183441?s=200&v=4'
+      });
+
+      expect(response.status).toBe(400);
+      expect(response.body.message).toBe(
+        'Cannot upload images from external sources. Please upload an image via the website.'
+      );
+
+      expect(onMembersLeftEvent).not.toHaveBeenCalled();
+      expect(onMembersJoinedEvent).not.toHaveBeenCalled();
+      expect(onMembersRolesChangedEvent).not.toHaveBeenCalled();
+    });
+
     it('should edit members list', async () => {
       const before = await api.get(`/groups/${globalData.testGroupNoLeaders.id}`);
       expect(before.status).toBe(200);
@@ -1055,11 +1107,13 @@ describe('Group API', () => {
 
       const response = await api.put(`/groups/${globalData.testGroupOneLeader.id}`).send({
         verificationCode: globalData.testGroupOneLeader.verificationCode,
-        profileImage: 'https://avatars.githubusercontent.com/u/65183441?s=200&v=4'
+        profileImage: 'https://wiseoldman.ams3.cdn.digitaloceanspaces.com/images/some_fake_profile_image.png'
       });
 
       expect(response.status).toBe(200);
-      expect(response.body.profileImage).toBe('https://avatars.githubusercontent.com/u/65183441?s=200&v=4');
+      expect(response.body.profileImage).toBe(
+        'https://wiseoldman.ams3.cdn.digitaloceanspaces.com/images/some_fake_profile_image.png'
+      );
 
       expect(onMembersLeftEvent).not.toHaveBeenCalled();
       expect(onMembersJoinedEvent).not.toHaveBeenCalled();
@@ -1079,11 +1133,13 @@ describe('Group API', () => {
 
       const response = await api.put(`/groups/${globalData.testGroupOneLeader.id}`).send({
         verificationCode: globalData.testGroupOneLeader.verificationCode,
-        bannerImage: 'https://avatars.githubusercontent.com/u/65183441?s=200&v=4'
+        bannerImage: 'https://wiseoldman.ams3.cdn.digitaloceanspaces.com/images/some_fake_banner_image.png'
       });
 
       expect(response.status).toBe(200);
-      expect(response.body.bannerImage).toBe('https://avatars.githubusercontent.com/u/65183441?s=200&v=4');
+      expect(response.body.bannerImage).toBe(
+        'https://wiseoldman.ams3.cdn.digitaloceanspaces.com/images/some_fake_banner_image.png'
+      );
 
       expect(onMembersLeftEvent).not.toHaveBeenCalled();
       expect(onMembersJoinedEvent).not.toHaveBeenCalled();

--- a/server/__tests__/suites/integration/patrons.test.ts
+++ b/server/__tests__/suites/integration/patrons.test.ts
@@ -1,0 +1,162 @@
+import axios from 'axios';
+import supertest from 'supertest';
+import MockAdapter from 'axios-mock-adapter';
+import env from '../../../src/env';
+import apiServer from '../../../src/api';
+import prisma from '../../../src/prisma';
+import { PlayerType } from '../../../src/utils';
+import {
+  readFile,
+  registerCMLMock,
+  registerHiscoresMock,
+  resetDatabase,
+  resetRedis,
+  sleep
+} from '../../utils';
+
+const api = supertest(apiServer.express);
+const axiosMock = new MockAdapter(axios, { onNoMatch: 'passthrough' });
+
+const HISCORES_FILE_PATH = `${__dirname}/../../data/hiscores/psikoi_hiscores.txt`;
+
+beforeAll(async () => {
+  await resetRedis();
+  await resetDatabase();
+
+  // Mock the history fetch from CML to always fail with a 404 status code
+  registerCMLMock(axiosMock, 404);
+
+  const hiscoresRawData = await readFile(HISCORES_FILE_PATH);
+
+  // Mock regular hiscores data, and block any ironman requests
+  registerHiscoresMock(axiosMock, {
+    [PlayerType.REGULAR]: { statusCode: 200, rawData: hiscoresRawData },
+    [PlayerType.IRONMAN]: { statusCode: 404 }
+  });
+});
+
+afterAll(async () => {
+  // Sleep for 5s to allow the server to shut down gracefully
+  await apiServer.shutdown().then(() => sleep(5000));
+}, 10_000);
+
+describe('Patrons API', () => {
+  describe('Claim Patreon benefits', () => {
+    it('should not claim patreon benefits (invalid admin password)', async () => {
+      const response = await api.put(`/patrons/claim/abc`).send({});
+
+      expect(response.status).toBe(400);
+      expect(response.body.message).toBe("Required parameter 'adminPassword' is undefined.");
+    });
+
+    it('should not claim patreon benefits (incorrect admin password)', async () => {
+      const response = await api.put(`/patrons/claim/abc`).send({
+        adminPassword: 'wrong'
+      });
+
+      expect(response.status).toBe(403);
+      expect(response.body.message).toBe('Incorrect admin password.');
+    });
+
+    it('should not claim patreon benefits (no username or groupId provided)', async () => {
+      const response = await api.put(`/patrons/claim/abc`).send({ adminPassword: env.ADMIN_PASSWORD });
+
+      expect(response.status).toBe(400);
+      expect(response.body.message).toBe('Username and/or groupId must be provided.');
+    });
+
+    it('should not claim patreon benefits (discord id not a patron)', async () => {
+      const response = await api
+        .put(`/patrons/claim/abc`)
+        .send({ adminPassword: env.ADMIN_PASSWORD, groupId: 123 });
+
+      expect(response.status).toBe(404);
+      expect(response.body.message).toBe('No patronage found for this discordId.');
+    });
+
+    it('should not claim patreon benefits (T1 patron cannot link a groupId)', async () => {
+      await prisma.patron.create({
+        data: {
+          id: 'some-patreon-id',
+          name: 'jonxslays',
+          email: 'jonxreallydobeslaying@gmail.com',
+          discordId: 'some-discord-id',
+          tier: 1
+        }
+      });
+
+      const response = await api
+        .put(`/patrons/claim/some-discord-id`)
+        .send({ adminPassword: env.ADMIN_PASSWORD, groupId: 123 });
+
+      expect(response.status).toBe(403);
+      expect(response.body.message).toBe('You must be a tier 2 patron to claim group benefits.');
+    });
+
+    it('should not claim patreon benefits (player not found)', async () => {
+      const response = await api
+        .put(`/patrons/claim/some-discord-id`)
+        .send({ adminPassword: env.ADMIN_PASSWORD, username: 'toph' });
+
+      expect(response.status).toBe(404);
+      expect(response.body.message).toBe('Player not found.');
+    });
+
+    it('should not claim patreon benefits (group not found)', async () => {
+      // Force upgrade them to T2
+      await prisma.patron.update({
+        where: { id: 'some-patreon-id' },
+        data: { tier: 2 }
+      });
+
+      const response = await api
+        .put(`/patrons/claim/some-discord-id`)
+        .send({ adminPassword: env.ADMIN_PASSWORD, groupId: 123 });
+
+      expect(response.status).toBe(404);
+      expect(response.body.message).toBe('Group not found.');
+    });
+
+    it('should claim patreon PLAYER benefits', async () => {
+      const trackResponse = await api.post(`/players/katara`);
+      expect(trackResponse.status).toBe(201);
+
+      const response = await api
+        .put(`/patrons/claim/some-discord-id`)
+        .send({ adminPassword: env.ADMIN_PASSWORD, username: 'katara' });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        id: 'some-patreon-id',
+        discordId: 'some-discord-id',
+        tier: 2,
+        playerId: trackResponse.body.id,
+        groupId: null
+      });
+    });
+
+    it('should claim patreon GROUP benefits', async () => {
+      const existingPatronage = await prisma.patron.findFirst({
+        where: {
+          id: 'some-patreon-id'
+        }
+      });
+
+      const createResponse = await api.post(`/groups`).send({ name: 'Test group', members: [] });
+      expect(createResponse.status).toBe(201);
+
+      const response = await api
+        .put(`/patrons/claim/some-discord-id`)
+        .send({ adminPassword: env.ADMIN_PASSWORD, groupId: createResponse.body.group.id });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        id: 'some-patreon-id',
+        discordId: 'some-discord-id',
+        tier: 2,
+        playerId: existingPatronage.playerId,
+        groupId: createResponse.body.group.id
+      });
+    });
+  });
+});

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.11",
+  "version": "2.4.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.4.11",
+      "version": "2.4.12",
       "license": "ISC",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.11",
+  "version": "2.4.12",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/jobs/job.manager.ts
+++ b/server/src/api/jobs/job.manager.ts
@@ -130,7 +130,7 @@ class JobManager {
     const priority = (options && options.priority) || JobPriority.MEDIUM;
     const payload = 'payload' in job ? job.payload : {};
 
-    logger.info(`Added job: ${job.type}`, job.payload, true);
+    logger.info(`Added job: ${job.type}`, 'payload' in job ? job.payload : {}, true);
 
     matchingQueue.add(job.type, payload, { ...options, priority });
   }

--- a/server/src/api/jobs/job.types.ts
+++ b/server/src/api/jobs/job.types.ts
@@ -39,6 +39,7 @@ export type JobPayload = {
   [JobType.UPDATE_COMPETITION_SCORE]: UpdateCompetitionScorePayload;
   [JobType.UPDATE_GROUP_SCORE]: UpdateGroupScorePayload;
   [JobType.UPDATE_PLAYER]: UpdatePlayerJobPayload;
+  [JobType.SYNC_PATRONS]: undefined;
 };
 
 export enum JobPriority {

--- a/server/src/api/modules/groups/group.controller.ts
+++ b/server/src/api/modules/groups/group.controller.ts
@@ -52,6 +52,7 @@ async function edit(req: Request): Promise<ControllerResponse> {
     homeworld: getNumber(req.body.homeworld),
     bannerImage: getString(req.body.bannerImage),
     profileImage: getString(req.body.profileImage),
+    socialLinks: req.body.socialLinks,
     members: req.body.members
   });
 

--- a/server/src/api/modules/groups/group.controller.ts
+++ b/server/src/api/modules/groups/group.controller.ts
@@ -50,6 +50,8 @@ async function edit(req: Request): Promise<ControllerResponse> {
     clanChat: getString(req.body.clanChat),
     description: getString(req.body.description),
     homeworld: getNumber(req.body.homeworld),
+    bannerImage: getString(req.body.bannerImage),
+    profileImage: getString(req.body.profileImage),
     members: req.body.members
   });
 

--- a/server/src/api/modules/groups/services/EditGroupService.ts
+++ b/server/src/api/modules/groups/services/EditGroupService.ts
@@ -27,6 +27,10 @@ const INVALID_CLAN_CHAT_ERROR = `Invalid 'clanChat'. Must be 1-12 character long
 const INVALID_MEMBERS_ARRAY_ERROR = "Parameter 'members' is not a valid array.";
 const INVALID_MEMBER_OBJECT_ERROR = `Invalid members list. Must be an array of { username: string; role?: string; }.`;
 
+// Only allow images from our DigitalOcean bucket CDN, to make sure people don't
+// upload unresize, or uncompressed images. They must edit images on the website.
+const ALLOWED_IMAGE_PATH = 'https://wiseoldman.ams3.cdn.digitaloceanspaces.com';
+
 const MEMBER_INPUT_SCHEMA = z.object(
   {
     username: z.string(),
@@ -92,6 +96,15 @@ async function editGroup(payload: EditGroupParams): Promise<GroupDetails> {
 
   if (params.socialLinks && !group.patron) {
     throw new BadRequestError('Social links can only be added to patron groups.');
+  }
+
+  if (
+    (params.bannerImage && !params.bannerImage.startsWith(ALLOWED_IMAGE_PATH)) ||
+    (params.profileImage && !params.profileImage.startsWith(ALLOWED_IMAGE_PATH))
+  ) {
+    throw new BadRequestError(
+      'Cannot upload images from external sources. Please upload an image via the website.'
+    );
   }
 
   if (params.bannerImage) {

--- a/server/src/api/modules/patrons/patron.controller.ts
+++ b/server/src/api/modules/patrons/patron.controller.ts
@@ -1,0 +1,24 @@
+import { Request } from 'express';
+import { ForbiddenError } from '../../errors';
+import { getNumber, getString } from '../../util/validation';
+import { ControllerResponse } from '../../util/routing';
+import * as adminGuard from '../../guards/admin.guard';
+import { claimPatreonBenefits } from './services/ClaimPatreonBenefitsService';
+
+// PUT /patrons/claim/:discordId
+// REQUIRES ADMIN PASSWORD
+async function claimBenefits(req: Request): Promise<ControllerResponse> {
+  if (!adminGuard.checkAdminPermissions(req)) {
+    throw new ForbiddenError('Incorrect admin password.');
+  }
+
+  const result = await claimPatreonBenefits({
+    discordId: getString(req.params.discordId),
+    username: getString(req.body.username),
+    groupId: getNumber(req.body.groupId)
+  });
+
+  return { statusCode: 200, response: result };
+}
+
+export { claimBenefits };

--- a/server/src/api/modules/patrons/patron.routes.ts
+++ b/server/src/api/modules/patrons/patron.routes.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { setupController } from '../../util/routing';
+import * as controller from './patron.controller';
+
+const patronsRouter = Router();
+
+patronsRouter.put('/claim/:discordId', setupController(controller.claimBenefits));
+
+export default patronsRouter;

--- a/server/src/api/modules/patrons/services/ClaimPatreonBenefitsService.ts
+++ b/server/src/api/modules/patrons/services/ClaimPatreonBenefitsService.ts
@@ -1,0 +1,74 @@
+import { z } from 'zod';
+import prisma, { Patron } from '../../../../prisma';
+import { JobType, jobManager } from '../../../jobs';
+import { BadRequestError, ForbiddenError, NotFoundError } from '../../../errors';
+
+const inputSchema = z.object({
+  discordId: z.string(),
+  username: z.string().optional(),
+  groupId: z.number().int().positive().optional()
+});
+
+type ClaimPatreonBenefitsServiceParams = z.infer<typeof inputSchema>;
+
+async function claimPatreonBenefits(payload: ClaimPatreonBenefitsServiceParams): Promise<Patron> {
+  const params = inputSchema.parse(payload);
+
+  const { discordId, username, groupId } = params;
+
+  if (!username && !groupId) {
+    throw new BadRequestError('Username and/or groupId must be provided.');
+  }
+
+  const patronage = await prisma.patron.findFirst({
+    where: { discordId }
+  });
+
+  if (!patronage) {
+    throw new NotFoundError('No patronage found for this discordId.');
+  }
+
+  if (patronage.tier !== 2 && groupId) {
+    throw new ForbiddenError('You must be a tier 2 patron to claim group benefits.');
+  }
+
+  let playerId;
+
+  if (username) {
+    const player = await prisma.player.findFirst({
+      where: { username }
+    });
+
+    if (!player) {
+      throw new NotFoundError('Player not found.');
+    }
+
+    playerId = player.id;
+  }
+
+  if (groupId) {
+    const group = await prisma.group.findFirst({
+      where: { id: groupId }
+    });
+
+    if (!group) {
+      throw new NotFoundError('Group not found.');
+    }
+  }
+
+  const updatedPatron = await prisma.patron.update({
+    where: {
+      id: patronage.id
+    },
+    data: {
+      groupId,
+      playerId
+    }
+  });
+
+  jobManager.add({ type: JobType.SYNC_PATRONS });
+
+  return updatedPatron;
+}
+
+export { claimPatreonBenefits };

--- a/server/src/api/routing.ts
+++ b/server/src/api/routing.ts
@@ -13,6 +13,7 @@ import groupRoutes from './modules/groups/group.routes';
 import nameRoutes from './modules/name-changes/name-change.routes';
 import playerRoutes from './modules/players/player.routes';
 import recordRoutes from './modules/records/record.routes';
+import patronRoutes from './modules/patrons/patron.routes';
 import metricsService from './services/external/metrics.service';
 
 class RoutingHandler {
@@ -48,6 +49,7 @@ class RoutingHandler {
     this.router.use('/groups', groupRoutes);
     this.router.use('/names', nameRoutes);
     this.router.use('/efficiency', efficiencyRoutes);
+    this.router.use('/patrons', patronRoutes);
 
     this.router.get('/metrics', async (req, res) => {
       const metrics = await metricsService.getMetrics();


### PR DESCRIPTION
- Adds (private endpoint) `/patrons/claim/:discordId`
- Adds the ability to edit `bannerImage`, `profileImage` and `socialLinks` on the `PUT /groups/:id` endpoint
  - Note: Only images hosted on WOM's image server are allowed, so we highly recommend using the website to upload images instead.

@Jonxslays ping ping