### PR TITLE
Update 3rd party library disclaimer

### DIFF
--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -42,8 +42,10 @@ This documentation website will provide examples for each request using **cURL**
 | `wom.py` | Python3  | `@jonxslays` | [Docs](https://jonxslays.github.io/wom.py/stable) \| [Repo](https://github.com/jonxslays/wom.py) |
 
 :::caution
-**Little to no support** may be provided for 3rd party libraries in the Wise Old Man discord server.
-If you are having issues or have questions, feel free to ask - but understand you may need to inquire with the maintainer of the library, or on the github repository directly.
+Support for 3rd party libraries **may be limited** depending on the availability of the maintainer.
+
+For the most part you can receive help in the Wise Old Man discord server. Alternatively, feel free to
+create an issue on the associated github repository or inquire with the maintainer of the library directly.
 :::
 
 ## Getting started


### PR DESCRIPTION
This PR changes the 3rd party library disclaimer to be a little bit less harsh, as the previous verbiage was seen to deter new users from trying any wom 3rd party libs.

Updated verbiage:

![image](https://github.com/wise-old-man/wise-old-man/assets/51417989/0a7a40b6-132d-4f1b-9ddd-d931c0a6aac2)
