### PR TITLE
[api] Fix ambiguous undefined values

### DIFF
--- a/client-js/package-lock.json
+++ b/client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "3.1.8",
+  "version": "3.1.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wise-old-man/utils",
-      "version": "3.1.8",
+      "version": "3.1.9",
       "license": "ISC",
       "dependencies": {
         "dayjs": "^1.11.5"

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "3.1.8",
+  "version": "3.1.9",
   "description": "A JavaScript/TypeScript client that interfaces and consumes the Wise Old Man API, an API that tracks and measures players' progress in Old School Runescape.",
   "keywords": [
     "wiseoldman",

--- a/server/__tests__/suites/integration/competitions.test.ts
+++ b/server/__tests__/suites/integration/competitions.test.ts
@@ -2421,31 +2421,31 @@ describe('Competition API', () => {
         player: { username: 'rorro' },
         progress: { start: 500, end: 557, gained: 57 }
       });
-      expect(response.body.participations[0].levels).toBeUndefined(); // shouldn't exist on a zulrah competition
+      expect(response.body.participations[0].levels).toMatchObject({ start: -1, end: -1, gained: 0 }); // should be the default for non-skill competitions
 
       expect(response.body.participations[1]).toMatchObject({
         player: { username: 'usbc' },
         progress: { start: -1, end: 60, gained: 56 } // we start counting at 4 kc (min kc is 5)
       });
-      expect(response.body.participations[1].levels).toBeUndefined(); // shouldn't exist on a zulrah competition
+      expect(response.body.participations[1].levels).toMatchObject({ start: -1, end: -1, gained: 0 }); // should be the default for non-skill competitions
 
       expect(response.body.participations[2]).toMatchObject({
         player: { username: 'lynx titan' },
         progress: { start: 1646, end: 1646, gained: 0 }
       });
-      expect(response.body.participations[2].levels).toBeUndefined(); // shouldn't exist on a zulrah competition
+      expect(response.body.participations[2].levels).toMatchObject({ start: -1, end: -1, gained: 0 }); // should be the default for non-skill competitions
 
       expect(response.body.participations[3]).toMatchObject({
         player: { username: 'psikoi' },
         progress: { start: 1000, end: 1000, gained: 0 }
       });
-      expect(response.body.participations[3].levels).toBeUndefined(); // shouldn't exist on a zulrah competition
+      expect(response.body.participations[3].levels).toMatchObject({ start: -1, end: -1, gained: 0 }); // should be the default for non-skill competitions
 
       expect(response.body.participations[4]).toMatchObject({
         player: { username: 'zulu' },
         progress: { start: -1, end: -1, gained: 0 }
       });
-      expect(response.body.participations[4].levels).toBeUndefined(); // shouldn't exist on a zulrah competition
+      expect(response.body.participations[4].levels).toMatchObject({ start: -1, end: -1, gained: 0 }); // should be the default for non-skill competitions
     });
 
     it('should view details (other metric)', async () => {

--- a/server/__tests__/suites/integration/groups.test.ts
+++ b/server/__tests__/suites/integration/groups.test.ts
@@ -566,7 +566,7 @@ describe('Group API', () => {
       expect(onMembersJoinedEvent).not.toHaveBeenCalled();
     });
 
-    it('should not edit banner image (not a patron)', async () => {
+    it('should not edit social links (not a patron)', async () => {
       const response = await api.put(`/groups/${globalData.testGroupNoMembers.id}`).send({
         verificationCode: globalData.testGroupNoMembers.verificationCode,
         socialLinks: {
@@ -1162,7 +1162,8 @@ describe('Group API', () => {
         socialLinks: {
           twitter: 'https://twitter.com/RubenPsikoi',
           youtube: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
-          twitch: '' // Accept empty string (to un-set links)
+          twitch: 'https://www.twitch.tv/oldschoolrs',
+          discord: 'https://discord.gg/wiseoldman'
         }
       });
 
@@ -1170,22 +1171,25 @@ describe('Group API', () => {
       expect(firstResponse.body.socialLinks).toMatchObject({
         twitter: 'https://twitter.com/RubenPsikoi',
         youtube: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
-        twitch: ''
+        twitch: 'https://www.twitch.tv/oldschoolrs'
       });
 
-      // Try again, but now override the existing twitter link, youtube shouldn't change
+      // Try again, but now override the existing twitter link, unset twitch, youtube shouldn't change
 
       const secondResponse = await api.put(`/groups/${globalData.testGroupOneLeader.id}`).send({
         verificationCode: globalData.testGroupOneLeader.verificationCode,
         socialLinks: {
-          twitter: 'https://twitter.com/OldSchoolRS'
+          twitter: 'https://twitter.com/OldSchoolRS',
+          twitch: null, // unset the twitch link,
+          discord: '' // unset the discord link (empty strings get converted to null values)
         }
       });
 
       expect(secondResponse.status).toBe(200);
       expect(secondResponse.body.socialLinks).toMatchObject({
         twitter: 'https://twitter.com/OldSchoolRS',
-        youtube: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
+        youtube: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+        twitch: null
       });
 
       expect(onMembersLeftEvent).not.toHaveBeenCalled();

--- a/server/__tests__/suites/integration/patrons.test.ts
+++ b/server/__tests__/suites/integration/patrons.test.ts
@@ -123,7 +123,7 @@ describe('Patrons API', () => {
 
       const response = await api
         .put(`/patrons/claim/some-discord-id`)
-        .send({ adminPassword: env.ADMIN_PASSWORD, username: 'katara' });
+        .send({ adminPassword: env.ADMIN_PASSWORD, username: 'Katara' });
 
       expect(response.status).toBe(200);
       expect(response.body).toMatchObject({

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.13",
+  "version": "2.4.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.4.13",
+      "version": "2.4.14",
       "license": "ISC",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.13",
+  "version": "2.4.14",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/modules/competitions/competition.types.ts
+++ b/server/src/api/modules/competitions/competition.types.ts
@@ -31,12 +31,12 @@ export interface ParticipationWithPlayer extends CleanParticipation {
 
 export interface ParticipationWithPlayerAndProgress extends ParticipationWithPlayer {
   progress: MeasuredDeltaProgress;
-  levels?: MeasuredDeltaProgress;
+  levels: MeasuredDeltaProgress;
 }
 
 export interface ParticipationWithCompetitionAndStandings extends ParticipationWithCompetition {
   progress: MeasuredDeltaProgress;
-  levels?: MeasuredDeltaProgress;
+  levels: MeasuredDeltaProgress;
   rank: number;
 }
 

--- a/server/src/api/modules/competitions/services/FetchCompetitionDetailsService.ts
+++ b/server/src/api/modules/competitions/services/FetchCompetitionDetailsService.ts
@@ -89,6 +89,8 @@ async function calculateParticipantsStandings(competitionId: number, metric: Met
 
       if (isSkill(metric) && startSnapshot && endSnapshot) {
         standing.levels = deltaUtils.calculateLevelDiff(metric, startSnapshot, endSnapshot, diff);
+      } else {
+        standing.levels = { gained: 0, start: -1, end: -1 };
       }
 
       return standing;

--- a/server/src/api/modules/groups/group.utils.ts
+++ b/server/src/api/modules/groups/group.utils.ts
@@ -6,4 +6,14 @@ function sanitizeName(name: string): string {
     .trim();
 }
 
-export { sanitizeName };
+function buildDefaultSocialLinks() {
+  return {
+    website: null,
+    discord: null,
+    twitter: null,
+    youtube: null,
+    twitch: null
+  };
+}
+
+export { sanitizeName, buildDefaultSocialLinks };

--- a/server/src/api/modules/groups/services/CreateGroupService.ts
+++ b/server/src/api/modules/groups/services/CreateGroupService.ts
@@ -7,7 +7,7 @@ import { BadRequestError, ServerError } from '../../../errors';
 import { GroupDetails } from '../group.types';
 import { isValidUsername, sanitize, standardize } from '../../players/player.utils';
 import * as playerServices from '../../players/player.services';
-import { sanitizeName } from '../group.utils';
+import { buildDefaultSocialLinks, sanitizeName } from '../group.utils';
 import { onGroupCreated } from '../group.events';
 
 const MIN_NAME_ERROR = 'Group name must have at least one character.';
@@ -110,6 +110,7 @@ async function createGroup(payload: CreateGroupParams): Promise<CreateGroupResul
   return {
     group: {
       ...omit(createdGroup, 'verificationHash'),
+      socialLinks: buildDefaultSocialLinks(),
       memberCount: sortedMemberships.length,
       memberships: sortedMemberships
     },

--- a/server/src/api/modules/groups/services/EditGroupService.ts
+++ b/server/src/api/modules/groups/services/EditGroupService.ts
@@ -40,11 +40,21 @@ const MEMBER_INPUT_SCHEMA = z.object(
 );
 
 const SOCIAL_LINKS_SCHEMA = z.object({
-  website: z.string().url(INVALID_SOCIAL_LINK_URL_ERROR).optional().or(z.literal('')),
-  discord: z.string().url(INVALID_SOCIAL_LINK_URL_ERROR).optional().or(z.literal('')),
-  twitter: z.string().url(INVALID_SOCIAL_LINK_URL_ERROR).optional().or(z.literal('')),
-  twitch: z.string().url(INVALID_SOCIAL_LINK_URL_ERROR).optional().or(z.literal('')),
-  youtube: z.string().url(INVALID_SOCIAL_LINK_URL_ERROR).optional().or(z.literal(''))
+  website: z.optional(
+    z.preprocess(str => (str === '' ? null : str), z.string().url(INVALID_SOCIAL_LINK_URL_ERROR).or(z.null()))
+  ),
+  discord: z.optional(
+    z.preprocess(str => (str === '' ? null : str), z.string().url(INVALID_SOCIAL_LINK_URL_ERROR).or(z.null()))
+  ),
+  twitter: z.optional(
+    z.preprocess(str => (str === '' ? null : str), z.string().url(INVALID_SOCIAL_LINK_URL_ERROR).or(z.null()))
+  ),
+  twitch: z.optional(
+    z.preprocess(str => (str === '' ? null : str), z.string().url(INVALID_SOCIAL_LINK_URL_ERROR).or(z.null()))
+  ),
+  youtube: z.optional(
+    z.preprocess(str => (str === '' ? null : str), z.string().url(INVALID_SOCIAL_LINK_URL_ERROR).or(z.null()))
+  )
 });
 
 const inputSchema = z

--- a/server/src/api/modules/groups/services/EditGroupService.ts
+++ b/server/src/api/modules/groups/services/EditGroupService.ts
@@ -13,7 +13,7 @@ import {
 } from '../group.types';
 import { isValidUsername, sanitize, standardize } from '../../players/player.utils';
 import * as playerServices from '../../players/player.services';
-import { sanitizeName } from '../group.utils';
+import { buildDefaultSocialLinks, sanitizeName } from '../group.utils';
 import { onMembersRolesChanged, onMembersJoined, onMembersLeft, onGroupUpdated } from '../group.events';
 
 const MIN_NAME_ERROR = 'Group name must have at least one character.';
@@ -192,7 +192,7 @@ async function editGroup(payload: EditGroupParams): Promise<GroupDetails> {
 
   return {
     ...omit(updatedGroup, 'verificationHash'),
-    socialLinks: updatedGroup.socialLinks?.length > 0 ? updatedGroup.socialLinks[0] : undefined,
+    socialLinks: updatedGroup.socialLinks[0] ?? buildDefaultSocialLinks(),
     memberCount: sortedMemberships.length,
     memberships: sortedMemberships
   };

--- a/server/src/api/modules/groups/services/FetchGroupDetailsService.ts
+++ b/server/src/api/modules/groups/services/FetchGroupDetailsService.ts
@@ -4,6 +4,7 @@ import { PRIVELEGED_GROUP_ROLES } from '../../../..//utils';
 import { omit } from '../../../util/objects';
 import { NotFoundError } from '../../../errors';
 import { GroupDetails } from '../group.types';
+import { buildDefaultSocialLinks } from '../group.utils';
 
 const inputSchema = z.object({
   id: z.number().int().positive()
@@ -32,7 +33,7 @@ async function fetchGroupDetails(payload: FetchGroupDetailsParams): Promise<Grou
 
   return {
     ...omit(group, 'verificationHash'),
-    socialLinks: group.socialLinks?.length > 0 ? group.socialLinks[0] : undefined,
+    socialLinks: group.socialLinks[0] ?? buildDefaultSocialLinks(),
     memberCount: group.memberships.length,
     // Sort the members list by role
     memberships: group.memberships.sort(

--- a/server/src/api/modules/patrons/services/ClaimPatreonBenefitsService.ts
+++ b/server/src/api/modules/patrons/services/ClaimPatreonBenefitsService.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import prisma, { Patron } from '../../../../prisma';
 import { JobType, jobManager } from '../../../jobs';
 import { BadRequestError, ForbiddenError, NotFoundError } from '../../../errors';
+import { standardize } from '../../players/player.utils';
 
 const inputSchema = z.object({
   discordId: z.string(),
@@ -36,7 +37,7 @@ async function claimPatreonBenefits(payload: ClaimPatreonBenefitsServiceParams):
 
   if (username) {
     const player = await prisma.player.findFirst({
-      where: { username }
+      where: { username: standardize(username) }
     });
 
     if (!player) {


### PR DESCRIPTION
- Competition details will now always include a `levels` object, regardless of the metric's type
  - For non-skill competitions, it'll be `{ start: -1, end: -1, gained: 0 }`
- Social links can now be send as `null` to be unset (also works with empty strings)
- Group details will now always include a `socialLinks` object. regardless of the patronage status
  - For non-patron groups, it'll be `{ website: null, discord: null, twitter: null, youtube: null, twitch: null }`
- Fixes an issue with the claim patreon benefits endpoint, where it wouldn't disregard username capitalization