### PR TITLE
Fix incomplete documentation with group-endpoints.mdx

### DIFF
--- a/docs/docs/groups-api/group-endpoints.mdx
+++ b/docs/docs/groups-api/group-endpoints.mdx
@@ -458,7 +458,7 @@ curl -X PUT https://api.wiseoldman.net/v2/groups/123 \
 ```
 
 ```javascript
-const { WOMClient } = require('@wise-old-man/utils');
+const { WOMClient, GroupRole } = require('@wise-old-man/utils');
 
 const client = new WOMClient();
 
@@ -701,7 +701,7 @@ curl -X POST https://api.wiseoldman.net/v2/groups/123/members \
 ```
 
 ```javascript
-const { WOMClient } = require('@wise-old-man/utils');
+const { WOMClient, GroupRole } = require('@wise-old-man/utils');
 
 const client = new WOMClient();
 


### PR DESCRIPTION
In 2 of the examples, the GroupRole import was missing. I've included them to provide more clear instructions to the user
