### PR TITLE
[api] Fix group role priority order

### DIFF
--- a/server/__tests__/suites/integration/groups.test.ts
+++ b/server/__tests__/suites/integration/groups.test.ts
@@ -982,8 +982,8 @@ describe('Group API', () => {
       expect(editResponse.body).toMatchObject({ memberCount: 3 });
 
       expect(editResponse.body.memberships.length).toBe(3);
-      expect(editResponse.body.memberships[0].player.username).toBe('riblet');
-      expect(editResponse.body.memberships[1].player.username).toBe('psikoi');
+      expect(editResponse.body.memberships[0].player.username).toBe('psikoi');
+      expect(editResponse.body.memberships[1].player.username).toBe('riblet');
       expect(editResponse.body.memberships[2].player.username).toBe('cookmeplox');
 
       const changedRoleEvents = onMembersRolesChangedEvent.mock.calls[0][0];

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.15",
+  "version": "2.4.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.4.15",
+      "version": "2.4.16",
       "license": "ISC",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.15",
+  "version": "2.4.16",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/modules/groups/services/CreateGroupService.ts
+++ b/server/src/api/modules/groups/services/CreateGroupService.ts
@@ -101,7 +101,7 @@ async function createGroup(payload: CreateGroupParams): Promise<CreateGroupResul
 
   onGroupCreated(createdGroup.id);
 
-  const priorities = PRIVELEGED_GROUP_ROLES.reverse();
+  const priorities = [...PRIVELEGED_GROUP_ROLES].reverse();
 
   const sortedMemberships = createdGroup.memberships.sort(
     (a, b) => priorities.indexOf(b.role) - priorities.indexOf(a.role) || a.role.localeCompare(b.role)

--- a/server/src/api/modules/groups/services/EditGroupService.ts
+++ b/server/src/api/modules/groups/services/EditGroupService.ts
@@ -184,7 +184,7 @@ async function editGroup(payload: EditGroupParams): Promise<GroupDetails> {
 
   logger.moderation(`[Group:${params.id}] Edited`);
 
-  const priorities = PRIVELEGED_GROUP_ROLES.reverse();
+  const priorities = [...PRIVELEGED_GROUP_ROLES].reverse();
 
   const sortedMemberships = updatedGroup.memberships.sort(
     (a, b) => priorities.indexOf(b.role) - priorities.indexOf(a.role) || a.role.localeCompare(b.role)
@@ -448,7 +448,7 @@ function calculateRoleChangeMaps(
   memberInputs: EditGroupParams['members']
 ) {
   // Note: reversing the array here to find the role that was last declared for a given username
-  const reversedInputs = memberInputs.reverse();
+  const reversedInputs = [...memberInputs].reverse();
 
   const newRoleMap = new Map<GroupRole, number[]>();
   const currentRoleMap = new Map<GroupRole, number[]>();

--- a/server/src/api/modules/groups/services/FetchGroupDetailsService.ts
+++ b/server/src/api/modules/groups/services/FetchGroupDetailsService.ts
@@ -29,7 +29,7 @@ async function fetchGroupDetails(payload: FetchGroupDetailsParams): Promise<Grou
     throw new NotFoundError('Group not found.');
   }
 
-  const priorities = PRIVELEGED_GROUP_ROLES.reverse();
+  const priorities = [...PRIVELEGED_GROUP_ROLES].reverse();
 
   return {
     ...omit(group, 'verificationHash'),

--- a/server/src/api/modules/groups/services/FetchMembersCSVService.ts
+++ b/server/src/api/modules/groups/services/FetchMembersCSVService.ts
@@ -34,7 +34,7 @@ async function fetchGroupMembersCSV(payload: FetchMembersCSVParams): Promise<str
     throw new BadRequestError('Group has no members.');
   }
 
-  const priorities = PRIVELEGED_GROUP_ROLES.reverse();
+  const priorities = [...PRIVELEGED_GROUP_ROLES].reverse();
 
   const headers = ['Player', 'Role', 'Experience', 'Last progressed', 'Last updated'].join(',');
 

--- a/server/src/utils/groups.ts
+++ b/server/src/utils/groups.ts
@@ -6,10 +6,10 @@ const GROUP_ROLES = Object.values(GroupRole);
 
 const PRIVELEGED_GROUP_ROLES: GroupRole[] = [
   GroupRole.ADMINISTRATOR,
-  GroupRole.DEPUTY_OWNER,
+  GroupRole.OWNER,
   GroupRole.LEADER,
-  GroupRole.MODERATOR,
-  GroupRole.OWNER
+  GroupRole.DEPUTY_OWNER,
+  GroupRole.MODERATOR
 ];
 
 type GroupRolePropsMap = MapOf<GroupRole, { name: string; isPriveleged: boolean }>;


### PR DESCRIPTION
Due to my misuse of JavaScript's `.reverse()` function, the order of player's roles on the group page wasn't consistent.

The order is now consistent and it's the following:
-  `administrator`
- `owner`
- `leader`
- `deputy_owner`
- `moderator`
- every other role, alphabetically sorted