### PR TITLE
[app] Move global flagged warning to players' profiles

### DIFF
--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -9,7 +9,6 @@ import { TailwindIndicator } from "~/components/TailwindIndicator";
 import { ReactQueryProvider } from "~/components/ReactQueryProvider";
 import { NavigationLoadingBar } from "~/components/NavigationLoadingBar";
 import "../globals.css";
-import { TopBanner } from "~/components/TopBanner";
 
 const inter = Inter({
   variable: "--font-inter",
@@ -32,13 +31,6 @@ function RootLayout(props: PropsWithChildren) {
     <html lang="en" className={inter.variable}>
       <body>
         <NavigationLoadingBar />
-        <TopBanner
-          body={
-            <>
-              {`⚠️ There's currently a issue with the Jagex hiscores due to a recently reverted banwave that is causing some players to get flagged or archived. If you're affected, try to log out in-game (to update your hiscores) and then update your profile.`}
-            </>
-          }
-        />
         <TooltipProvider delayDuration={300}>
           <ReactQueryProvider>
             <Navigation>

--- a/app/src/app/players/[username]/layout.tsx
+++ b/app/src/app/players/[username]/layout.tsx
@@ -99,11 +99,7 @@ function Header(props: PlayerDetails) {
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" className="w-52">
-            <a
-              target="_blank"
-              rel="noopener noreferrer"
-              href={getHiscoresURL(displayName, type)}
-            >
+            <a target="_blank" rel="noopener noreferrer" href={getHiscoresURL(displayName, type)}>
               <DropdownMenuItem>
                 Open Official Hiscores <ExternalIcon className="ml-2 h-4 w-4" />
               </DropdownMenuItem>
@@ -215,6 +211,13 @@ function PlayerStatusAlert(props: { player: Player }) {
               contact us on Discord
             </a>
             {` for more information.`}
+
+            <p className="mt-5">
+              <span className="text-white">Note (November 14th):</span> There&apos;s currently a issue
+              with the Jagex hiscores due to a recently reverted banwave that is causing some players to
+              get flagged or archived. If you&apos;re affected, try to log out in-game (to update your
+              hiscores) and then update your WOM profile.
+            </p>
           </AlertDescription>
         </div>
       </Alert>


### PR DESCRIPTION
Now that most people affected by the Jagex banwave have been unflagged, we don't need the global warning banner anymore, so I moved the information to flagged players' profiles.