### PR TITLE
[api] Reduce update player job retries

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.17",
+  "version": "2.4.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.4.17",
+      "version": "2.4.18",
       "license": "ISC",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.17",
+  "version": "2.4.18",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/jobs/instances/UpdatePlayerJob.ts
+++ b/server/src/api/jobs/instances/UpdatePlayerJob.ts
@@ -1,5 +1,9 @@
+import prisma from '../../../prisma';
+import { PlayerStatus, PlayerType } from '../../../utils';
 import redisService from '../../services/external/redis.service';
 import * as playerServices from '../../modules/players/player.services';
+import { standardize } from '../../modules/players/player.utils';
+import { RateLimitError, ServerError, BadRequestError } from '../../errors';
 import { JobType, JobDefinition, JobOptions } from '../job.types';
 
 export interface UpdatePlayerJobPayload {
@@ -22,16 +26,72 @@ class UpdatePlayerJob implements JobDefinition<UpdatePlayerJobPayload> {
   async execute(data: UpdatePlayerJobPayload) {
     if (!data.username) return;
 
-    await playerServices.updatePlayer({ username: data.username });
+    await playerServices.updatePlayer({ username: data.username }).catch(async error => {
+      if (await shouldRetry(data.username, error)) {
+        throw error;
+      }
+    });
   }
 
-  onFailure(data: UpdatePlayerJobPayload) {
+  onFailedAllAttempts(data: UpdatePlayerJobPayload) {
     redisService.deleteKey(`cd:UpdatePlayer:${data.username}`);
   }
 
   onSuccess(data: UpdatePlayerJobPayload) {
     redisService.deleteKey(`cd:UpdatePlayer:${data.username}`);
   }
+}
+
+/**
+ * Some of the reasons a player update might fail aren't necessarily
+ * a network/hiscores issue, so we should be selective about when
+ * we retry a job to avoid wasting resources.
+ */
+async function shouldRetry(username: string, error: Error) {
+  if (error instanceof RateLimitError) {
+    return false;
+  }
+
+  if (error instanceof BadRequestError) {
+    // Invalid username, no point in retrying this job
+    if (error.message.includes('Validation error')) {
+      return false;
+    }
+
+    // Archived player, no point in retrying this job
+    if (error.message.includes('Player is archived')) {
+      return false;
+    }
+
+    const player = await prisma.player.findFirst({
+      where: {
+        username: standardize(username)
+      }
+    });
+
+    if (!player) {
+      return true;
+    }
+
+    if (
+      player.type === PlayerType.UNKNOWN ||
+      player.status === PlayerStatus.UNRANKED ||
+      player.status === PlayerStatus.BANNED
+    ) {
+      // This player likely doesn't exist on the hiscores, we can save on resources by not auto-retrying
+      return false;
+    }
+  } else if (error instanceof ServerError) {
+    if (error.message.includes('Player is flagged.')) {
+      return false;
+    }
+
+    if (error.message.includes('The OSRS Hiscores were updated.')) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 export default new UpdatePlayerJob();


### PR DESCRIPTION
Initially the point of having retries for "UPDATE_PLAYER" jobs was to handle the hiscores misbehaving, but after some digging I've noticed that the vast majority of these jobs are failing for reasons that could be predicted and wasting resources.

Not every failed update attempt needs to be retried, for example:
- If the player is archived
- If the player is banned
- If the username is Invalid (too long, too short)
- etc

This prevents further retries if it finds the current failure justified.