### PR TITLE
[api] Retry proxied requests

### DIFF
--- a/server/__tests__/suites/integration/players.test.ts
+++ b/server/__tests__/suites/integration/players.test.ts
@@ -99,13 +99,13 @@ describe('Player API', () => {
     it('should not track player (hiscores failed)', async () => {
       // Mock the hiscores to fail
       registerHiscoresMock(axiosMock, {
-        [PlayerType.REGULAR]: { statusCode: 500, rawData: '' }
+        [PlayerType.REGULAR]: { statusCode: 404, rawData: '' }
       });
 
       const response = await api.post(`/players/enrique`);
 
-      expect(response.status).toBe(500);
-      expect(response.body.message).toMatch('Failed to load hiscores: Connection refused.');
+      expect(response.status).toBe(400);
+      expect(response.body.message).toMatch('Failed to load hiscores for enrique.');
 
       expect(onPlayerUpdatedEvent).not.toHaveBeenCalled();
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.18",
+  "version": "2.4.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.4.18",
+      "version": "2.4.19",
       "license": "ISC",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.18",
+  "version": "2.4.19",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/services/external/jagex.service.ts
+++ b/server/src/api/services/external/jagex.service.ts
@@ -13,15 +13,10 @@ export const OSRS_HISCORES_URLS = {
 };
 
 async function checkIsBanned(username: string) {
-  const proxy = proxiesService.getNextProxy();
   const url = `${RUNEMETRICS_URL}?user=${username}`;
 
   try {
-    const { data } = await axios({
-      url: proxy ? url.replace('https', 'http') : url,
-      proxy
-    });
-
+    const data = await fetchWithProxy(url);
     return 'error' in data && data.error === 'NOT_A_MEMBER';
   } catch (e) {
     return false;
@@ -32,14 +27,10 @@ async function checkIsBanned(username: string) {
  * Fetches the player data from the Hiscores API.
  */
 async function fetchHiscoresData(username: string, type: PlayerType = PlayerType.REGULAR): Promise<string> {
-  const proxy = proxiesService.getNextProxy();
   const url = `${OSRS_HISCORES_URLS[type]}?player=${username}`;
 
   try {
-    const { data } = await axios({
-      url: proxy ? url.replace('https', 'http') : url,
-      proxy
-    });
+    const data = await fetchWithProxy(url);
 
     if (!data || !data.length || data.includes('Unavailable') || data.includes('<')) {
       throw new ServerError('Failed to load hiscores: Jagex service is unavailable');
@@ -53,6 +44,33 @@ async function fetchHiscoresData(username: string, type: PlayerType = PlayerType
       throw new BadRequestError('Failed to load hiscores: Invalid username.');
     } else {
       throw new ServerError('Failed to load hiscores: Connection refused.');
+    }
+  }
+}
+
+async function fetchWithProxy(url: string) {
+  const MAX_RETRIES = 3;
+  let retries = 0;
+
+  while (retries < MAX_RETRIES) {
+    const proxy = proxiesService.getNextProxy();
+
+    try {
+      const { data } = await axios({
+        url: proxy ? url.replace('https', 'http') : url,
+        proxy
+      });
+
+      return data;
+    } catch (error) {
+      // If a proxy request fails with ECONNREFUSED, try again (up to 3 times)
+      // with a different proxy and wait 1000 milliseconds in between attempts.
+      if (proxy && 'code' in error && error.code === 'ECONNREFUSED') {
+        retries++;
+        await new Promise(r => setTimeout(r, 1000)); // Sleep for 1s
+      } else {
+        throw error;
+      }
     }
   }
 }


### PR DESCRIPTION
Continuing with the effort to increase "player update" reliability, this PR adds a retry mechanism for proxied requests to Jagex services.

Sometimes our proxies fail to respond, this tends to happen 300-400 times per day, which is not a huge problem as we send about 165k of these requests per day, but since it's easy to fix, might as well.