### PR TITLE
[api] Auto-update participants 12h before competition ends

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.19",
+  "version": "2.4.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.4.19",
+      "version": "2.4.20",
       "license": "ISC",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.19",
+  "version": "2.4.20",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/jobs/index.ts
+++ b/server/src/api/jobs/index.ts
@@ -1,2 +1,2 @@
-export { JobType } from './job.types';
+export { JobType, JobPriority } from './job.types';
 export { default as jobManager } from './job.manager';


### PR DESCRIPTION
> 12 hours before a competition ends, update all participants. This solves a fairly rare occurence
where a player is actively competing, but has only been updated once at the start of the competition.
By updating them again 12h before it ends, that'll award them some gains, ensuring they get updated twice,
and making them an active competitor. This active competitor status is important for the code block above this,
where 2h before a competition ends, all active competitors get updated again.

> Note: These should be low priority updates as to not delay regularly scheduled updates. 10-12h should be more than enough
for these to slowly get processed.