### PR TITLE
[api] Archive discarded player profiles on name change approvals

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.20",
+  "version": "2.4.21",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.4.20",
+      "version": "2.4.21",
       "license": "ISC",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.20",
+  "version": "2.4.21",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/modules/name-changes/services/ApproveNameChangeService.ts
+++ b/server/src/api/modules/name-changes/services/ApproveNameChangeService.ts
@@ -2,13 +2,9 @@ import { z } from 'zod';
 import prisma, {
   Player,
   Record,
-  Snapshot,
-  Membership,
-  Participation,
   NameChange,
   NameChangeStatus,
   PrismaTypes,
-  PrismaPromise,
   setHooksEnabled
 } from '../../../../prisma';
 import { PlayerStatus } from '../../../../utils';
@@ -53,12 +49,10 @@ async function approveNameChange(payload: ApproveNameChangeService): Promise<Nam
   }
 
   // Attempt to transfer data between both accounts
-  try {
-    await transferPlayerData(oldPlayer, newPlayer, nameChange.newName);
-  } catch (error) {
-    logger.debug('Failed to transfer name change data.', error);
-    throw error;
-  }
+  const updatedPlayer = await transferPlayerData(oldPlayer, newPlayer, nameChange.newName).catch(e => {
+    logger.debug('Failed to transfer name change data.', e);
+    throw e;
+  });
 
   // If successful, resolve the name change
   const updatedNameChange = await prisma.nameChange.update({
@@ -70,6 +64,8 @@ async function approveNameChange(payload: ApproveNameChangeService): Promise<Nam
     }
   });
 
+  playerEvents.onPlayerNameChanged(updatedPlayer, oldPlayer.displayName);
+
   // Update the player ID caches
   await playerUtils.setCachedPlayerId(nameChange.oldName, null);
   await playerUtils.setCachedPlayerId(nameChange.newName, nameChange.playerId);
@@ -79,92 +75,89 @@ async function approveNameChange(payload: ApproveNameChangeService): Promise<Nam
   return updatedNameChange as NameChange;
 }
 
-async function transferPlayerData(oldPlayer: Player, newPlayer: Player, newName: string): Promise<void> {
+async function transferPlayerData(oldPlayer: Player, newPlayer: Player, newName: string): Promise<Player> {
   const transitionDate = (await snapshotServices.findPlayerSnapshot({ id: oldPlayer.id })).createdAt;
   const playerUpdateFields: PrismaTypes.PlayerUpdateInput = {};
 
-  const promises: PrismaPromise<unknown>[] = [];
+  const newPlayerExists = newPlayer && oldPlayer.id !== newPlayer.id;
 
-  if (newPlayer && oldPlayer.id !== newPlayer.id) {
+  const recordData = {
+    oldRecords: [] as Record[],
+    newRecords: [] as Record[]
+  };
+
+  if (newPlayerExists) {
     // Fetch all of older player's records, to compare to the new ones
-    const oldRecords = await prisma.record.findMany({
+    recordData.oldRecords = await prisma.record.findMany({
       where: { playerId: oldPlayer.id }
     });
 
     // Find all of new player's records (post transition date)
-    const newRecords = await prisma.record.findMany({
+    recordData.newRecords = await prisma.record.findMany({
       where: { playerId: newPlayer.id, updatedAt: { gte: transitionDate } }
     });
-
-    // Fetch all of new player's snapshots (post transition date)
-    const newSnapshots = await prisma.snapshot.findMany({
-      where: { playerId: newPlayer.id, createdAt: { gte: transitionDate } }
-    });
-
-    // Fetch all of new player's memberships (post transition date)
-    const newMemberships = await prisma.membership.findMany({
-      where: { playerId: newPlayer.id, createdAt: { gte: transitionDate } }
-    });
-
-    // Fetch all of new player's participations (post transition date)
-    const newParticipations = await prisma.participation.findMany({
-      where: { playerId: newPlayer.id, createdAt: { gte: transitionDate } }
-    });
-
-    promises.push(
-      // Transfer all snapshots from the newPlayer (post transition date) to the old player
-      transferSnapshots(oldPlayer.id, newSnapshots),
-
-      // Transfer all memberships from the newPlayer (post transition date) to the old player
-      transferMemberships(oldPlayer.id, newMemberships),
-
-      // Transfer all participations from the newPlayer (post transition date) to the old player
-      transferParticipations(oldPlayer.id, newParticipations),
-
-      // Transfer all records from the newPlayer (post transition date) to the old player
-      // If some records are lower than the oldPlayer already had, they are discarded in favor of existing ones
-      ...transferRecords(oldPlayer.id, oldRecords, newRecords),
-
-      // Delete the new player
-      prisma.player.delete({ where: { id: newPlayer.id } })
-    );
-
-    if (newPlayer.country && !oldPlayer.country) {
-      // Set the player's flag to the new one, if one didn't exist before
-      playerUpdateFields.country = newPlayer.country;
-    }
   }
-
-  // Update the player to the new username & displayName
-  playerUpdateFields.username = playerUtils.standardize(newName);
-  playerUpdateFields.displayName = playerUtils.sanitize(newName);
-  playerUpdateFields.status = PlayerStatus.ACTIVE;
 
   // Disable prisma hooks to ensure that we don't get any "player joined group/competition" events,
   // that wouldn't make sense because it's the same player, just under a different name, and about to be merged into one
   setHooksEnabled(false);
 
-  const updatePlayerPromise = prisma.player.update({
-    where: { id: oldPlayer.id },
-    data: playerUpdateFields
-  });
+  const result = await prisma
+    .$transaction(async transaction => {
+      // had to, ffs
+      const tx = transaction as unknown as PrismaTypes.TransactionClient;
 
-  const results = await prisma.$transaction([...promises, updatePlayerPromise]);
+      if (newPlayerExists) {
+        // Transfer all snapshots from the newPlayer (post transition date) to the old player
+        await transferSnapshots(tx, oldPlayer.id, newPlayer.id, transitionDate);
+
+        // Transfer all memberships from the newPlayer (post transition date) to the old player
+        await transferMemberships(tx, oldPlayer.id, newPlayer.id, transitionDate);
+
+        // Transfer all participations from the newPlayer (post transition date) to the old player
+        await transferParticipations(tx, oldPlayer.id, newPlayer.id, transitionDate);
+
+        // Transfer all records from the newPlayer (post transition date) to the old player
+        await transferRecords(tx, oldPlayer.id, recordData.oldRecords, recordData.newRecords);
+
+        // Delete the "new" player profile
+        await tx.player.delete({ where: { id: newPlayer.id } });
+
+        if (newPlayer.country && !oldPlayer.country) {
+          // Set the player's flag to the new one, if one didn't exist before
+          playerUpdateFields.country = newPlayer.country;
+        }
+      }
+
+      // Update the player to the new username & displayName
+      playerUpdateFields.username = playerUtils.standardize(newName);
+      playerUpdateFields.displayName = playerUtils.sanitize(newName);
+      playerUpdateFields.status = PlayerStatus.ACTIVE;
+
+      const updatedPlayer = await tx.player.update({
+        where: { id: oldPlayer.id },
+        data: playerUpdateFields
+      });
+
+      return updatedPlayer as unknown as Player;
+    })
+    .catch(e => {
+      setHooksEnabled(true);
+      logger.error('Failed to transfer name change data', e);
+      throw new ServerError('Failed to transfer name change data');
+    });
 
   setHooksEnabled(true);
 
-  if (!results || results.length === 0) return;
-
-  const updatedPlayer = results[results.length - 1] as Awaited<typeof updatePlayerPromise>;
-
-  playerEvents.onPlayerNameChanged(updatedPlayer, oldPlayer.displayName);
+  return result;
 }
 
-function transferRecords(
+async function transferRecords(
+  transaction: PrismaTypes.TransactionClient,
   oldPlayerId: number,
   oldRecords: Record[],
   newRecords: Record[]
-): PrismaPromise<unknown>[] {
+) {
   const recordsToAdd: Record[] = [];
   const recordsToUpdate: { record: Record; newValue: number }[] = [];
 
@@ -181,70 +174,79 @@ function transferRecords(
     }
   });
 
-  const promises: PrismaPromise<unknown>[] = [];
-
-  if (recordsToAdd.length > 0) {
-    promises.push(
-      prisma.record.createMany({
-        data: recordsToAdd.map(record => ({
-          ...record,
-          id: undefined,
-          playerId: oldPlayerId,
-          value: prepareRecordValue(record.metric, record.value)
-        }))
-      })
-    );
+  for (const record of recordsToAdd) {
+    await transaction.record.update({
+      where: { id: record.id },
+      data: {
+        playerId: oldPlayerId,
+        value: prepareRecordValue(record.metric, record.value)
+      }
+    });
   }
 
-  if (recordsToUpdate.length > 0) {
-    promises.push(
-      ...recordsToUpdate.map(({ record, newValue }) =>
-        prisma.record.update({
-          where: { id: record.id },
-          data: { value: prepareRecordValue(record.metric, newValue) }
-        })
-      )
-    );
+  for (const { record, newValue } of recordsToUpdate) {
+    await transaction.record.update({
+      where: { id: record.id },
+      data: {
+        value: prepareRecordValue(record.metric, newValue)
+      }
+    });
   }
-
-  return promises;
 }
 
 function transferSnapshots(
+  transaction: PrismaTypes.TransactionClient,
   oldPlayerId: number,
-  newSnapshots: Snapshot[]
-): PrismaPromise<PrismaTypes.BatchPayload> {
-  // Transfer all snapshots to the old player id
-  return prisma.snapshot.createMany({
-    data: newSnapshots.map(snapshot => ({ ...snapshot, id: undefined, playerId: oldPlayerId })),
-    skipDuplicates: true
+  newPlayerId: number,
+  transitionDate: Date
+) {
+  // Transfer all snapshots (post transition) to the old player id
+  return transaction.snapshot.updateMany({
+    where: {
+      playerId: newPlayerId,
+      createdAt: { gte: transitionDate }
+    },
+    data: {
+      playerId: oldPlayerId
+    }
   });
 }
 
 function transferMemberships(
+  transaction: PrismaTypes.TransactionClient,
   oldPlayerId: number,
-  newMemberships: Membership[]
-): PrismaPromise<PrismaTypes.BatchPayload> {
-  // Transfer all memberships to the old player id
-  return prisma.membership.createMany({
-    data: newMemberships.map(membership => ({ ...membership, playerId: oldPlayerId })),
-    skipDuplicates: true
+  newPlayerId: number,
+  transitionDate: Date
+) {
+  // Transfer all memberships (post transition) to the old player id
+  return transaction.membership.updateMany({
+    where: {
+      playerId: newPlayerId,
+      createdAt: { gte: transitionDate }
+    },
+    data: {
+      playerId: oldPlayerId
+    }
   });
 }
 
 function transferParticipations(
+  transaction: PrismaTypes.TransactionClient,
   oldPlayerId: number,
-  newParticipations: Participation[]
-): PrismaPromise<PrismaTypes.BatchPayload> {
-  // Transfer all participations to the old player id
-  return prisma.participation.createMany({
-    data: newParticipations.map(participation => ({
-      ...participation,
+  newPlayerId: number,
+  transitionDate: Date
+) {
+  // Transfer all participations (post transition) to the old player id
+  return transaction.participation.updateMany({
+    where: {
+      playerId: newPlayerId,
+      createdAt: { gte: transitionDate }
+    },
+    data: {
       playerId: oldPlayerId,
       startSnapshotId: null,
       endSnapshotId: null
-    })),
-    skipDuplicates: true
+    }
   });
 }
 


### PR DESCRIPTION
fixes #909 

Previously, when approving name changes, any excess data would be deleted. This could cause a (rare) bug with double name changes, described in #909, that could result in data being lost.

This PR refactors name change approvals to archive "excess" data, instead of deleting it. With this change, if this bug occurs again, we can easily restore this affected profile and retain all the data.