### PR TITLE
[api] Filter leaderboards on active player status

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.22",
+  "version": "2.4.23",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/jobs/job.manager.ts
+++ b/server/src/api/jobs/job.manager.ts
@@ -97,11 +97,11 @@ const CRON_JOBS = [
   {
     type: JobType.SCHEDULE_BANNED_PLAYER_CHECKS,
     interval: '0 8 * * *' // everyday at 8AM
-  },
-  {
-    // type: JobType.SCHEDULE_TREND_CALCS,
-    // interval: '0 */12 * * *' // every 12 hours
   }
+  // {
+  // type: JobType.SCHEDULE_TREND_CALCS,
+  // interval: '0 */12 * * *' // every 12 hours
+  // }
 ];
 
 class JobManager {

--- a/server/src/api/modules/deltas/services/FindDeltaLeaderboardsService.ts
+++ b/server/src/api/modules/deltas/services/FindDeltaLeaderboardsService.ts
@@ -1,5 +1,13 @@
 import { z } from 'zod';
-import { Period, Metric, PlayerType, PlayerBuild, Country, DeltaLeaderboardEntry } from '../../../../utils';
+import {
+  Period,
+  Metric,
+  PlayerType,
+  PlayerBuild,
+  Country,
+  DeltaLeaderboardEntry,
+  PlayerStatus
+} from '../../../../utils';
 import prisma, { PrismaTypes } from '../../../../prisma';
 import { parseNum } from '../delta.utils';
 
@@ -33,7 +41,7 @@ async function findDeltaLeaderboards(payload: FindDeltaLeaderboardsParams): Prom
   const deltas = await prisma.delta.findMany({
     where: {
       period: params.period,
-      player: { ...playerQuery }
+      player: { ...playerQuery, status: PlayerStatus.ACTIVE }
     },
     select: {
       [params.metric]: true,

--- a/server/src/api/modules/efficiency/services/FindEfficiencyLeaderboardsService.ts
+++ b/server/src/api/modules/efficiency/services/FindEfficiencyLeaderboardsService.ts
@@ -46,7 +46,7 @@ async function fetchSortedPlayersList(params: FindEfficiencyLeaderboardsParams) 
   const playerQuery: PrismaTypes.PlayerWhereInput = {
     type: params.playerType,
     build: params.playerBuild,
-    status: { not: PlayerStatus.ARCHIVED }
+    status: PlayerStatus.ACTIVE
   };
 
   // When filtering by player type, the ironman filter should include UIM and HCIM

--- a/server/src/api/modules/records/services/FindRecordLeaderboardsService.ts
+++ b/server/src/api/modules/records/services/FindRecordLeaderboardsService.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { PlayerType, PlayerBuild, Period, Metric, Country } from '../../../../utils';
+import { PlayerType, PlayerBuild, Period, Metric, Country, PlayerStatus } from '../../../../utils';
 import prisma, { PrismaTypes } from '../../../../prisma';
 import { RecordLeaderboardEntry } from '../record.types';
 
@@ -35,7 +35,7 @@ async function findRecordLeaderboards(
     where: {
       metric: params.metric,
       period: params.period,
-      player: { ...playerQuery }
+      player: { ...playerQuery, status: PlayerStatus.ACTIVE }
     },
     include: { player: true },
     orderBy: [{ value: 'desc' }],


### PR DESCRIPTION
- Filters out any players that don't have an `active` player status.
- Fixes a wrongly commented object causing error.