### PR TITLE
[app] Prevent custom periods before 2013

### DIFF
--- a/app/src/components/CustomPeriodDialog.tsx
+++ b/app/src/components/CustomPeriodDialog.tsx
@@ -63,35 +63,29 @@ export function CustomPeriodDialog(props: CustomPeriodDialogProps) {
 }
 
 function validateDate(date: DateValue, time: TimeValue, type: string) {
-  console.log("validating date")
   const dateTime = toDate(date, time);
   if (type === typeEnum.START && dateTime.getFullYear() < 2013) {
     setInvalidStartDate(true);
     setStartDate(earliestDate);
-    console.log("1 return false")
     return false;
   }
   if (type === typeEnum.END) {
     if (dateTime < toDate(startDate, startTime)) {
       setStartDateAfterEndDate(true);
       setEndDateTime(toDate(startDate, startTime));
-      console.log("2 return false")
       return false;
     }
     if (dateTime > new Date()) {
       setInvalidEndDate(true);
       setEndDateTime(new Date());
-      console.log("3 return false")
       return false;
     }
   }
-  console.log("resetting states because we validatedProperly")
   resetStates();
   return true;
 }
 
   function handleSelection() {
-    console.log("fixing state?")
     resetStates();
 
     if (validateDate(startDate, startTime, typeEnum.START) !== true) return;
@@ -121,7 +115,6 @@ function validateDate(date: DateValue, time: TimeValue, type: string) {
         <form
           className="mt-2 flex flex-col"
           onSubmit={(e) => {
-            console.log("submitting")
             e.preventDefault();
             handleSelection();
           }}

--- a/app/src/components/CustomPeriodDialog.tsx
+++ b/app/src/components/CustomPeriodDialog.tsx
@@ -30,7 +30,16 @@ export function CustomPeriodDialog(props: CustomPeriodDialogProps) {
 
   const [endDate, setEndDate] = useState<DateValue>(toCalendarDate(new Date()));
 
+  const [invalidStartDate, setInvalidStartDate] = useState(false);
+
   function handleSelection() {
+    if (startDate.year < 2013) {
+      setInvalidStartDate(true);
+      setStartDate(toCalendarDate(new Date(2013, 0, 1)));
+      return;
+    }
+
+    setInvalidStartDate(false);
     const startDateTime = toDate(startDate, startTime);
     const endDateTime = toDate(endDate, endTime);
 
@@ -61,7 +70,7 @@ export function CustomPeriodDialog(props: CustomPeriodDialogProps) {
         >
           <div className="flex grow gap-x-4">
             <div className="grow">
-              <Label className="mb-2 block text-xs text-gray-200">Start date</Label>
+              { !invalidStartDate ? <Label className="mb-2 block text-xs text-gray-200">Start date</Label> : <Label className="mb-2 block text-xs text-red-500">Start date must be after 01/01/2013</Label> }
               <DateTimePicker inDialog value={startDate} onChange={setStartDate} />
             </div>
             <div className="grow">

--- a/app/src/components/CustomPeriodDialog.tsx
+++ b/app/src/components/CustomPeriodDialog.tsx
@@ -35,7 +35,7 @@ export function CustomPeriodDialog(props: CustomPeriodDialogProps) {
   const [startDateAfterEndDate, setStartDateAfterEndDate] = useState(false);
 
   const earliestDate = toCalendarDate(new Date(2013, 0, 1));
-  const typeEnum = { START: 'start', END: 'end' };
+  const typeEnum = { START_DATE: 'start', END_DATE: 'end' };
 
   const errorLabels = {
     start: "Start date must be after " + earliestDate.toString(),
@@ -50,9 +50,9 @@ export function CustomPeriodDialog(props: CustomPeriodDialogProps) {
  }
 
  function getLabel(type: string) {
-  const isError = type === typeEnum.START ? invalidStartDate : invalidEndDate || startDateAfterEndDate;
-  const label = type === typeEnum.START ? "Start date" : "End date";
-  const errorText = type === typeEnum.START ? errorLabels.start : invalidEndDate ? errorLabels.endFuture : errorLabels.endBeforeStart;
+  const isError = type === typeEnum.START_DATE ? invalidStartDate : invalidEndDate || startDateAfterEndDate;
+  const label = type === typeEnum.START_DATE ? "Start date" : "End date";
+  const errorText = type === typeEnum.START_DATE ? errorLabels.start : invalidEndDate ? errorLabels.endFuture : errorLabels.endBeforeStart;
   const className = `mb-2 block text-xs ${isError ? "text-red-500" : "text-gray-200"}`;
   return <Label className={className}>{isError ? errorText : label}</Label>;
 }
@@ -64,12 +64,12 @@ export function CustomPeriodDialog(props: CustomPeriodDialogProps) {
 
 function validateDate(date: DateValue, time: TimeValue, type: string) {
   const dateTime = toDate(date, time);
-  if (type === typeEnum.START && dateTime.getFullYear() < 2013) {
+  if (type === typeEnum.START_DATE && dateTime.getFullYear() < 2013) {
     setInvalidStartDate(true);
     setStartDate(earliestDate);
     return false;
   }
-  if (type === typeEnum.END) {
+  if (type === typeEnum.END_DATE) {
     if (dateTime < toDate(startDate, startTime)) {
       setStartDateAfterEndDate(true);
       setEndDateTime(toDate(startDate, startTime));
@@ -88,8 +88,8 @@ function validateDate(date: DateValue, time: TimeValue, type: string) {
   function handleSelection() {
     resetStates();
 
-    if (validateDate(startDate, startTime, typeEnum.START) !== true) return;
-    if (validateDate(endDate, endTime, typeEnum.END) !== true ) return;
+    if (!validateDate(startDate, startTime, typeEnum.START_DATE)) return;
+    if (!validateDate(endDate, endTime, typeEnum.END_DATE)) return;
 
 
     const startDateTime = toDate(startDate, startTime);
@@ -121,7 +121,7 @@ function validateDate(date: DateValue, time: TimeValue, type: string) {
         >
           <div className="flex grow gap-x-4">
             <div className="grow">
-              { getLabel(typeEnum.START) }
+              { getLabel(typeEnum.START_DATE) }
               <DateTimePicker inDialog value={startDate} onChange={setStartDate} />
             </div>
             <div className="grow">
@@ -131,7 +131,7 @@ function validateDate(date: DateValue, time: TimeValue, type: string) {
           </div>
           <div className="mt-5 flex grow gap-x-4">
             <div className="grow">
-              {getLabel(typeEnum.END)}
+              {getLabel(typeEnum.END_DATE)}
               <DateTimePicker inDialog value={endDate} onChange={setEndDate}/>
             </div>
             <div className="grow">

--- a/app/src/components/CustomPeriodDialog.tsx
+++ b/app/src/components/CustomPeriodDialog.tsx
@@ -29,17 +29,62 @@ export function CustomPeriodDialog(props: CustomPeriodDialogProps) {
   );
 
   const [endDate, setEndDate] = useState<DateValue>(toCalendarDate(new Date()));
-
   const [invalidStartDate, setInvalidStartDate] = useState(false);
+
   const [invalidEndDate, setInvalidEndDate] = useState(false);
+  const [startDateAfterEndDate, setStartDateAfterEndDate] = useState(false);
+
+  const earliestDate = toCalendarDate(new Date(2013, 0, 1));
+  const typeEnum = { START: 'start', END: 'end' };
+
+ function resetStates() {
+    setInvalidStartDate(false);
+    setInvalidEndDate(false);
+    setStartDateAfterEndDate(false);
+ }
+
+ function getLabel(type: string) {
+    if (type === typeEnum.START && invalidStartDate) {
+      return <Label className="mb-2 block text-xs text-red-500">Start date must be after {earliestDate.toString()}</Label>
+    } else if (type === typeEnum.END && invalidEndDate) {
+      return <Label className="mb-2 block text-xs text-red-500">End date must not be in the future</Label>
+    } else if (type === typeEnum.END && startDateAfterEndDate) {
+      return <Label className="mb-2 block text-xs text-red-500">End date must be after start date</Label>
+    } else if (type === typeEnum.END) {
+      return <Label className="mb-2 block text-xs text-gray-200">End date</Label>
+    } else {
+      return <Label className="mb-2 block text-xs text-gray-200">Start date</Label>
+    }
+ }
 
   function handleSelection() {
+    resetStates();
+
+    // Prevent users from checking metrics before 2013
     if (startDate.year < 2013) {
       setInvalidStartDate(true);
       setStartDate(toCalendarDate(new Date(2013, 0, 1)));
       return;
     }
 
+    // Prevent users from checking past metrics that don't exist
+    if (endDate.year < 2013) {
+      setInvalidEndDate(true);
+      setEndDate(toCalendarDate(new Date(2013, 0, 1)));
+      return;
+      }
+
+    // Check if endtime is before starttime
+    if (toDate(endDate, endTime) < toDate(startDate, startTime)) {
+      console.log("End date is before start date");
+      setStartDateAfterEndDate(true);
+      //Set the end date to a minute after the start date
+      setEndDate(toCalendarDate(toDate(startDate, startTime)));
+      setEndTime(new Time(toDate(startDate, startTime).getMinutes()+1));
+      return;
+    }
+
+    // Prevent users from checking future metrics that don't exist
     if (toDate(endDate, endTime) > new Date()) {
       setInvalidEndDate(true);
       setEndTime(new Time(new Date().getHours(), new Date().getMinutes()));
@@ -47,8 +92,6 @@ export function CustomPeriodDialog(props: CustomPeriodDialogProps) {
       return;
     }
 
-    setInvalidStartDate(false);
-    setInvalidEndDate(false);
     const startDateTime = toDate(startDate, startTime);
     const endDateTime = toDate(endDate, endTime);
 
@@ -79,7 +122,7 @@ export function CustomPeriodDialog(props: CustomPeriodDialogProps) {
         >
           <div className="flex grow gap-x-4">
             <div className="grow">
-              { !invalidStartDate ? <Label className="mb-2 block text-xs text-gray-200">Start date</Label> : <Label className="mb-2 block text-xs text-red-500">Start date must be after 01/01/2013</Label> }
+              { getLabel(typeEnum.START) }
               <DateTimePicker inDialog value={startDate} onChange={setStartDate} />
             </div>
             <div className="grow">
@@ -89,7 +132,7 @@ export function CustomPeriodDialog(props: CustomPeriodDialogProps) {
           </div>
           <div className="mt-5 flex grow gap-x-4">
             <div className="grow">
-              { !invalidEndDate ? <Label className="mb-2 block text-xs text-gray-200">End date</Label> : <Label className="mb-2 block text-xs text-red-500">Enter valid end date</Label> }
+              {getLabel(typeEnum.END)}
               <DateTimePicker inDialog value={endDate} onChange={setEndDate}/>
             </div>
             <div className="grow">

--- a/app/src/components/CustomPeriodDialog.tsx
+++ b/app/src/components/CustomPeriodDialog.tsx
@@ -64,7 +64,7 @@ export function CustomPeriodDialog(props: CustomPeriodDialogProps) {
 
 function validateDate(date: DateValue, time: TimeValue, type: string) {
   const dateTime = toDate(date, time);
-  if (type === typeEnum.START_DATE && dateTime.getFullYear() < 2013) {
+  if (type === typeEnum.START_DATE && dateTime.getFullYear() < earliestDate.year) {
     setInvalidStartDate(true);
     setStartDate(earliestDate);
     return false;

--- a/app/src/components/CustomPeriodDialog.tsx
+++ b/app/src/components/CustomPeriodDialog.tsx
@@ -31,6 +31,7 @@ export function CustomPeriodDialog(props: CustomPeriodDialogProps) {
   const [endDate, setEndDate] = useState<DateValue>(toCalendarDate(new Date()));
 
   const [invalidStartDate, setInvalidStartDate] = useState(false);
+  const [invalidEndDate, setInvalidEndDate] = useState(false);
 
   function handleSelection() {
     if (startDate.year < 2013) {
@@ -39,7 +40,15 @@ export function CustomPeriodDialog(props: CustomPeriodDialogProps) {
       return;
     }
 
+    if (toDate(endDate, endTime) > new Date()) {
+      setInvalidEndDate(true);
+      setEndTime(new Time(new Date().getHours(), new Date().getMinutes()));
+      setEndDate(toCalendarDate(new Date()));
+      return;
+    }
+
     setInvalidStartDate(false);
+    setInvalidEndDate(false);
     const startDateTime = toDate(startDate, startTime);
     const endDateTime = toDate(endDate, endTime);
 
@@ -80,8 +89,8 @@ export function CustomPeriodDialog(props: CustomPeriodDialogProps) {
           </div>
           <div className="mt-5 flex grow gap-x-4">
             <div className="grow">
-              <Label className="mb-2 block text-xs text-gray-200">End date</Label>
-              <DateTimePicker inDialog value={endDate} onChange={setEndDate} />
+              { !invalidEndDate ? <Label className="mb-2 block text-xs text-gray-200">End date</Label> : <Label className="mb-2 block text-xs text-red-500">Enter valid end date</Label> }
+              <DateTimePicker inDialog value={endDate} onChange={setEndDate}/>
             </div>
             <div className="grow">
               <Label className="mb-2 block text-xs text-gray-200">End time</Label>


### PR DESCRIPTION
Looking to address #1373 

I wasn't sure if there was already a component that can handle something like this, so I wrote it as a ternary for the time being. If there's already an abstract component that exists that I can use, please point me in that direction and I'll use that instead.

I also wasn't sure if there were any contribution guides for labels and generalized styling choices. I looked around but was able to find anything. I thought this implementation was simple enough in terms of visual queues, but when hitting another error (trying to update too fast), I saw a red X in a toast notification. 