### PR TITLE
[app] Show archival details in player profiles

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -24,7 +24,7 @@
         "@tailwindcss/container-queries": "^0.1.1",
         "@tanstack/react-query": "^5.0.0-alpha.34",
         "@tanstack/react-table": "^8.9.1",
-        "@wise-old-man/utils": "^3.1.8",
+        "@wise-old-man/utils": "^3.1.12",
         "autoprefixer": "10.4.14",
         "class-variance-authority": "^0.5.2",
         "clsx": "^1.2.1",
@@ -7518,9 +7518,9 @@
       }
     },
     "node_modules/@wise-old-man/utils": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/@wise-old-man/utils/-/utils-3.1.8.tgz",
-      "integrity": "sha512-FGLdiJwfkRlnPB2S83DZNIYP04qiCt0c0nKW2CNyx8+FoWZDkWBrbf5dnZeyqcxWqGsJ06Koan97CVrX8nKsqQ==",
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/@wise-old-man/utils/-/utils-3.1.12.tgz",
+      "integrity": "sha512-+XOTbAS866+7lR4E1HPQOvsOFrXR2EXZss+nHjHMNIta9xdMFGRkkksXScHCmYc4Y5lHQBu1sTPV4MckrkC/kg==",
       "dependencies": {
         "dayjs": "^1.11.5"
       }
@@ -19199,9 +19199,9 @@
       }
     },
     "@wise-old-man/utils": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/@wise-old-man/utils/-/utils-3.1.8.tgz",
-      "integrity": "sha512-FGLdiJwfkRlnPB2S83DZNIYP04qiCt0c0nKW2CNyx8+FoWZDkWBrbf5dnZeyqcxWqGsJ06Koan97CVrX8nKsqQ==",
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/@wise-old-man/utils/-/utils-3.1.12.tgz",
+      "integrity": "sha512-+XOTbAS866+7lR4E1HPQOvsOFrXR2EXZss+nHjHMNIta9xdMFGRkkksXScHCmYc4Y5lHQBu1sTPV4MckrkC/kg==",
       "requires": {
         "dayjs": "^1.11.5"
       }

--- a/app/package.json
+++ b/app/package.json
@@ -25,7 +25,7 @@
     "@tailwindcss/container-queries": "^0.1.1",
     "@tanstack/react-query": "^5.0.0-alpha.34",
     "@tanstack/react-table": "^8.9.1",
-    "@wise-old-man/utils": "^3.1.8",
+    "@wise-old-man/utils": "^3.1.12",
     "autoprefixer": "10.4.14",
     "class-variance-authority": "^0.5.2",
     "clsx": "^1.2.1",

--- a/app/src/app/players/[username]/name-changes/page.tsx
+++ b/app/src/app/players/[username]/name-changes/page.tsx
@@ -6,7 +6,6 @@ import { ListTable, ListTableCell, ListTableRow } from "~/components/ListTable";
 import { getPlayerArchives, getPlayerDetails, getPlayerNames } from "~/services/wiseoldman";
 
 import ArrowRightIcon from "~/assets/arrow_right.svg";
-import { PlayerStatus } from "@wise-old-man/utils";
 
 export const dynamic = "force-dynamic";
 
@@ -29,15 +28,11 @@ export default async function PlayerNameChangesPage(props: PageProps) {
 
   const username = decodeURI(params.username);
 
-  const [player, nameChanges] = await Promise.all([
+  const [player, nameChanges, archives] = await Promise.all([
     getPlayerDetails(username),
     getPlayerNames(username),
+    getPlayerArchives(username),
   ]);
-
-  let archives = null;
-  if (player.status === PlayerStatus.ARCHIVED) {
-    archives = await getPlayerArchives(username);
-  }
 
   return (
     <>

--- a/app/src/components/NameChangeSubmissionDialog.tsx
+++ b/app/src/components/NameChangeSubmissionDialog.tsx
@@ -13,6 +13,7 @@ import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } f
 
 interface NameChangeSubmissionDialogProps {
   oldName?: string;
+  hideOldName?: boolean;
 }
 
 export function NameChangeSubmissionDialog(props: NameChangeSubmissionDialogProps) {
@@ -33,7 +34,7 @@ export function NameChangeSubmissionDialog(props: NameChangeSubmissionDialogProp
           <DialogTitle>Submit new name change</DialogTitle>
           <DialogDescription>
             Most name changes are usually auto-reviewed within the first two minutes. If yours
-            doesn&apos;t, you can contact us on&nbsp;
+            isn&apos;t, you can contact us on&nbsp;
             <a
               href="https://wiseoldman.net/discord"
               target="_blank"
@@ -45,7 +46,7 @@ export function NameChangeSubmissionDialog(props: NameChangeSubmissionDialogProp
             &nbsp;for help.
           </DialogDescription>
         </DialogHeader>
-        <SubmitNameChangeForm {...props} />
+        <SubmitNameChangeForm key={props.oldName} {...props} />
       </DialogContent>
     </Dialog>
   );
@@ -92,10 +93,10 @@ function SubmitNameChangeForm(props: NameChangeSubmissionDialogProps) {
   // Clear the inputs when the form is unmounted
   useEffect(() => {
     return () => {
-      setOldName("");
+      setOldName(props.oldName || "");
       setNewName("");
     };
-  }, []);
+  }, [props]);
 
   return (
     <form
@@ -105,17 +106,21 @@ function SubmitNameChangeForm(props: NameChangeSubmissionDialogProps) {
         submitMutation.mutate({ oldName, newName });
       }}
     >
-      <div className="flex flex-col">
-        <Label className="mb-2 text-xs font-normal text-gray-200">Old Name</Label>
-        <Input
-          placeholder="Ex: Zezima"
-          name="oldName"
-          value={oldName}
-          onChange={(e) => setOldName(e.target.value)}
-          className={cn(oldNameError && "border-red-400")}
-        />
-        {oldNameError && <Label className="mt-2 text-xs font-normal text-red-400">{oldNameError}</Label>}
-      </div>
+      {!props.hideOldName && (
+        <div className={"flex flex-col"}>
+          <Label className="mb-2 text-xs font-normal text-gray-200">Old Name</Label>
+          <Input
+            placeholder="Ex: Zezima"
+            name="oldName"
+            value={oldName}
+            onChange={(e) => setOldName(e.target.value)}
+            className={cn(oldNameError && "border-red-400")}
+          />
+          {oldNameError && (
+            <Label className="mt-2 text-xs font-normal text-red-400">{oldNameError}</Label>
+          )}
+        </div>
+      )}
       <div className="mt-1 flex flex-col">
         <Label className="mb-2 text-xs font-normal text-gray-200">New Name</Label>
         <Input

--- a/app/src/components/PlayerIdentity.tsx
+++ b/app/src/components/PlayerIdentity.tsx
@@ -65,7 +65,7 @@ export function PlayerIdentity(props: PlayerIdentityProps) {
                 player.patron && "text-amber-300"
               )}
             >
-              {player.displayName}
+              {player.status === PlayerStatus.ARCHIVED ? "[Archived]" : player.displayName}
             </Link>
           </TooltipTrigger>
           {caption && <span className="text-xs text-gray-200">{caption}</span>}
@@ -88,7 +88,7 @@ export function PlayerIdentityTooltip(props: { player: Player }) {
   return (
     <>
       <div className="flex flex-col rounded-t-lg border-b border-gray-500 px-4 py-3">
-        <span>{player.displayName}</span>
+        <span>{player.status === PlayerStatus.ARCHIVED ? "[Archived]" : player.displayName}</span>
         <span className="text-xs text-gray-200">{updatedTimeago}</span>
         {player.status === PlayerStatus.ARCHIVED && (
           <span className="mt-4 text-xs text-red-400">

--- a/app/src/services/wiseoldman.ts
+++ b/app/src/services/wiseoldman.ts
@@ -165,6 +165,10 @@ export const getPlayerNames = cache((username: string) => {
   return handleNotFound(apiClient.players.getPlayerNames(username));
 });
 
+export const getPlayerArchives = cache((username: string) => {
+  return handleNotFound(apiClient.players.getPlayerArchives(username));
+});
+
 export const getPlayerRecords = cache((username: string) => {
   return handleNotFound(apiClient.players.getPlayerRecords(username));
 });


### PR DESCRIPTION
- Adds "previously known as" to archived players' profiles (and instructions on how to restore)
- Adds "archived profiles" list on non-archived players' profiles
- Also fixes the "old name" field in the submit name change modal on player's profiles (it wasn't being pre-populated with the player's current username)