### PR TITLE
[api] Delete empty archived profiles

### DIFF
--- a/server/__tests__/suites/integration/players.test.ts
+++ b/server/__tests__/suites/integration/players.test.ts
@@ -266,7 +266,7 @@ describe('Player API', () => {
 
       const secondResponse = await api.post(`/players/ash`);
       expect(secondResponse.status).toBe(400);
-      expect(secondResponse.body.message).toMatch('Failed to load hiscores for ash.');
+      expect(secondResponse.body.message).toMatch('Failed to load hiscores: Invalid username.');
 
       // failed to review (null cooldown = no review)
       expect(await redisService.getValue('cd:PlayerTypeReview', 'ash')).toBeNull();

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.25",
+  "version": "2.4.26",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.4.25",
+      "version": "2.4.26",
       "license": "ISC",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.25",
+  "version": "2.4.26",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/jobs/instances/CheckPlayerRankedJob.ts
+++ b/server/src/api/jobs/instances/CheckPlayerRankedJob.ts
@@ -40,7 +40,7 @@ class CheckPlayerRankedJob implements JobDefinition<CheckPlayerRankedPayload> {
   }
 
   async onFailedAllAttempts(data: CheckPlayerRankedPayload, error: Error) {
-    // If it fails every attempt with the "Failed to load hiscores" (404) error message,
+    // If it fails every attempt with the "Failed to load hiscores" (400) error message,
     // then we can be pretty sure that the player is unranked.
     if (!(error instanceof BadRequestError) || !error.message.includes('Failed to load hiscores')) return;
 

--- a/server/src/api/modules/players/services/UpdatePlayerService.ts
+++ b/server/src/api/modules/players/services/UpdatePlayerService.ts
@@ -68,7 +68,7 @@ async function updatePlayer(payload: UpdatePlayerParams): Promise<UpdatePlayerRe
       // If failed to load this player's stats from the hiscores, and they're not "regular" or "unknown"
       // we should at least check if their type has changed (e.g. the name was transfered to a regular acc)
       if (await shouldReviewType(player)) {
-        const hasTypeChanged = await reviewType(player);
+        const hasTypeChanged = await reviewType(player).catch(() => false);
         // If they did in fact change type, call this function recursively,
         // so that it fetches their stats from the correct hiscores.
         if (hasTypeChanged) return updatePlayer(player);


### PR DESCRIPTION
Whenever a name change is approved (and the new name was already tracked), the "new player" profile is archived before having its data transfered to the "old player". This can sometimes result in archived profiles with 0 useful data in it, which is super unnecessary.

This checks if the archived profile has less than 2 snapshots, and deletes if so.