### PR TITLE
[api] Fix race condition in RuneLite self-submitted name change

### DIFF
--- a/server/__tests__/suites/integration/players.test.ts
+++ b/server/__tests__/suites/integration/players.test.ts
@@ -789,7 +789,8 @@ describe('Player API', () => {
         .send({ accountHash: '123456' })
         .set('User-Agent', 'RuneLite');
 
-      expect(secondResponse.status).toBe(201);
+      expect(secondResponse.status).toBe(500); // Player update gets interrupted if a name change is detected
+      expect(secondResponse.body.message).toBe('Failed to update: Name change detected.');
 
       const fetchNameChangesResponse = await api.get('/names').query({ username: 'ruben' });
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.26",
+  "version": "2.4.27",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.4.26",
+      "version": "2.4.27",
       "license": "ISC",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.26",
+  "version": "2.4.27",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/modules/name-changes/services/ApproveNameChangeService.ts
+++ b/server/src/api/modules/name-changes/services/ApproveNameChangeService.ts
@@ -52,6 +52,7 @@ async function approveNameChange(payload: ApproveNameChangeService): Promise<Nam
   if (newPlayer && newPlayer.id !== oldPlayer.id) {
     // Archive the "new" profile, in case we need to restore some of this data later
     await archivePlayer(newPlayer, false);
+    await playerUtils.setCachedPlayerId(newPlayer.username, null);
   }
 
   // Attempt to transfer data between both accounts

--- a/server/src/api/modules/players/player.events.ts
+++ b/server/src/api/modules/players/player.events.ts
@@ -32,10 +32,10 @@ async function onPlayerNameChanged(player: Player, previousDisplayName: string) 
   await metrics.trackEffect(discordService.dispatchNameChanged, player, previousDisplayName);
 
   // Setup jobs to assert the player's account type and auto-update them
-  // jobManager.add({
-  //   type: JobType.UPDATE_PLAYER,
-  //   payload: { username: player.username }
-  // });
+  jobManager.add({
+    type: JobType.UPDATE_PLAYER,
+    payload: { username: player.username }
+  });
 
   jobManager.add({
     type: JobType.ASSERT_PLAYER_TYPE,

--- a/server/src/api/modules/players/player.routes.ts
+++ b/server/src/api/modules/players/player.routes.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { setupController } from '../../util/routing';
+import { detectRuneLiteNameChange } from '../../util/middlewares';
 import * as controller from './player.controller';
 
 const api = Router();
@@ -21,7 +22,7 @@ api.get('/:username/names', setupController(controller.names));
 api.get('/:username/archives', setupController(controller.archives));
 api.put('/:username/country', setupController(controller.changeCountry));
 api.get('/:username', setupController(controller.details));
-api.post('/:username', setupController(controller.track));
+api.post('/:username', detectRuneLiteNameChange, setupController(controller.track));
 api.post('/:username/rollback', setupController(controller.rollback));
 api.post('/:username/archive', setupController(controller.archive));
 api.delete('/:username', setupController(controller.deletePlayer));

--- a/server/src/api/util/middlewares.ts
+++ b/server/src/api/util/middlewares.ts
@@ -1,8 +1,13 @@
+import { Response, Request, NextFunction } from 'express';
 import { isMetric, parseMetricAbbreviation } from '../../utils';
+import * as nameChangeServices from '../modules/name-changes/name-change.services';
+import redisService from '../services/external/redis.service';
+import logger from '../util/logging';
+import { ServerError } from '../errors';
 
-function metricAbbreviation(req, res, next) {
+export function metricAbbreviation(req: Request, _res: Response, next: NextFunction) {
   if (!req) {
-    next();
+    return next();
   }
 
   // Swap any metric abbreviations in the request body
@@ -16,7 +21,7 @@ function metricAbbreviation(req, res, next) {
 
   // Swap any metric abbreviations in the request query
   if (req.query && req.query.metric) {
-    const metric = req.query.metric.toLowerCase();
+    const metric = String(req.query.metric).toLowerCase();
 
     if (!isMetric(metric)) {
       req.query.metric = parseMetricAbbreviation(metric) || metric;
@@ -26,4 +31,44 @@ function metricAbbreviation(req, res, next) {
   next();
 }
 
-export { metricAbbreviation };
+export async function detectRuneLiteNameChange(req: Request, res: Response, next: NextFunction) {
+  if (!req) {
+    return next();
+  }
+
+  const userAgent = res.locals.userAgent;
+
+  const { accountHash } = req.body;
+  const { username } = req.params;
+
+  if ((userAgent !== 'RuneLite' && userAgent !== 'WiseOldMan RuneLite Plugin') || !accountHash) {
+    return next();
+  }
+
+  // RuneLite requests include an "accountHash" body param that serves as a unique ID per OSRS account.
+  // If this ID is linked to a different username than before, that means that account has changed
+  // their name and we should automatically submit a name change for it.
+
+  const storedUsername = await redisService.getValue('hash', accountHash);
+
+  await redisService.setValue('hash', accountHash, username);
+
+  if (storedUsername && storedUsername !== username) {
+    logger.debug('Detected name change from account hash, auto-submitting name change.', {
+      oldName: storedUsername,
+      newName: username
+    });
+
+    try {
+      await nameChangeServices.submitNameChange({ oldName: storedUsername, newName: username });
+
+      // Interrupt the player update by forwarding an error.
+      // This prevent a race condition where the player is updated during a name change's data transfer.
+      return next(new ServerError('Failed to update: Name change detected.'));
+    } catch (error) {
+      logger.error('Failed to auto-submit name changed from account hash.', error);
+    }
+  }
+
+  next();
+}


### PR DESCRIPTION
A race condition caused by updating a player and approving a name change for them at the same time resulted in new data being added to archived profiles, which was incorrectly reverting them back to active profiles.

This happened when a player changed names in-game, logged out using RuneLite, and our plugin sent hints of that name change to our server, which would in turn would submit a name change, and then continue with the update, which would happen in parallel with the name change reivew/approval.