### PR TITLE
[app] Add drag to select time range in "Player Gained" chart

### DIFF
--- a/app/src/components/LineChart.tsx
+++ b/app/src/components/LineChart.tsx
@@ -78,13 +78,15 @@ export default function LineChart(props: LineChartProps) {
   function handleRangeSelected() {
     if (!selectedRangeStart || !selectedRangeEnd || !onRangeSelected) return;
 
-    let range = [selectedRangeStart, selectedRangeEnd];
+    if (selectedRangeStart.getTime() !== selectedRangeEnd.getTime()) {
+      let range = [selectedRangeStart, selectedRangeEnd];
 
-    if (selectedRangeStart.getTime() > selectedRangeEnd.getTime()) {
-      range = [selectedRangeEnd, selectedRangeStart];
+      if (selectedRangeStart.getTime() > selectedRangeEnd.getTime()) {
+        range = [selectedRangeEnd, selectedRangeStart];
+      }
+
+      onRangeSelected(range as [Date, Date]);
     }
-
-    onRangeSelected(range as [Date, Date]);
 
     setSelectedRangeStart(undefined);
     setSelectedRangeEnd(undefined);
@@ -110,11 +112,11 @@ export default function LineChart(props: LineChartProps) {
         <LineChartPrimitive
           margin={{ bottom: 20, left: 5, right: 5, top: 5 }}
           onMouseDown={(e) => {
-            if (!e.activeLabel || !onRangeSelected) return;
+            if (!e || !e.activeLabel || !onRangeSelected) return;
             setSelectedRangeStart(new Date(e.activeLabel));
           }}
           onMouseMove={(e) => {
-            if (!e.activeLabel || !selectedRangeStart || !onRangeSelected) return;
+            if (!e || !e.activeLabel || !selectedRangeStart || !onRangeSelected) return;
             setSelectedRangeEnd(new Date(e.activeLabel));
           }}
           onMouseUp={() => {

--- a/app/src/components/LineChart.tsx
+++ b/app/src/components/LineChart.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { formatNumber } from "@wise-old-man/utils";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import {
   LineChart as LineChartPrimitive,
   Line,
@@ -58,6 +58,8 @@ export default function LineChart(props: LineChartProps) {
     tooltipValueFormatter,
   } = props;
 
+  const [hasMounted, setHasMounted] = useState(false);
+
   const [selectedRangeStart, setSelectedRangeStart] = useState<Date | undefined>(undefined);
   const [selectedRangeEnd, setSelectedRangeEnd] = useState<Date | undefined>(undefined);
 
@@ -87,6 +89,20 @@ export default function LineChart(props: LineChartProps) {
     setSelectedRangeStart(undefined);
     setSelectedRangeEnd(undefined);
   }
+
+  useEffect(() => {
+    // I want the line to animate whenever the data changes, but I don't want it to animate
+    // on the first render, so I need to track when it becomes mounted. So it becomes "mounted"
+    // 500ms after the first render is done.
+
+    const timeout = setTimeout(() => {
+      setHasMounted(true);
+    }, 500);
+
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, [setHasMounted]);
 
   return (
     <div className="aspect-video w-full">
@@ -199,7 +215,8 @@ export default function LineChart(props: LineChartProps) {
                   strokeWidth="2"
                   dot={<ChartDot />}
                   activeDot={<ChartDot stroke={COLORS[index]} active />}
-                  isAnimationActive={false}
+                  animationDuration={200}
+                  isAnimationActive={hasMounted}
                 />
               );
             })}

--- a/app/src/components/players/PlayerGainedChart.tsx
+++ b/app/src/components/players/PlayerGainedChart.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useTransition } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import dynamicImport from "next/dynamic";
 import { TimeRangeFilter } from "~/services/wiseoldman";

--- a/app/src/components/players/PlayerGainedChart.tsx
+++ b/app/src/components/players/PlayerGainedChart.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useTransition } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import dynamicImport from "next/dynamic";
 import { TimeRangeFilter } from "~/services/wiseoldman";
 import { Metric, MetricProps, PeriodProps } from "@wise-old-man/utils";
@@ -19,6 +21,26 @@ interface PlayerGainedChartProps {
 
 export async function PlayerGainedChart(props: PlayerGainedChartProps) {
   const { data, view, metric, timeRange } = props;
+
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const [, startTransition] = useTransition();
+
+  function handleTimeRangeSelected(range: [Date, Date]) {
+    const [startDate, endDate] = range;
+
+    const nextParams = new URLSearchParams(searchParams);
+
+    // Pad these dates by 1 second in each direction so that the next data set includes them
+    nextParams.set("startDate", new Date(startDate.getTime() - 1000).toISOString());
+    nextParams.set("endDate", new Date(endDate.getTime() + 1000).toISOString());
+
+    startTransition(() => {
+      router.push(`${pathname}?${nextParams.toString()}`, { scroll: false });
+    });
+  }
 
   if (data.length < 2 || data.every((d) => d.value === -1)) {
     return (
@@ -44,7 +66,10 @@ export async function PlayerGainedChart(props: PlayerGainedChartProps) {
       datasets={[
         {
           name: `${name} ${isShowingRanks ? "rank" : measure}`,
-          data: data.map((d) => ({ value: isShowingRanks ? d.rank : d.value, time: d.date.getTime() })),
+          data: data.map((d) => ({
+            value: isShowingRanks ? d.rank : d.value,
+            time: d.date.getTime(),
+          })),
         },
       ]}
       reversed={isShowingRanks}
@@ -63,6 +88,7 @@ export async function PlayerGainedChart(props: PlayerGainedChartProps) {
 
         return formatDate(new Date(timestamp), { month: "short", day: "numeric" });
       }}
+      onRangeSelected={handleTimeRangeSelected}
     />
   );
 }

--- a/app/src/components/players/PlayerGainedChart.tsx
+++ b/app/src/components/players/PlayerGainedChart.tsx
@@ -26,8 +26,6 @@ export async function PlayerGainedChart(props: PlayerGainedChartProps) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
-  const [, startTransition] = useTransition();
-
   function handleTimeRangeSelected(range: [Date, Date]) {
     const [startDate, endDate] = range;
 
@@ -37,9 +35,7 @@ export async function PlayerGainedChart(props: PlayerGainedChartProps) {
     nextParams.set("startDate", new Date(startDate.getTime() - 1000).toISOString());
     nextParams.set("endDate", new Date(endDate.getTime() + 1000).toISOString());
 
-    startTransition(() => {
-      router.push(`${pathname}?${nextParams.toString()}`, { scroll: false });
-    });
+    router.push(`${pathname}?${nextParams.toString()}`, { scroll: false });
   }
 
   if (data.length < 2 || data.every((d) => d.value === -1)) {

--- a/app/src/components/players/PlayerGainedTimeCards.tsx
+++ b/app/src/components/players/PlayerGainedTimeCards.tsx
@@ -66,7 +66,7 @@ function InfoPanel(props: InfoPanelProps) {
       ) : (
         <>
           {!props.date ? (
-            "---"
+            <span className="text-xs text-white">---</span>
           ) : (
             <Tooltip>
               <TooltipTrigger asChild>


### PR DESCRIPTION
Allows users to drag on the chart to select a custom time range.


https://github.com/wise-old-man/wise-old-man/assets/3278148/f5a5ea99-0fa2-4426-846d-2738383e01df

