### PR TITLE
Set Default Value for 'startDate' to January 1, 2013.

### DIFF
--- a/app/src/components/CustomPeriodDialog.tsx
+++ b/app/src/components/CustomPeriodDialog.tsx
@@ -25,16 +25,19 @@ export function CustomPeriodDialog(props: CustomPeriodDialogProps) {
   const [endTime, setEndTime] = useState<TimeValue>(new Time(12, 0));
 
   const [startDate, setStartDate] = useState<DateValue>(
-      toCalendarDate(new Date('2013-01-01T00:00:00'))
+      toCalendarDate(new Date(Math.max(Date.now() - PeriodProps[Period.WEEK].milliseconds, new Date('2013-01-01T00:00:00').getTime())))
   );
 
   const [endDate, setEndDate] = useState<DateValue>(toCalendarDate(new Date()));
 
   function handleSelection() {
-    const startDateTime = toDate(startDate, startTime);
-    const endDateTime = toDate(endDate, endTime);
+    const startDateTime = Math.max(
+        toDate(startDate, startTime).getTime(),
+        new Date('2013-01-01T00:00:00').getTime()
+    );
+    const endDateTime = toDate(endDate, endTime).getTime();
 
-    onSelected(startDateTime, endDateTime);
+    onSelected(new Date(startDateTime), new Date(endDateTime));
   }
 
   return (

--- a/app/src/components/CustomPeriodDialog.tsx
+++ b/app/src/components/CustomPeriodDialog.tsx
@@ -25,17 +25,18 @@ export function CustomPeriodDialog(props: CustomPeriodDialogProps) {
   const [endTime, setEndTime] = useState<TimeValue>(new Time(12, 0));
 
   const [startDate, setStartDate] = useState<DateValue>(
-      toCalendarDate(new Date(Math.max(Date.now() - PeriodProps[Period.WEEK].milliseconds, new Date('2013-01-01T00:00:00').getTime())))
+      toCalendarDate(new Date(
+          Math.max(Date.now() -
+              PeriodProps[Period.WEEK].milliseconds,
+              new Date('2013-01-01T00:00:00').getTime())))
   );
 
   const [endDate, setEndDate] = useState<DateValue>(toCalendarDate(new Date()));
 
   function handleSelection() {
-    const startDateTime = Math.max(
-        toDate(startDate, startTime).getTime(),
-        new Date('2013-01-01T00:00:00').getTime()
-    );
-    const endDateTime = toDate(endDate, endTime).getTime();
+    const startDateTime = Math.max(toDate(startDate, startTime).getTime(),
+        new Date('2013-01-01T00:00:00').getTime());
+    const endDateTime = toDate(endDate, endTime);
 
     onSelected(new Date(startDateTime), new Date(endDateTime));
   }

--- a/app/src/components/CustomPeriodDialog.tsx
+++ b/app/src/components/CustomPeriodDialog.tsx
@@ -25,7 +25,7 @@ export function CustomPeriodDialog(props: CustomPeriodDialogProps) {
   const [endTime, setEndTime] = useState<TimeValue>(new Time(12, 0));
 
   const [startDate, setStartDate] = useState<DateValue>(
-    toCalendarDate(new Date(Date.now() - PeriodProps[Period.WEEK].milliseconds))
+      toCalendarDate(new Date('2013-01-01T00:00:00'))
   );
 
   const [endDate, setEndDate] = useState<DateValue>(toCalendarDate(new Date()));

--- a/app/src/components/CustomPeriodDialog.tsx
+++ b/app/src/components/CustomPeriodDialog.tsx
@@ -32,14 +32,20 @@ export function CustomPeriodDialog(props: CustomPeriodDialogProps) {
 
   /* minDate = OSRS Launch Date February 22nd 2012 @ 12:00:00 PM */
   const minDate = new Date('2012-02-22T12:00:00');
+    /* maxDate = Today */
+  const maxDate = new Date();
 
   function handleSelection() {
-    const startDateTime = new Date(Math.max(toDate(startDate, startTime).getTime(),
+    let startDateTime = new Date(Math.max(toDate(startDate, startTime).getTime(),
         minDate.getTime()));
-    const endDateTime = toDate(endDate, endTime);
+    let endDateTime = new Date(Math.min(Math.max(toDate(endDate, endTime).getTime(),
+        minDate.getTime()), maxDate.getTime()));
+    if (startDateTime.getTime() >= endDateTime.getTime() || endDateTime.getTime() <= minDate.getTime()) {
+      startDateTime = minDate;
+      endDateTime = maxDate;
+    }
     onSelected(startDateTime, endDateTime);
   }
-
   return (
     <Dialog
       open={isOpen}

--- a/app/src/components/CustomPeriodDialog.tsx
+++ b/app/src/components/CustomPeriodDialog.tsx
@@ -25,20 +25,19 @@ export function CustomPeriodDialog(props: CustomPeriodDialogProps) {
   const [endTime, setEndTime] = useState<TimeValue>(new Time(12, 0));
 
   const [startDate, setStartDate] = useState<DateValue>(
-      toCalendarDate(new Date(
-          Math.max(Date.now() -
-              PeriodProps[Period.WEEK].milliseconds,
-              new Date('2013-01-01T00:00:00').getTime())))
+      toCalendarDate(new Date(Date.now() - PeriodProps[Period.WEEK].milliseconds))
   );
 
   const [endDate, setEndDate] = useState<DateValue>(toCalendarDate(new Date()));
 
-  function handleSelection() {
-    const startDateTime = Math.max(toDate(startDate, startTime).getTime(),
-        new Date('2013-01-01T00:00:00').getTime());
-    const endDateTime = toDate(endDate, endTime);
+  /* minDate = OSRS Launch Date February 22nd 2012 @ 12:00:00 PM */
+  const minDate = new Date('2012-02-22T12:00:00');
 
-    onSelected(new Date(startDateTime), new Date(endDateTime));
+  function handleSelection() {
+    const startDateTime = new Date(Math.max(toDate(startDate, startTime).getTime(),
+        minDate.getTime()));
+    const endDateTime = toDate(endDate, endTime);
+    onSelected(startDateTime, endDateTime);
   }
 
   return (


### PR DESCRIPTION
_Re: https://github.com/wise-old-man/wise-old-man/issues/1373_

**Changes:**

1. Refactored the date selection logic to address user input issues and improve browser compatibility.
2. Introduced a fixed Min Date (OSRS Launch Date: February 22, 2012) to prevent users from selecting dates before this point.
3. Set a Max Date dynamically to the current date to prevent users from selecting future dates.

**Outcome:**

1. Resolves issues related to unconventional user input, such as entering a Year of '1', by ensuring that the start date defaults to '01-01-2013'.
2. Enhances browser compatibility and mitigates unexpected behaviours triggered by non-sanitized dates.
3. Improves the user experience by providing a stable and predictable date selection process.
4. Enhances data integrity and prevents users from selecting illogical date ranges, ensuring that the end date is not set before the start date and vice versa. This measure contributes to the overall robustness and accuracy of the date selection process.