### PR TITLE
Add case for when a ehb / ehp may be negative

### DIFF
--- a/app/src/components/names/ReviewContextTooltip.tsx
+++ b/app/src/components/names/ReviewContextTooltip.tsx
@@ -54,6 +54,8 @@ function ReviewContextContent(props: NameChange) {
 
   if (reviewContext.reason === "excessive_gains") {
     const { hoursDiff, ehpDiff, ehbDiff } = reviewContext;
+    const ehbFloored = Math.floor(ehbDiff);
+    const ehpFloored = Math.floor(ehpDiff);
 
     return (
       <>
@@ -61,9 +63,9 @@ function ReviewContextContent(props: NameChange) {
         the two names.
         <br />
         <br />
-        EHP: +{Math.floor(ehpDiff)}
+        EHP: { ehpFloored > 0 ? `+${ehpFloored}` : ehpFloored }
         <br />
-        EHB: +{Math.floor(ehbDiff)}
+        EHB: { ehbFloored > 0 ? `+${ehbFloored}` : ehbFloored }
         <br />
         Hours in between: {Math.floor(hoursDiff)}
       </>


### PR DESCRIPTION
_Re: #1393_ 

**Changes:**
1. Added a case for when EHP may be negative and removed the hardcoded + unless the value is positive.
2. Added a case for when EHB may be negative and removed the hardcoded + unless the value is positive.

**Outcome:**
1. When a number is added which is negative, there is no + sign suffixed.

Below is the screenshot of the user which was identified in the issue.

![Screenshot 2024-01-17 at 20 35 03](https://github.com/wise-old-man/wise-old-man/assets/146995075/d39ec6cf-e5ce-47e4-a36d-7610498e6c3d)