### PR TITLE
Add limit and offset params to efficiency api docs

### DIFF
--- a/docs/docs/efficiency-api/efficiency-endpoints.mdx
+++ b/docs/docs/efficiency-api/efficiency-endpoints.mdx
@@ -19,12 +19,14 @@ Fetches the current efficiency leaderboard for a specific efficiency metric. Ret
 
 **Query Params**
 
-| Field       | Type                                                                         | Required | Description                                  |
-| ----------- | ---------------------------------------------------------------------------- | -------- | -------------------------------------------- |
-| metric      | [ComputedMetric](/global-type-definitions#enum-computed-metric) or `ehp+ehb` | `true`   | The efficiency metric.                       |
-| playerType  | [PlayerType](/players-api/player-type-definitions#enum-player-type)?         | `false`  | The player's account type to filter by.      |
-| playerBuild | [PlayerBuild](/players-api/player-type-definitions#enum-player-build)?       | `false`  | The player's account build to filter by.     |
-| country     | [Country](/players-api/player-type-definitions#enum-country)?                | `false`  | The player's country of origin to filter by. |
+| Field        | Type                                                                         | Required | Description                                           |
+| -----------  | ---------------------------------------------------------------------------- | -------- | ----------------------------------------------------- |
+| metric       | [ComputedMetric](/global-type-definitions#enum-computed-metric) or `ehp+ehb` | `true`   | The efficiency metric.                                |
+| playerType   | [PlayerType](/players-api/player-type-definitions#enum-player-type)?         | `false`  | The player's account type to filter by.               |
+| playerBuild  | [PlayerBuild](/players-api/player-type-definitions#enum-player-build)?       | `false`  | The player's account build to filter by.              |
+| country      | [Country](/players-api/player-type-definitions#enum-country)?                | `false`  | The player's country of origin to filter by.          |
+| limit        | integer                                                                      | `false`  | The pagination limit. See [Pagination](/#pagination)  |
+| offset       | integer                                                                      | `false`  | The pagination offset. See [Pagination](/#pagination) |
 
 <br />
 


### PR DESCRIPTION
Re: https://github.com/wise-old-man/wise-old-man/issues/1388

Tested/confirmed both `limit` and `offset` params were functional for the `/v2/efficiency/leaderboard` endpoint.

Changes:
1. Added `limit` and `offset` parameters to efficiency endpoint docs, following pattern observed on [other endpoints/docs](https://docs.wiseoldman.net/players-api/player-endpoints)