### PR TITLE
Only show (special) on profiles page when build is LVL3, F2P, F2P_LVL3

### DIFF
--- a/app/src/components/players/PlayerStatsTable.tsx
+++ b/app/src/components/players/PlayerStatsTable.tsx
@@ -22,7 +22,7 @@ import {
   getLevel,
 } from "@wise-old-man/utils";
 import { formatDatetime, timeago } from "~/utils/dates";
-import { getBuildHiddenMetrics, hasSpecialEhp } from "~/utils/metrics";
+import { getBuildHiddenMetrics } from "~/utils/metrics";
 import { Label } from "../Label";
 import { Button } from "../Button";
 import { Checkbox } from "../Checkbox";
@@ -207,6 +207,10 @@ function PlayerSkillsTable(
 }
 
 function getSkillColumnDefinitions(player: Player, showVirtualLevels: boolean): ColumnDef<SkillValue>[] {
+  const hasSpecialEhp = (player: Player) => {
+    return ['f2p', 'f2p_lvl3', 'lvl3'].includes(player.build) || player.type !== PlayerType.REGULAR;
+  }
+
   return [
     {
       accessorKey: "skill",
@@ -214,13 +218,12 @@ function getSkillColumnDefinitions(player: Player, showVirtualLevels: boolean): 
         return <TableSortButton column={column}>Skill</TableSortButton>;
       },
       cell: ({ row }) => {
-        const isSpecialEHP = hasSpecialEhp(player);
 
         return (
           <div className="flex items-center gap-x-2">
             <MetricIconSmall metric={row.original.metric} />
             {MetricProps[row.original.metric].name}
-            {(row.original.metric as Metric) === Metric.EHP && isSpecialEHP && (
+            {(row.original.metric as Metric) === Metric.EHP && hasSpecialEhp(player) && (
               <Tooltip>
                 <TooltipTrigger>
                   <span>(Special)</span>

--- a/app/src/components/players/PlayerStatsTable.tsx
+++ b/app/src/components/players/PlayerStatsTable.tsx
@@ -22,7 +22,7 @@ import {
   getLevel,
 } from "@wise-old-man/utils";
 import { formatDatetime, timeago } from "~/utils/dates";
-import { getBuildHiddenMetrics } from "~/utils/metrics";
+import { getBuildHiddenMetrics, hasSpecialEhp } from "~/utils/metrics";
 import { Label } from "../Label";
 import { Button } from "../Button";
 import { Checkbox } from "../Checkbox";
@@ -214,7 +214,7 @@ function getSkillColumnDefinitions(player: Player, showVirtualLevels: boolean): 
         return <TableSortButton column={column}>Skill</TableSortButton>;
       },
       cell: ({ row }) => {
-        const isSpecialEHP = player.type !== PlayerType.REGULAR || player.build !== PlayerBuild.MAIN;
+        const isSpecialEHP = hasSpecialEhp(player.build);
 
         return (
           <div className="flex items-center gap-x-2">

--- a/app/src/components/players/PlayerStatsTable.tsx
+++ b/app/src/components/players/PlayerStatsTable.tsx
@@ -214,7 +214,7 @@ function getSkillColumnDefinitions(player: Player, showVirtualLevels: boolean): 
         return <TableSortButton column={column}>Skill</TableSortButton>;
       },
       cell: ({ row }) => {
-        const isSpecialEHP = hasSpecialEhp(player.build);
+        const isSpecialEHP = hasSpecialEhp(player);
 
         return (
           <div className="flex items-center gap-x-2">

--- a/app/src/components/players/PlayerStatsTable.tsx
+++ b/app/src/components/players/PlayerStatsTable.tsx
@@ -207,9 +207,7 @@ function PlayerSkillsTable(
 }
 
 function getSkillColumnDefinitions(player: Player, showVirtualLevels: boolean): ColumnDef<SkillValue>[] {
-  const hasSpecialEhp = (player: Player) => {
-    return ['f2p', 'f2p_lvl3', 'lvl3'].includes(player.build) || player.type !== PlayerType.REGULAR;
-  }
+  const hasSpecialEhp = player.type !== PlayerType.REGULAR || ['f2p', 'f2p_lvl3', 'lvl3'].includes(player.build);
 
   return [
     {
@@ -223,7 +221,7 @@ function getSkillColumnDefinitions(player: Player, showVirtualLevels: boolean): 
           <div className="flex items-center gap-x-2">
             <MetricIconSmall metric={row.original.metric} />
             {MetricProps[row.original.metric].name}
-            {(row.original.metric as Metric) === Metric.EHP && hasSpecialEhp(player) && (
+            {(row.original.metric as Metric) === Metric.EHP && hasSpecialEhp && (
               <Tooltip>
                 <TooltipTrigger>
                   <span>(Special)</span>

--- a/app/src/utils/metrics.ts
+++ b/app/src/utils/metrics.ts
@@ -1,7 +1,7 @@
-import { COMBAT_SKILLS, MEMBER_SKILLS, Metric, PlayerBuild } from "@wise-old-man/utils";
+import { COMBAT_SKILLS, MEMBER_SKILLS, Metric, Player, PlayerBuild } from "@wise-old-man/utils";
 
-export function hasSpecialEhp(build: PlayerBuild) {
-  return ['f2p', 'f2p_lvl3', 'lvl3'].includes(build);
+export function hasSpecialEhp(player: Player) {
+  return ['f2p', 'f2p_lvl3', 'lvl3'].includes(player.build);
 }
 
 export function getBuildHiddenMetrics(build: PlayerBuild): Metric[] {

--- a/app/src/utils/metrics.ts
+++ b/app/src/utils/metrics.ts
@@ -1,9 +1,5 @@
 import { COMBAT_SKILLS, MEMBER_SKILLS, Metric, Player, PlayerBuild } from "@wise-old-man/utils";
 
-export function hasSpecialEhp(player: Player) {
-  return ['f2p', 'f2p_lvl3', 'lvl3'].includes(player.build);
-}
-
 export function getBuildHiddenMetrics(build: PlayerBuild): Metric[] {
   switch (build) {
     case "f2p":

--- a/app/src/utils/metrics.ts
+++ b/app/src/utils/metrics.ts
@@ -1,4 +1,4 @@
-import { COMBAT_SKILLS, MEMBER_SKILLS, Metric, Player, PlayerBuild } from "@wise-old-man/utils";
+import { COMBAT_SKILLS, MEMBER_SKILLS, Metric, PlayerBuild } from "@wise-old-man/utils";
 
 export function getBuildHiddenMetrics(build: PlayerBuild): Metric[] {
   switch (build) {

--- a/app/src/utils/metrics.ts
+++ b/app/src/utils/metrics.ts
@@ -1,5 +1,9 @@
 import { COMBAT_SKILLS, MEMBER_SKILLS, Metric, PlayerBuild } from "@wise-old-man/utils";
 
+export function hasSpecialEhp(build: PlayerBuild) {
+  return ['f2p', 'f2p_lvl3', 'lvl3'].includes(build);
+}
+
 export function getBuildHiddenMetrics(build: PlayerBuild): Metric[] {
   switch (build) {
     case "f2p":


### PR DESCRIPTION
_Re: #1394_

**Changes:**

1. Introduce new method to check wherever you are in the application if the player has a special EHP rate. `hasSpecialEhp(player)`.
2. Used this to determine if the (Special) should show on the player details page.

**Evidence:**
Normal account (1 def pure):
![Screenshot 2024-01-18 at 12 43 52](https://github.com/wise-old-man/wise-old-man/assets/146995075/8ce717a7-f8b6-43ed-a964-f462c9a3fa0e)

Special account (skiller):
![Screenshot 2024-01-18 at 12 44 23](https://github.com/wise-old-man/wise-old-man/assets/146995075/8efc9d33-f526-4d74-b70f-55eb15645e6e)
