### PR TITLE
[api] Fix CSV export date format

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.29",
+  "version": "2.4.30",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.4.29",
+      "version": "2.4.30",
       "license": "ISC",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.29",
+  "version": "2.4.30",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/modules/competitions/services/FetchCompetitionCSVService.ts
+++ b/server/src/api/modules/competitions/services/FetchCompetitionCSVService.ts
@@ -62,7 +62,7 @@ function getParticipantsCSV(competitionDetails: CompetitionDetails): string {
     { header: 'Start', resolveCell: row => String(row.progress.start) },
     { header: 'End', resolveCell: row => String(row.progress.end) },
     { header: 'Gained', resolveCell: row => String(row.progress.gained) },
-    { header: 'Last Updated', resolveCell: row => formatDate(row.updatedAt) }
+    { header: 'Last Updated', resolveCell: row => formatDate(row.updatedAt, 'MM/DD/YYYY HH:mm:ss') }
   ];
 
   if (competitionDetails.type === CompetitionType.TEAM) {

--- a/server/src/api/modules/groups/services/FetchMembersCSVService.ts
+++ b/server/src/api/modules/groups/services/FetchMembersCSVService.ts
@@ -45,8 +45,8 @@ async function fetchGroupMembersCSV(payload: FetchMembersCSVParams): Promise<str
         membership.player.displayName,
         membership.role,
         membership.player.exp,
-        formatDate(membership.player.lastChangedAt),
-        formatDate(membership.player.updatedAt)
+        formatDate(membership.player.lastChangedAt, 'MM/DD/YYYY HH:mm:ss'),
+        formatDate(membership.player.updatedAt, 'MM/DD/YYYY HH:mm:ss')
       ].join(',');
     });
 


### PR DESCRIPTION
Apparently the date mask we were using (`MM-DD-YYYY HH:mm`) was causing some issues on Google Sheets.

The date mask has been changed to `MM/DD/YYYY HH:mm:ss` for CSV outputs.