### PR TITLE
[api] Set reviewContext to null upon nameChange approval

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.30",
+  "version": "2.4.31",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.4.30",
+      "version": "2.4.31",
       "license": "ISC",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.30",
+  "version": "2.4.31",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/modules/name-changes/services/ApproveNameChangeService.ts
+++ b/server/src/api/modules/name-changes/services/ApproveNameChangeService.ts
@@ -67,7 +67,7 @@ async function approveNameChange(payload: ApproveNameChangeService): Promise<Nam
     data: {
       status: NameChangeStatus.APPROVED,
       resolvedAt: new Date(),
-      reviewContext: undefined
+      reviewContext: PrismaTypes.DbNull
     }
   });
 


### PR DESCRIPTION
Fixes https://github.com/wise-old-man/wise-old-man/issues/1392

Changes:
* Change `approveNameChange` to update `reviewContext` to `null` upon successful resolution
* Add integration test to verify this behavior by creating a name change request, populating the `reviewContext` column, then calling `/names/:id/approve` and verifying `reviewContext` is `null`

Outcome:
* Approved name changes now clear `reviewContext`

**Why this approach?**
I needed to use the `Prism.DbNull` type as opposed to `null` since [Prism appears to have nuance when working with null values](https://www.prisma.io/docs/orm/prisma-client/special-fields-and-types/working-with-json-fields#using-null-values), especially for columns expecting JSON. I think this is probably why `undefined` was originally set here as the error message is not very helpful:

```
Argument reviewContext for data.reviewContext must not be null. Please use undefined instead.
```