### PR TITLE
[api] Fix handling of null player.updatedAt fields

### DIFF
--- a/server/__tests__/suites/integration/competitions.test.ts
+++ b/server/__tests__/suites/integration/competitions.test.ts
@@ -3089,6 +3089,12 @@ describe('Competition API', () => {
     });
 
     it('should not update all (no outdated participants)', async () => {
+      // Force this player's last update timestamp to be recent
+      await prisma.player.update({
+        where: { username: 'zezima' },
+        data: { updatedAt: new Date() }
+      });
+
       const response = await api
         .post(`/competitions/${globalData.testCompetitionOngoing.id}/update-all`)
         .send({
@@ -3102,6 +3108,12 @@ describe('Competition API', () => {
     });
 
     it('should not update all (no outdated participants, near start)', async () => {
+      // Force this player's last update timestamp to be recent
+      await prisma.player.update({
+        where: { username: 'zulu' },
+        data: { updatedAt: new Date() }
+      });
+
       const response = await api
         .post(`/competitions/${globalData.testCompetitionStarted.id}/update-all`)
         .send({
@@ -3211,6 +3223,12 @@ describe('Competition API', () => {
         data: { updatedAt: tenHourOldDate }
       });
 
+      // Force this player's last update timestamp to be now
+      await prisma.player.update({
+        where: { username: 'toph' },
+        data: { updatedAt: new Date() }
+      });
+
       const response = await api
         .post(`/competitions/${globalData.testCompetitionEnding.id}/update-all`)
         .send({ verificationCode: globalData.testCompetitionEnding.verificationCode });
@@ -3219,7 +3237,8 @@ describe('Competition API', () => {
 
       // This competition has started 2 days ago and ends soon (in 20mins), so players
       // are considered outdated after 1h. USBC was updated 10h ago, so they will count as outdated.
-      expect(response.body.message).toMatch('2 outdated (updated > 1h ago) players are being updated.');
+      // One play (toph) has been updated just now, so they shouldn't be included, every other player (9), should.
+      expect(response.body.message).toMatch('9 outdated (updated > 1h ago) players are being updated.');
     });
   });
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.32",
+  "version": "2.4.33",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.4.32",
+      "version": "2.4.33",
       "license": "ISC",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.32",
+  "version": "2.4.33",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/jobs/instances/AutoUpdatePatronGroupsJob.ts
+++ b/server/src/api/jobs/instances/AutoUpdatePatronGroupsJob.ts
@@ -29,7 +29,7 @@ class AutoUpdatePatronGroupsJob implements JobDefinition<unknown> {
       where: {
         groupId: { in: patronGroupIds },
         player: {
-          updatedAt: { lt: dayAgo }
+          OR: [{ updatedAt: { lt: dayAgo } }, { updatedAt: null }]
         }
       },
       include: {

--- a/server/src/api/jobs/instances/AutoUpdatePatronPlayersJob.ts
+++ b/server/src/api/jobs/instances/AutoUpdatePatronPlayersJob.ts
@@ -23,7 +23,7 @@ class AutoUpdatePatronPlayersJob implements JobDefinition<unknown> {
         where: {
           playerId: { not: null },
           player: {
-            updatedAt: { lt: dayAgo }
+            OR: [{ updatedAt: { lt: dayAgo } }, { updatedAt: null }]
           }
         },
         include: {

--- a/server/src/api/modules/competitions/services/FetchCompetitionCSVService.ts
+++ b/server/src/api/modules/competitions/services/FetchCompetitionCSVService.ts
@@ -62,7 +62,10 @@ function getParticipantsCSV(competitionDetails: CompetitionDetails): string {
     { header: 'Start', resolveCell: row => String(row.progress.start) },
     { header: 'End', resolveCell: row => String(row.progress.end) },
     { header: 'Gained', resolveCell: row => String(row.progress.gained) },
-    { header: 'Last Updated', resolveCell: row => formatDate(row.updatedAt, 'MM/DD/YYYY HH:mm:ss') }
+    {
+      header: 'Last Updated',
+      resolveCell: row => (row.updatedAt ? formatDate(row.updatedAt, 'MM/DD/YYYY HH:mm:ss') : '')
+    }
   ];
 
   if (competitionDetails.type === CompetitionType.TEAM) {

--- a/server/src/api/modules/competitions/services/UpdateAllParticipantsService.ts
+++ b/server/src/api/modules/competitions/services/UpdateAllParticipantsService.ts
@@ -77,7 +77,7 @@ async function getOutdatedParticipants(
     where: {
       competitionId,
       player: {
-        updatedAt: { lt: cooldownExpiration }
+        OR: [{ updatedAt: { lt: cooldownExpiration } }, { updatedAt: null }]
       }
     },
     include: {

--- a/server/src/api/modules/efficiency/services/FindEfficiencyLeaderboardsService.ts
+++ b/server/src/api/modules/efficiency/services/FindEfficiencyLeaderboardsService.ts
@@ -118,7 +118,7 @@ async function fetchPlayersList(params: FindEfficiencyLeaderboardsParams) {
       ...p,
       exp: Number(p.exp),
       registeredAt: new Date(p.registeredAt),
-      updatedAt: new Date(p.updatedAt),
+      updatedAt: p.updatedAt ? new Date(p.updatedAt) : null,
       lastChangedAt: p.lastChangedAt ? new Date(p.lastChangedAt) : null,
       lastImportedAt: p.lastImportedAt ? new Date(p.lastImportedAt) : null
     }))

--- a/server/src/api/modules/groups/services/FetchMembersCSVService.ts
+++ b/server/src/api/modules/groups/services/FetchMembersCSVService.ts
@@ -41,12 +41,14 @@ async function fetchGroupMembersCSV(payload: FetchMembersCSVParams): Promise<str
   const rows = memberships
     .sort((a, b) => priorities.indexOf(b.role) - priorities.indexOf(a.role) || a.role.localeCompare(b.role))
     .map(membership => {
+      const { role, player } = membership;
+
       return [
-        membership.player.displayName,
-        membership.role,
-        membership.player.exp,
-        formatDate(membership.player.lastChangedAt, 'MM/DD/YYYY HH:mm:ss'),
-        formatDate(membership.player.updatedAt, 'MM/DD/YYYY HH:mm:ss')
+        player.displayName,
+        role,
+        player.exp,
+        player.lastChangedAt ? formatDate(player.lastChangedAt, 'MM/DD/YYYY HH:mm:ss') : '',
+        player.updatedAt ? formatDate(player.updatedAt, 'MM/DD/YYYY HH:mm:ss') : ''
       ].join(',');
     });
 

--- a/server/src/api/modules/groups/services/UpdateAllMembersService.ts
+++ b/server/src/api/modules/groups/services/UpdateAllMembersService.ts
@@ -46,7 +46,7 @@ async function getOutdatedMembers(groupId: number): Promise<Pick<Player, 'userna
     where: {
       groupId,
       player: {
-        updatedAt: { lt: dayAgo }
+        OR: [{ updatedAt: { lt: dayAgo } }, { updatedAt: null }]
       }
     },
     include: {


### PR DESCRIPTION
- Fix CSV exports returning "Invalid date" for null "updatedAt" fields, it now returns an empty string
- Fix "update all" not including players with null "updatedAt" fields