### PR TITLE
[api] Optimize competition search query

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.33",
+  "version": "2.4.34",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.4.33",
+      "version": "2.4.34",
       "license": "ISC",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.33",
+  "version": "2.4.34",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",


### PR DESCRIPTION
It was counting aggregations on all competitions (32k), instead of just the 20 returned on that page, silly.