### PR TITLE
[api] Update rate limit decay

### DIFF
--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -63,7 +63,7 @@ Example: <br />
 
 ### Rate Limits & API Keys
 
-There is a maximum of 100 requests per 5 minutes, however, this can be increased (to 500) if you register for an **API key**.
+There is a maximum of 20 requests per 60 seconds, however, this can be increased (to 100) if you register for an **API key**.
 
 **API Keys** help us keep track of who is actually using our API, and what resources they need the most, and can be really helpful for us to know how to contact our API consumers.
 

--- a/server/__tests__/suites/integration/general.test.ts
+++ b/server/__tests__/suites/integration/general.test.ts
@@ -96,7 +96,7 @@ describe('General API', () => {
       process.env.NODE_ENV = 'test';
     });
 
-    it('should not allow more than 100 requests (no API key)', async () => {
+    it('should not allow more than 20 requests per minute (no API key)', async () => {
       // Flush redis to reset rate limits
       await resetRedis();
 
@@ -107,7 +107,7 @@ describe('General API', () => {
       process.env.NODE_ENV = 'production';
 
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      for (const i of Array.from(Array(150).keys())) {
+      for (const i of Array.from(Array(100).keys())) {
         const response = await api.get('/');
         if (response.status === 200) successCount++;
         else if (response.status === 429) rateLimitedCount++;
@@ -115,11 +115,11 @@ describe('General API', () => {
 
       process.env.NODE_ENV = 'test';
 
-      expect(successCount).toBe(100);
-      expect(rateLimitedCount).toBe(50);
+      expect(successCount).toBe(20);
+      expect(rateLimitedCount).toBe(80);
     });
 
-    it('should not allow more than 500 requests (with API key)', async () => {
+    it('should not allow more than 200 requests per minute (with API key)', async () => {
       // Flush redis to reset rate limits
       await resetRedis();
 
@@ -138,7 +138,7 @@ describe('General API', () => {
       process.env.NODE_ENV = 'production';
 
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      for (const i of Array.from(Array(550).keys())) {
+      for (const i of Array.from(Array(500).keys())) {
         const response = await api.get('/').set({ 'x-api-key': apiKeyResponse.body.id });
 
         if (response.status === 200) successCount++;
@@ -147,11 +147,11 @@ describe('General API', () => {
 
       process.env.NODE_ENV = 'test';
 
-      expect(successCount).toBe(500);
-      expect(rateLimitedCount).toBe(50);
+      expect(successCount).toBe(200);
+      expect(rateLimitedCount).toBe(300);
     });
 
-    it('should allow more than 500 requests (with master API key)', async () => {
+    it('should allow more than 200 requests per minute (with master API key)', async () => {
       // Flush redis to reset rate limits
       await resetRedis();
 

--- a/server/__tests__/suites/integration/general.test.ts
+++ b/server/__tests__/suites/integration/general.test.ts
@@ -119,7 +119,7 @@ describe('General API', () => {
       expect(rateLimitedCount).toBe(80);
     });
 
-    it('should not allow more than 200 requests per minute (with API key)', async () => {
+    it('should not allow more than 100 requests per minute (with API key)', async () => {
       // Flush redis to reset rate limits
       await resetRedis();
 
@@ -138,7 +138,7 @@ describe('General API', () => {
       process.env.NODE_ENV = 'production';
 
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      for (const i of Array.from(Array(500).keys())) {
+      for (const i of Array.from(Array(300).keys())) {
         const response = await api.get('/').set({ 'x-api-key': apiKeyResponse.body.id });
 
         if (response.status === 200) successCount++;
@@ -147,11 +147,11 @@ describe('General API', () => {
 
       process.env.NODE_ENV = 'test';
 
-      expect(successCount).toBe(200);
-      expect(rateLimitedCount).toBe(300);
+      expect(successCount).toBe(100);
+      expect(rateLimitedCount).toBe(200);
     });
 
-    it('should allow more than 200 requests per minute (with master API key)', async () => {
+    it('should allow more than 100 requests per minute (with master API key)', async () => {
       // Flush redis to reset rate limits
       await resetRedis();
 
@@ -177,7 +177,7 @@ describe('General API', () => {
       process.env.NODE_ENV = 'production';
 
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      for (const i of Array.from(Array(1000).keys())) {
+      for (const i of Array.from(Array(500).keys())) {
         const response = await api.get('/').set({ 'x-api-key': apiKeyResponse.body.id });
 
         if (response.status === 200) successCount++;
@@ -186,7 +186,7 @@ describe('General API', () => {
 
       process.env.NODE_ENV = 'test';
 
-      expect(successCount).toBe(1000);
+      expect(successCount).toBe(500);
       expect(rateLimitedCount).toBe(0);
     });
   });

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.35",
+  "version": "2.4.37",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.4.35",
+      "version": "2.4.37",
       "license": "ISC",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.36",
+  "version": "2.4.37",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -10,15 +10,15 @@ import router from './routing';
 import metricsService from './services/external/metrics.service';
 import redisService from './services/external/redis.service';
 
-const RATE_LIMIT_MAX_REQUESTS = 100;
-const RATE_LIMIT_DURATION_MINUTES = 5 * 60;
+const RATE_LIMIT_MAX_REQUESTS = 20;
+const RATE_LIMIT_DURATION_SECONDS = 60;
 
-// Trusted developers are allowed 5x more requests per 5 mins
-const RATE_LIMIT_TRUSTED_RATIO = 5;
+// Trusted developers are allowed 10x more requests per minute
+const RATE_LIMIT_TRUSTED_RATIO = 10;
 
 const rateLimiter = new RateLimiterRedis({
   points: RATE_LIMIT_MAX_REQUESTS * RATE_LIMIT_TRUSTED_RATIO,
-  duration: RATE_LIMIT_DURATION_MINUTES,
+  duration: RATE_LIMIT_DURATION_SECONDS,
   storeClient: redisService.redisClient
 });
 
@@ -89,7 +89,7 @@ class API {
         .then(() => next())
         .catch(() =>
           res.status(429).json({
-            message: 'Too Many Requests. Please check https://docs.wiseoldman.net/#rate-limits--api-keys. '
+            message: 'Too Many Requests. Please check https://docs.wiseoldman.net/#rate-limits--api-keys.'
           })
         );
     });

--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -13,8 +13,8 @@ import redisService from './services/external/redis.service';
 const RATE_LIMIT_MAX_REQUESTS = 20;
 const RATE_LIMIT_DURATION_SECONDS = 60;
 
-// Trusted developers are allowed 10x more requests per minute
-const RATE_LIMIT_TRUSTED_RATIO = 10;
+// Trusted developers are allowed 5x more requests per minute
+const RATE_LIMIT_TRUSTED_RATIO = 5;
 
 const rateLimiter = new RateLimiterRedis({
   points: RATE_LIMIT_MAX_REQUESTS * RATE_LIMIT_TRUSTED_RATIO,


### PR DESCRIPTION
Decreased the decay time for rate limits from 5 minutes to 60 seconds. This will change the distribution of the rate limits, hopefully reducing burst of high server usage, without reducing the effective rate of "requests per minute/hour/etc"

Previous rates:
- No API Key: 100 requests every 5 minutes
- With API Key: 500 requests every 5 minutes

New rates:
- No API Key: 20 requests every 60 seconds
- With API Key: 100 requests every 60 seconds