### PR TITLE
[api] Endpoint pagination changes

### DIFF
--- a/client-js/package-lock.json
+++ b/client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "3.1.14",
+  "version": "3.1.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wise-old-man/utils",
-      "version": "3.1.14",
+      "version": "3.1.15",
       "license": "ISC",
       "dependencies": {
         "dayjs": "^1.11.5"

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "3.1.14",
+  "version": "3.1.15",
   "description": "A JavaScript/TypeScript client that interfaces and consumes the Wise Old Man API, an API that tracks and measures players' progress in Old School Runescape.",
   "keywords": [
     "wiseoldman",

--- a/client-js/src/clients/PlayersClient.ts
+++ b/client-js/src/clients/PlayersClient.ts
@@ -142,8 +142,11 @@ export default class PlayersClient extends BaseAPIClient {
    * Fetches all of the player's past snapshots.
    * @returns A list of snapshots.
    */
-  getPlayerSnapshots(username: string, options?: TimeRangeFilter) {
-    return this.getRequest<FormattedSnapshot[]>(`/players/${username}/snapshots`, options);
+  getPlayerSnapshots(username: string, filter: TimeRangeFilter, pagination?: PaginationOptions) {
+    return this.getRequest<FormattedSnapshot[]>(`/players/${username}/snapshots`, {
+      ...filter,
+      ...pagination
+    });
   }
 
   /**

--- a/docs/docs/groups-api/group-endpoints.mdx
+++ b/docs/docs/groups-api/group-endpoints.mdx
@@ -1094,6 +1094,10 @@ Fetches the top gains for a group's member list (filtered by metric and period/d
 This endpoint accepts either `period` or `startDate` + `endDate`.
 :::
 
+:::info
+Unlike most other endpoints, this one does not have a maximum result limit.
+:::
+
 <br />
 
 **Example Request**
@@ -1438,6 +1442,10 @@ Fetches a group's hiscores for a specific metric. Returns an array of [GroupHisc
 | metric | [Metric](/global-type-definitions#enum-metric) | `true`   | The hiscores' metric.                                 |
 | limit  | integer                                        | `false`  | The pagination limit. See [Pagination](/#pagination)  |
 | offset | integer                                        | `false`  | The pagination offset. See [Pagination](/#pagination) |
+
+:::info
+Unlike most other endpoints, this one does not have a maximum result limit.
+:::
 
 <br />
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -67,6 +67,10 @@ There is a maximum of 20 requests per 60 seconds, however, this can be increased
 
 <br />
 
+:::info
+Regardless of rate limits, we ask you to add delays between your requests to help evenly distribute the server load. Keep in mind this is a free project with very real hosting costs.
+:::
+
 :::caution
 If you're planning on using the API to auto-update players on any given **short** interval, please think twice before doing so.
 
@@ -84,6 +88,10 @@ Feel free to reach out to us on Discord if you are unsure about the best approac
 **If you want an API key, or just want to be notified of API changes, just send us a message on [our discord](https://wiseoldman.net/discord) and we'll help you.**
 
 Alternatively, you can add a user agent header to your requests, which would help us identify who you are, however, this does not increase API rate limits.
+
+:::info
+If you do not provide us with a user agent that we can use to potentially contact you if you are found to be abusing our API, we have no other choice but to IP ban you.
+:::
 
 Examples:
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -65,6 +65,20 @@ Example: <br />
 
 There is a maximum of 20 requests per 60 seconds, however, this can be increased (to 100) if you register for an **API key**.
 
+<br />
+
+:::caution
+If you're planning on using the API to auto-update players on any given **short** interval, please think twice before doing so.
+
+Often, the best approach is to use a **longer** interval, such as 1-6 hours, to avoid overloading our servers with mostly redundant requests. Short intervals are often overkill for most players, and can be detrimental to the API's performance.
+
+If you are found to be updating players too often, this can result in an IP ban.
+
+Feel free to reach out to us on Discord if you are unsure about the best approach/timing for your use case.
+:::
+
+<br />
+
 **API Keys** help us keep track of who is actually using our API, and what resources they need the most, and can be really helpful for us to know how to contact our API consumers.
 
 **If you want an API key, or just want to be notified of API changes, just send us a message on [our discord](https://wiseoldman.net/discord) and we'll help you.**
@@ -120,10 +134,16 @@ Error Statuses:
 
 Some API endpoints support pagination in the form of `limit` and `offset` query parameters. This will be indicated in the endpoint description.
 
-| Field  | Default | Max |
-| ------ | ------- | --- |
-| limit  | 20      | 50  |
-| offset | 0       | --- |
+| Field  | Default | Max  |
+| ------ | ------- | ---- |
+| limit  | 20      | 50\* |
+| offset | 0       | ---  |
+
+:::note
+
+\*There are exceptions for some endpoints such as `/groups/:id/hiscores` and `/groups/:id/gained`. These do not have a maximum limit, they will return every result available.
+
+:::
 
 Examples
 

--- a/docs/docs/players-api/player-endpoints.mdx
+++ b/docs/docs/players-api/player-endpoints.mdx
@@ -1208,11 +1208,13 @@ Fetches all of the player's past snapshots. Returns an array of [Snapshot](/play
 
 **Request Params**
 
-| Field     | Type                                           | Required | Description                            |
-| --------- | ---------------------------------------------- | -------- | -------------------------------------- |
-| period    | [Period](/global-type-definitions#enum-period) | `false`  | The period to filter the snapshots by. |
-| startDate | date                                           | `false`  | The minimum date for the snapshots.    |
-| endDate   | date                                           | `false`  | The maximum date for the snapshots.    |
+| Field     | Type                                           | Required | Description                                           |
+| --------- | ---------------------------------------------- | -------- | ----------------------------------------------------- |
+| period    | [Period](/global-type-definitions#enum-period) | `false`  | The period to filter the snapshots by.                |
+| startDate | date                                           | `false`  | The minimum date for the snapshots.                   |
+| endDate   | date                                           | `false`  | The maximum date for the snapshots.                   |
+| limit     | integer                                        | `false`  | The pagination limit. See [Pagination](/#pagination)  |
+| offset    | integer                                        | `false`  | The pagination offset. See [Pagination](/#pagination) |
 
 :::info
 This endpoint accepts either `period` or `startDate` + `endDate`.

--- a/server/__tests__/suites/integration/groups.test.ts
+++ b/server/__tests__/suites/integration/groups.test.ts
@@ -2303,15 +2303,6 @@ describe('Group API', () => {
       expect(response.status).toBe(400);
       expect(response.body.message).toMatch("Parameter 'limit' must be > 0.");
     });
-
-    it('should not view hiscores (limit > 50)', async () => {
-      const response = await api
-        .get(`/groups/${globalData.testGroupOneLeader.id}/hiscores`)
-        .query({ metric: 'magic', limit: 1000 });
-
-      expect(response.status).toBe(400);
-      expect(response.body.message).toMatch('The maximum results limit is 50');
-    });
   });
 
   describe('12 - View Group Activity', () => {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.38",
+  "version": "2.4.39",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.4.38",
+      "version": "2.4.39",
       "license": "ISC",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.38",
+  "version": "2.4.39",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/jobs/job.manager.ts
+++ b/server/src/api/jobs/job.manager.ts
@@ -102,7 +102,7 @@ const CRON_JOBS = [
   },
   {
     type: JobType.CALCULATE_COMPUTED_METRIC_RANK_TABLES,
-    interval: '0 * * * *' // every hour (change to every 6 hours soon?)
+    interval: '0 8 * * *' // everyday at 8AM
   }
   // {
   // type: JobType.SCHEDULE_TREND_CALCS,

--- a/server/src/api/modules/achievements/services/FindGroupAchievementsService.ts
+++ b/server/src/api/modules/achievements/services/FindGroupAchievementsService.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import prisma from '../../../../prisma';
-import { PAGINATION_SCHEMA } from '../../../util/validation';
+import { getPaginationSchema } from '../../../util/validation';
 import { NotFoundError } from '../../../errors';
 import { ExtendedAchievementWithPlayer } from '../achievement.types';
 import { extend } from '../achievement.utils';
@@ -9,7 +9,7 @@ const inputSchema = z
   .object({
     id: z.number().int().positive()
   })
-  .merge(PAGINATION_SCHEMA);
+  .merge(getPaginationSchema());
 
 type FindGroupAchievementsParams = z.infer<typeof inputSchema>;
 

--- a/server/src/api/modules/competitions/services/FetchTop5ProgressService.ts
+++ b/server/src/api/modules/competitions/services/FetchTop5ProgressService.ts
@@ -1,17 +1,14 @@
 import { z } from 'zod';
 import { Snapshot } from '../../../../prisma';
 import { getMetricValueKey, Metric } from '../../../../utils';
-import { PAGINATION_SCHEMA } from '../../../util/validation';
 import * as snapshotServices from '../../snapshots/snapshot.services';
 import { Top5ProgressResult } from '../competition.types';
 import { fetchCompetitionDetails } from './FetchCompetitionDetailsService';
 
-const inputSchema = z
-  .object({
-    id: z.number().int().positive(),
-    metric: z.nativeEnum(Metric).optional()
-  })
-  .merge(PAGINATION_SCHEMA);
+const inputSchema = z.object({
+  id: z.number().int().positive(),
+  metric: z.nativeEnum(Metric).optional()
+});
 
 type FetchTop5ProgressParams = z.infer<typeof inputSchema>;
 

--- a/server/src/api/modules/competitions/services/SearchCompetitionsService.ts
+++ b/server/src/api/modules/competitions/services/SearchCompetitionsService.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import prisma, { PrismaTypes } from '../../../../prisma';
 import { Metric, CompetitionStatus, CompetitionType } from '../../../../utils';
 import { omit } from '../../../util/objects';
-import { PAGINATION_SCHEMA } from '../../../util/validation';
+import { getPaginationSchema } from '../../../util/validation';
 import { CompetitionListItem } from '../competition.types';
 
 const inputSchema = z
@@ -12,7 +12,7 @@ const inputSchema = z
     type: z.nativeEnum(CompetitionType).optional(),
     status: z.nativeEnum(CompetitionStatus).optional()
   })
-  .merge(PAGINATION_SCHEMA);
+  .merge(getPaginationSchema());
 
 type SearchCompetitionsParams = z.infer<typeof inputSchema>;
 

--- a/server/src/api/modules/deltas/services/FindGroupDeltasService.ts
+++ b/server/src/api/modules/deltas/services/FindGroupDeltasService.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { omit } from '../../../util/objects';
 import { Metric, parsePeriodExpression } from '../../../../utils';
 import prisma, { Player, Snapshot } from '../../../../prisma';
-import { PAGINATION_SCHEMA } from '../../../util/validation';
+import { getPaginationSchema } from '../../../util/validation';
 import { BadRequestError, NotFoundError } from '../../../errors';
 import * as snapshotServices from '../../snapshots/snapshot.services';
 import { calculateMetricDelta } from '../delta.utils';
@@ -18,7 +18,7 @@ const inputSchema = z
     minDate: z.date().optional(),
     maxDate: z.date().optional()
   })
-  .merge(PAGINATION_SCHEMA)
+  .merge(getPaginationSchema(100_000)) // unlimited "max" limit
   .refine(s => s.period || (s.maxDate && s.minDate), {
     message: 'Invalid period and start/end dates.'
   })

--- a/server/src/api/modules/efficiency/services/ComputePlayerMetricsService.ts
+++ b/server/src/api/modules/efficiency/services/ComputePlayerMetricsService.ts
@@ -3,7 +3,6 @@ import { Snapshot } from '../../../../prisma';
 import { PlayerType, PlayerBuild, Metric } from '../../../../utils';
 import * as efficiencyUtils from '../efficiency.utils';
 import * as efficiencyServices from '../efficiency.services';
-import metricsService from '../../../services/external/metrics.service';
 
 const inputSchema = z.object({
   player: z.object({
@@ -37,20 +36,16 @@ async function computePlayerMetrics(payload: ComputePlayerMetricsParams) {
   const ehpValue = Math.max(0, algorithm.calculateEHP(experienceMap));
   const ehbValue = Math.max(0, algorithm.calculateEHB(killcountMap));
 
-  const ehpRank = await metricsService.trackEffectDebug('computeEfficiencyRank_ehp', () => {
-    return efficiencyServices.computeEfficiencyRank({
-      player,
-      metric: Metric.EHP,
-      value: ehpValue
-    });
+  const ehpRank = await efficiencyServices.computeEfficiencyRank({
+    player,
+    metric: Metric.EHP,
+    value: ehpValue
   });
 
-  const ehbRank = await metricsService.trackEffectDebug('computeEfficiencyRank_ehb', () => {
-    return efficiencyServices.computeEfficiencyRank({
-      player,
-      metric: Metric.EHB,
-      value: ehbValue
-    });
+  const ehbRank = await efficiencyServices.computeEfficiencyRank({
+    player,
+    metric: Metric.EHB,
+    value: ehbValue
   });
 
   const result: ComputePlayerMetricsResult = {

--- a/server/src/api/modules/efficiency/services/FindEfficiencyLeaderboardsService.ts
+++ b/server/src/api/modules/efficiency/services/FindEfficiencyLeaderboardsService.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import prisma, { Player, PrismaTypes } from '../../../../prisma';
 import { PlayerType, PlayerBuild, Metric, Country, PlayerStatus } from '../../../../utils';
 import { omit } from '../../../util/objects';
-import { PAGINATION_SCHEMA } from '../../../util/validation';
+import { getPaginationSchema } from '../../../util/validation';
 
 const COMBINED_METRIC = 'ehp+ehb';
 
@@ -13,7 +13,7 @@ const inputSchema = z
     playerType: z.nativeEnum(PlayerType).optional().default(PlayerType.REGULAR),
     playerBuild: z.nativeEnum(PlayerBuild).optional().default(PlayerBuild.MAIN)
   })
-  .merge(PAGINATION_SCHEMA);
+  .merge(getPaginationSchema());
 
 type FindEfficiencyLeaderboardsParams = z.infer<typeof inputSchema>;
 

--- a/server/src/api/modules/groups/services/FetchGroupActivityService.ts
+++ b/server/src/api/modules/groups/services/FetchGroupActivityService.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { PAGINATION_SCHEMA } from '../../../util/validation';
+import { getPaginationSchema } from '../../../util/validation';
 import { MemberActivityWithPlayer } from '../group.types';
 import prisma from '../../../../prisma';
 import { NotFoundError } from '../../../errors';
@@ -8,7 +8,7 @@ const inputSchema = z
   .object({
     groupId: z.number().int().positive()
   })
-  .merge(PAGINATION_SCHEMA);
+  .merge(getPaginationSchema());
 
 type FetchGroupActivityParams = z.infer<typeof inputSchema>;
 

--- a/server/src/api/modules/groups/services/FetchGroupHiscoresService.ts
+++ b/server/src/api/modules/groups/services/FetchGroupHiscoresService.ts
@@ -9,7 +9,7 @@ import {
   getLevel
 } from '../../../../utils';
 import { omit } from '../../../util/objects';
-import { PAGINATION_SCHEMA } from '../../../util/validation';
+import { getPaginationSchema } from '../../../util/validation';
 import { NotFoundError } from '../../../errors';
 import { GroupHiscoresEntry, GroupHiscoresSkillItem } from '../group.types';
 import { getTotalLevel } from '../../snapshots/snapshot.utils';
@@ -19,7 +19,7 @@ const inputSchema = z
     id: z.number().int().positive(),
     metric: z.nativeEnum(Metric)
   })
-  .merge(PAGINATION_SCHEMA);
+  .merge(getPaginationSchema(100_000)); // unlimited "max" limit
 
 type FetchGroupHiscoresParams = z.infer<typeof inputSchema>;
 

--- a/server/src/api/modules/groups/services/FindPlayerMembershipsService.ts
+++ b/server/src/api/modules/groups/services/FindPlayerMembershipsService.ts
@@ -1,14 +1,14 @@
 import { z } from 'zod';
 import prisma from '../../../../prisma';
 import { omit } from '../../../util/objects';
-import { PAGINATION_SCHEMA } from '../../../util/validation';
+import { getPaginationSchema } from '../../../util/validation';
 import { MembershipWithGroup } from '../group.types';
 
 const inputSchema = z
   .object({
     playerId: z.number().int().positive()
   })
-  .merge(PAGINATION_SCHEMA);
+  .merge(getPaginationSchema());
 
 type FindPlayerMembershipsParams = z.infer<typeof inputSchema>;
 

--- a/server/src/api/modules/groups/services/SearchGroupsService.ts
+++ b/server/src/api/modules/groups/services/SearchGroupsService.ts
@@ -1,14 +1,14 @@
 import { z } from 'zod';
 import prisma from '../../../../prisma';
 import { omit } from '../../../util/objects';
-import { PAGINATION_SCHEMA } from '../../../util/validation';
+import { getPaginationSchema } from '../../../util/validation';
 import { GroupListItem } from '../group.types';
 
 const inputSchema = z
   .object({
     name: z.string().optional()
   })
-  .merge(PAGINATION_SCHEMA);
+  .merge(getPaginationSchema());
 
 type SearchGroupsParams = z.infer<typeof inputSchema>;
 

--- a/server/src/api/modules/name-changes/services/FindGroupNameChangesService.ts
+++ b/server/src/api/modules/name-changes/services/FindGroupNameChangesService.ts
@@ -1,14 +1,14 @@
 import { z } from 'zod';
 import prisma, { NameChangeStatus } from '../../../../prisma';
 import { NotFoundError } from '../../../errors';
-import { PAGINATION_SCHEMA } from '../../../util/validation';
+import { getPaginationSchema } from '../../../util/validation';
 import { NameChangeWithPlayer } from '../name-change.types';
 
 const inputSchema = z
   .object({
     id: z.number().int().positive()
   })
-  .merge(PAGINATION_SCHEMA);
+  .merge(getPaginationSchema());
 
 type FindGroupNameChangesParams = z.infer<typeof inputSchema>;
 

--- a/server/src/api/modules/name-changes/services/SearchNameChangesService.ts
+++ b/server/src/api/modules/name-changes/services/SearchNameChangesService.ts
@@ -1,13 +1,13 @@
 import { z } from 'zod';
 import prisma, { PrismaTypes, NameChange, NameChangeStatus } from '../../../../prisma';
-import { PAGINATION_SCHEMA } from '../../../util/validation';
+import { getPaginationSchema } from '../../../util/validation';
 
 const inputSchema = z
   .object({
     username: z.string().optional(),
     status: z.nativeEnum(NameChangeStatus).optional()
   })
-  .merge(PAGINATION_SCHEMA);
+  .merge(getPaginationSchema());
 
 type SearchNameChangesParams = z.infer<typeof inputSchema>;
 

--- a/server/src/api/modules/players/player.controller.ts
+++ b/server/src/api/modules/players/player.controller.ts
@@ -187,11 +187,16 @@ async function records(req: Request): Promise<ControllerResponse> {
 async function snapshots(req: Request): Promise<ControllerResponse> {
   const player = await playerUtils.resolvePlayer(getString(req.params.username));
 
+  let limit = req.query.limit ? getNumber(req.query.limit) : undefined;
+  if (limit && limit > 50) limit = 50;
+
   const results = await snapshotServices.findPlayerSnapshots({
     id: player.id,
     period: getEnum(req.query.period),
     minDate: getDate(req.query.startDate),
-    maxDate: getDate(req.query.endDate)
+    maxDate: getDate(req.query.endDate),
+    limit,
+    offset: getNumber(req.query.offset)
   });
 
   const formattedSnapshots = results.map(s =>

--- a/server/src/api/modules/players/services/SearchPlayersService.ts
+++ b/server/src/api/modules/players/services/SearchPlayersService.ts
@@ -1,12 +1,12 @@
 import { z } from 'zod';
 import prisma, { Player } from '../../../../prisma';
-import { PAGINATION_SCHEMA } from '../../../util/validation';
+import { getPaginationSchema } from '../../../util/validation';
 
 const inputSchema = z
   .object({
     username: z.string().min(1, { message: "Parameter 'username' is undefined." })
   })
-  .merge(PAGINATION_SCHEMA);
+  .merge(getPaginationSchema());
 
 type SearchPlayersParams = z.infer<typeof inputSchema>;
 

--- a/server/src/api/modules/records/services/FindGroupRecordsService.ts
+++ b/server/src/api/modules/records/services/FindGroupRecordsService.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { Period, Metric } from '../../../../utils';
 import prisma from '../../../../prisma';
-import { PAGINATION_SCHEMA } from '../../../util/validation';
+import { getPaginationSchema } from '../../../util/validation';
 import { NotFoundError } from '../../../errors';
 import { RecordLeaderboardEntry } from '../record.types';
 
@@ -11,7 +11,7 @@ const inputSchema = z
     period: z.nativeEnum(Period),
     metric: z.nativeEnum(Metric)
   })
-  .merge(PAGINATION_SCHEMA);
+  .merge(getPaginationSchema());
 
 type FindGroupRecordsParams = z.infer<typeof inputSchema>;
 

--- a/server/src/api/modules/snapshots/services/FindPlayerSnapshotsService.ts
+++ b/server/src/api/modules/snapshots/services/FindPlayerSnapshotsService.ts
@@ -11,7 +11,8 @@ const inputSchema = z
     // or by a time range (min date and max date)
     minDate: z.date().optional(),
     maxDate: z.date().optional(),
-    limit: z.number().int().positive().optional().default(100_000)
+    limit: z.number().int().positive().optional().default(100_000),
+    offset: z.optional(z.number().int().nonnegative("Parameter 'offset' must be >= 0.")).default(0)
   })
   .refine(s => !(s.minDate && s.maxDate && s.minDate >= s.maxDate), {
     message: 'Min date must be before the max date.'
@@ -27,7 +28,8 @@ async function findPlayerSnapshots(payload: FindPlayerSnapshotsParams): Promise<
   const snapshots = await prisma.snapshot.findMany({
     where: { playerId: params.id, ...filterQuery },
     orderBy: { createdAt: 'desc' },
-    take: params.limit
+    take: params.limit,
+    skip: params.offset
   });
 
   return snapshots;

--- a/server/src/api/services/external/metrics.service.ts
+++ b/server/src/api/services/external/metrics.service.ts
@@ -98,18 +98,6 @@ class MetricsService {
     }
   }
 
-  async trackEffectDebug<T>(effectName: string, handler: () => Promise<T>) {
-    const endTimer = this.effectHistogram.startTimer();
-    try {
-      const res = await handler();
-      endTimer({ effectName, status: 1 });
-      return res;
-    } catch (error) {
-      endTimer({ effectName, status: 0 });
-      throw error;
-    }
-  }
-
   async trackJob(jobType: JobType, handler: () => Promise<void>) {
     const endTimer = this.jobHistogram.startTimer();
 

--- a/server/src/api/util/validation.ts
+++ b/server/src/api/util/validation.ts
@@ -34,19 +34,21 @@ z.setErrorMap((issue, ctx) => {
   return { message: ctx.defaultError };
 });
 
-export const PAGINATION_SCHEMA = z.object({
-  limit: z
-    .number()
-    .int()
-    .positive("Parameter 'limit' must be > 0.")
-    .max(
-      50,
-      "The maximum results limit is 50. Please consider using the 'offset' parameter to load more data."
-    )
-    .optional()
-    .default(20),
-  offset: z.number().int().nonnegative("Parameter 'offset' must be >= 0.").optional().default(0)
-});
+export function getPaginationSchema(maxLimit = 50) {
+  let limit = z.number().int().positive("Parameter 'limit' must be > 0.");
+
+  if (maxLimit) {
+    limit = limit.max(
+      maxLimit,
+      `The maximum results limit is ${maxLimit}. Please consider using the 'offset' parameter to load more data.`
+    );
+  }
+
+  return z.object({
+    limit: z.optional(limit).default(20),
+    offset: z.optional(z.number().int().nonnegative("Parameter 'offset' must be >= 0.")).default(0)
+  });
+}
 
 export function getNumber(payload: any): number | undefined {
   if (payload === undefined || payload === null || isNaN(payload) || String(payload).length === 0) {


### PR DESCRIPTION
- Removes max limit of 50 for `/groups/:id/hiscores` and `/groups/:id/gained`
- Adds max limit of 50 for `/players/:username/snapshots`
- Adds warning about frequent player updates in docs