### PR TITLE
[api] Disable CML imports

### DIFF
--- a/server/__tests__/suites/integration/achievements.test.ts
+++ b/server/__tests__/suites/integration/achievements.test.ts
@@ -7,6 +7,7 @@ import apiServer from '../../../src/api';
 import { Achievement, Metric, PlayerType, SKILL_EXP_AT_99 } from '../../../src/utils';
 import * as achievementEvents from '../../../src/api/modules/achievements/achievement.events';
 import { ACHIEVEMENT_TEMPLATES } from '../../../src/api/modules/achievements/achievement.templates';
+import { importPlayerHistory } from '../../../src/api/modules/players/services/ImportPlayerHistoryService';
 import {
   registerCMLMock,
   registerHiscoresMock,
@@ -163,12 +164,13 @@ describe('Achievements API', () => {
       // Setup the CML request to return our mock raw data
       registerCMLMock(axiosMock, 200, globalData.cmlRawData);
 
-      // Import player history
-      const importResponse = await api
-        .post(`/players/Psikoi/import-history`)
-        .send({ adminPassword: process.env.ADMIN_PASSWORD });
+      const player = await prisma.player.findFirst({
+        where: {
+          username: 'psikoi'
+        }
+      });
 
-      expect(importResponse.status).toBe(200);
+      await importPlayerHistory(player);
 
       // Wait a bit for the onPlayerImported hook to fire
       await sleep(500);

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.44",
+  "version": "2.4.45",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.4.44",
+      "version": "2.4.45",
       "license": "ISC",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.44",
+  "version": "2.4.45",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/modules/players/player.events.ts
+++ b/server/src/api/modules/players/player.events.ts
@@ -7,7 +7,6 @@ import { reevaluatePlayerAchievements } from '../achievements/services/Reevaluat
 import { syncPlayerAchievements } from '../achievements/services/SyncPlayerAchievementsService';
 import { syncParticipations } from '../competitions/services/SyncParticipationsService';
 import { syncPlayerDeltas } from '../deltas/services/SyncPlayerDeltasService';
-import { importPlayerHistory } from './services/ImportPlayerHistoryService';
 
 async function onPlayerFlagged(player: Player, flaggedContext: FlaggedPlayerReviewContext) {
   await metrics.trackEffect(discordService.dispatchPlayerFlaggedReview, player, flaggedContext);
@@ -59,8 +58,9 @@ async function onPlayerUpdated(
   // Update this player's deltas (gains)
   await metrics.trackEffect(syncPlayerDeltas, player, current);
 
-  // Attempt to import this player's history from CML
-  await metrics.trackEffect(importPlayerHistory, player);
+  // Disabled for now. CML seems to have disabled their API (or blocked us)
+  // // Attempt to import this player's history from CML
+  // await metrics.trackEffect(importPlayerHistory, player);
 }
 
 async function onPlayerImported(playerId: number) {

--- a/server/src/api/modules/players/player.router.ts
+++ b/server/src/api/modules/players/player.router.ts
@@ -26,7 +26,6 @@ import { changePlayerCountry } from './services/ChangePlayerCountryService';
 import { deletePlayer } from './services/DeletePlayerService';
 import { fetchPlayerDetails } from './services/FetchPlayerDetailsService';
 import { findPlayerArchives } from './services/FindPlayerArchivesService';
-import { importPlayerHistory } from './services/ImportPlayerHistoryService';
 import { searchPlayers } from './services/SearchPlayersService';
 import { updatePlayer } from './services/UpdatePlayerService';
 
@@ -99,7 +98,10 @@ router.get(
     const { id } = req.params;
 
     // Find the username for this player ID.
-    const query = await prisma.player.findFirst({ where: { id } });
+    const query = await prisma.player.findFirst({
+      where: { id },
+      select: { username: true }
+    });
 
     if (!query) {
       throw new NotFoundError('Player not found.');
@@ -108,27 +110,6 @@ router.get(
     const result = await fetchPlayerDetails(query.username);
 
     res.status(200).json(result);
-  })
-);
-
-router.post(
-  '/players/:username/import-history',
-  checkAdminPermission,
-  validateRequest({
-    params: z.object({
-      username: z.string()
-    })
-  }),
-  executeRequest(async (req, res) => {
-    const { username } = req.params;
-
-    const player = await resolvePlayer(username);
-    const { count } = await importPlayerHistory(player);
-
-    res.status(200).json({
-      count,
-      message: `Successfully imported ${count} snapshots from CML.`
-    });
   })
 );
 


### PR DESCRIPTION
CML imports have stopped working, the last successful attempt I can find is from July 2023. I'm not sure if this means they've blocked us, or just restricted their API in some way, regardless, I'm disabling the attempts as they all fail anyways.