### PR TITLE
[api] Reduce usage of player ID cache (as a test)

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.47",
+  "version": "2.4.48",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.4.47",
+      "version": "2.4.48",
       "license": "ISC",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.47",
+  "version": "2.4.48",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/modules/players/player.router.ts
+++ b/server/src/api/modules/players/player.router.ts
@@ -270,9 +270,7 @@ router.get(
     const { username } = req.params;
     const { metric, period, startDate, endDate } = req.query;
 
-    const player = await resolvePlayer(username);
-    const results = await findPlayerSnapshotTimeline(player.id, metric, period, startDate, endDate);
-
+    const results = await findPlayerSnapshotTimeline(username, metric, period, startDate, endDate);
     res.status(200).json(results);
   })
 );
@@ -304,8 +302,7 @@ router.get(
     const { username } = req.params;
     const { limit, offset } = req.query;
 
-    const playerId = await resolvePlayerId(username);
-    const results = await findPlayerMemberships(playerId, { limit, offset });
+    const results = await findPlayerMemberships(username, { limit, offset });
 
     res.status(200).json(results);
   })
@@ -437,9 +434,7 @@ router.get(
   executeRequest(async (req, res) => {
     const { username } = req.params;
 
-    const playerId = await resolvePlayerId(username);
-    const results = await findPlayerAchievementProgress(playerId);
-
+    const results = await findPlayerAchievementProgress(username);
     res.status(200).json(results);
   })
 );


### PR DESCRIPTION
I'm looking to get rid of the player ID cache on our API, this is a Redis based cache that maps player IDs to usernames.

I believe the complexity it adds doesn't outweigh the performance gains, so I'm getting rid of this cache for 3 very popular endpoints to measure the impact on request duration:

Endpoints:
- `/players/:username/snapshots/timeline` (BEFORE: avg. 20 ms request duration)
- `/players/:username/achievements/progress` (BEFORE: avg. 160 ms request duration)
- `/players/:username/groups` (BEFORE: avg. 30 ms request duration)

Note:
`/players/:username/achievements/progress` in particular has a chance of becoming a lot faster due to the use of the "newish" `latestSnapshot` field.