### PR TITLE
[api] Remove player id cache

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.48",
+  "version": "2.4.49",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.4.48",
+      "version": "2.4.49",
       "license": "ISC",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.4.48",
+  "version": "2.4.49",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/modules/competitions/services/FindPlayerParticipationsStandingsService.ts
+++ b/server/src/api/modules/competitions/services/FindPlayerParticipationsStandingsService.ts
@@ -3,12 +3,13 @@ import { findPlayerParticipations } from './FindPlayerParticipationsService';
 import { ParticipationWithCompetitionAndStandings } from '../competition.types';
 import { calculateParticipantsStandings } from './FetchCompetitionDetailsService';
 import { CompetitionStatus } from '../../../../utils';
+import { standardize } from '../../players/player.utils';
 
 async function findPlayerParticipationsStandings(
-  playerId: number,
+  username: string,
   status: CompetitionStatus
 ): Promise<ParticipationWithCompetitionAndStandings[]> {
-  const participations = await findPlayerParticipations(playerId, status);
+  const participations = await findPlayerParticipations(username, status);
 
   const competitionsStandings = await Promise.all(
     participations.map(async p => {
@@ -20,7 +21,7 @@ async function findPlayerParticipationsStandings(
   );
 
   const playerParticipations = competitionsStandings.map(c => {
-    const playerIndex = c.participants.findIndex(p => p.playerId === playerId);
+    const playerIndex = c.participants.findIndex(p => p.player.username === standardize(username));
 
     if (playerIndex === -1) {
       throw new Error("Player couldn't be found in participations list.");

--- a/server/src/api/modules/name-changes/name-change.router.ts
+++ b/server/src/api/modules/name-changes/name-change.router.ts
@@ -3,7 +3,6 @@ import { z } from 'zod';
 import { checkAdminPermission } from '../../util/middlewares';
 import { executeRequest, validateRequest } from '../../util/routing';
 import { getPaginationSchema } from '../../util/validation';
-import { resolvePlayerId } from '../players/player.utils';
 import { NameChangeStatus } from './name-change.types';
 import { approveNameChange } from './services/ApproveNameChangeService';
 import { bulkSubmitNameChanges } from './services/BulkSubmitNameChangesService';
@@ -128,8 +127,7 @@ router.post(
   executeRequest(async (req, res) => {
     const { username } = req.params;
 
-    const playerId = await resolvePlayerId(username);
-    const { count } = await clearNameChangeHistory(playerId);
+    const { count } = await clearNameChangeHistory(username);
 
     res.status(200).json({
       count,

--- a/server/src/api/modules/name-changes/services/ApproveNameChangeService.ts
+++ b/server/src/api/modules/name-changes/services/ApproveNameChangeService.ts
@@ -43,7 +43,6 @@ async function approveNameChange(id: number): Promise<NameChange> {
   if (newPlayer && newPlayer.id !== oldPlayer.id) {
     // Archive the "new" profile, in case we need to restore some of this data later
     await archivePlayer(newPlayer, false);
-    await playerUtils.setCachedPlayerId(newPlayer.username, null);
   }
 
   // Attempt to transfer data between both accounts
@@ -88,10 +87,6 @@ async function approveNameChange(id: number): Promise<NameChange> {
   }
 
   playerEvents.onPlayerNameChanged(updatedPlayer, oldPlayer.displayName);
-
-  // Update the player ID caches
-  await playerUtils.setCachedPlayerId(nameChange.oldName, null);
-  await playerUtils.setCachedPlayerId(nameChange.newName, nameChange.playerId);
 
   logger.moderation(`[NameChange:${nameChange.id}] Approved`);
 

--- a/server/src/api/modules/name-changes/services/ClearNameChangeHistoryService.ts
+++ b/server/src/api/modules/name-changes/services/ClearNameChangeHistoryService.ts
@@ -1,16 +1,29 @@
 import prisma from '../../../../prisma';
-import { BadRequestError } from '../../../errors';
+import { BadRequestError, NotFoundError } from '../../../errors';
+import { standardize } from '../../players/player.utils';
 
-async function clearNameChangeHistory(playerId: number): Promise<{ count: number }> {
+async function clearNameChangeHistory(username: string): Promise<{ count: number }> {
   const { count } = await prisma.nameChange.deleteMany({
-    where: { playerId }
+    where: {
+      player: {
+        username: standardize(username)
+      }
+    }
   });
 
-  if (count === 0) {
-    throw new BadRequestError('No name changes were found for this player.');
+  if (count > 0) {
+    return { count };
   }
 
-  return { count };
+  const player = await prisma.player.findFirst({
+    where: { username: standardize(username) }
+  });
+
+  if (!player) {
+    throw new NotFoundError('Player not found.');
+  }
+
+  throw new BadRequestError('No name changes were found for this player.');
 }
 
 export { clearNameChangeHistory };

--- a/server/src/api/modules/name-changes/services/FindPlayerNameChangesService.ts
+++ b/server/src/api/modules/name-changes/services/FindPlayerNameChangesService.ts
@@ -1,11 +1,30 @@
 import prisma, { NameChange, NameChangeStatus } from '../../../../prisma';
+import { NotFoundError } from '../../../errors';
+import { standardize } from '../../players/player.utils';
 
-async function findPlayerNameChanges(playerId: number): Promise<NameChange[]> {
+async function findPlayerNameChanges(username: string): Promise<NameChange[]> {
   // Query the database for all (approved) name changes of "playerId"
   const nameChanges = await prisma.nameChange.findMany({
-    where: { playerId, status: NameChangeStatus.APPROVED },
-    orderBy: { resolvedAt: 'desc' }
+    where: {
+      player: {
+        username: standardize(username)
+      },
+      status: NameChangeStatus.APPROVED
+    },
+    orderBy: {
+      resolvedAt: 'desc'
+    }
   });
+
+  if (nameChanges.length === 0) {
+    const player = await prisma.player.findFirst({
+      where: { username: standardize(username) }
+    });
+
+    if (!player) {
+      throw new NotFoundError('Player not found.');
+    }
+  }
 
   return nameChanges as NameChange[];
 }

--- a/server/src/api/modules/players/player.router.ts
+++ b/server/src/api/modules/players/player.router.ts
@@ -19,7 +19,7 @@ import { findPlayerSnapshotTimeline } from '../snapshots/services/FindPlayerSnap
 import { findPlayerSnapshots } from '../snapshots/services/FindPlayerSnapshotsService';
 import { rollbackSnapshots } from '../snapshots/services/RollbackSnapshotsService';
 import { formatSnapshot } from '../snapshots/snapshot.utils';
-import { resolvePlayer, resolvePlayerId } from './player.utils';
+import { resolvePlayer } from './player.utils';
 import { archivePlayer } from './services/ArchivePlayerService';
 import { assertPlayerType } from './services/AssertPlayerTypeService';
 import { changePlayerCountry } from './services/ChangePlayerCountryService';
@@ -322,8 +322,7 @@ router.get(
     const { username } = req.params;
     const { status } = req.query;
 
-    const playerId = await resolvePlayerId(username);
-    const results = await findPlayerParticipations(playerId, status);
+    const results = await findPlayerParticipations(username, status);
 
     res.status(200).json(results);
   })
@@ -343,8 +342,7 @@ router.get(
     const { username } = req.params;
     const { status } = req.query;
 
-    const playerId = await resolvePlayerId(username);
-    const results = await findPlayerParticipationsStandings(playerId, status);
+    const results = await findPlayerParticipationsStandings(username, status);
 
     res.status(200).json(results);
   })
@@ -360,8 +358,7 @@ router.get(
   executeRequest(async (req, res) => {
     const { username } = req.params;
 
-    const playerId = await resolvePlayerId(username);
-    const results = await findPlayerNameChanges(playerId);
+    const results = await findPlayerNameChanges(username);
 
     res.status(200).json(results);
   })

--- a/server/src/api/modules/players/player.router.ts
+++ b/server/src/api/modules/players/player.router.ts
@@ -19,7 +19,7 @@ import { findPlayerSnapshotTimeline } from '../snapshots/services/FindPlayerSnap
 import { findPlayerSnapshots } from '../snapshots/services/FindPlayerSnapshotsService';
 import { rollbackSnapshots } from '../snapshots/services/RollbackSnapshotsService';
 import { formatSnapshot } from '../snapshots/snapshot.utils';
-import { resolvePlayer } from './player.utils';
+import { standardize } from './player.utils';
 import { archivePlayer } from './services/ArchivePlayerService';
 import { assertPlayerType } from './services/AssertPlayerTypeService';
 import { changePlayerCountry } from './services/ChangePlayerCountryService';
@@ -123,7 +123,14 @@ router.post(
   executeRequest(async (req, res) => {
     const { username } = req.params;
 
-    const player = await resolvePlayer(username);
+    const player = await prisma.player.findFirst({
+      where: { username: standardize(username) }
+    });
+
+    if (!player) {
+      throw new NotFoundError('Player not found.');
+    }
+
     const [, updatedPlayer, changed] = await assertPlayerType(player, true);
 
     res.status(200).json({ player: updatedPlayer, changed });
@@ -165,7 +172,13 @@ router.post(
     const { username } = req.params;
     const { untilLastChange } = req.body;
 
-    const player = await resolvePlayer(username);
+    const player = await prisma.player.findFirst({
+      where: { username: standardize(username) }
+    });
+
+    if (!player) {
+      throw new NotFoundError('Player not found.');
+    }
 
     await rollbackSnapshots(
       player.id,
@@ -191,7 +204,13 @@ router.post(
   executeRequest(async (req, res) => {
     const { username } = req.params;
 
-    const player = await resolvePlayer(username);
+    const player = await prisma.player.findFirst({
+      where: { username: standardize(username) }
+    });
+
+    if (!player) {
+      throw new NotFoundError('Player not found.');
+    }
 
     const { archivedPlayer } = await archivePlayer(player);
 
@@ -242,7 +261,14 @@ router.get(
     const { username } = req.params;
     const { period, startDate, endDate, ...pagination } = req.query;
 
-    const player = await resolvePlayer(username);
+    const player = await prisma.player.findFirst({
+      where: { username: standardize(username) }
+    });
+
+    if (!player) {
+      throw new NotFoundError('Player not found.');
+    }
+
     const results = await findPlayerSnapshots(player.id, period, startDate, endDate, pagination);
 
     const formattedSnapshots = results.map(s => {

--- a/server/src/api/modules/players/player.utils.ts
+++ b/server/src/api/modules/players/player.utils.ts
@@ -1,7 +1,6 @@
 import { Period, PeriodProps, PlayerBuild, PlayerDetails } from '../../../utils';
 import prisma, { Player, PlayerArchive, Snapshot } from '../../../prisma';
 import { BadRequestError, NotFoundError } from '../../errors';
-import redisService from '../../services/external/redis.service';
 import * as snapshotUtils from '../snapshots/snapshot.utils';
 import { getPlayerEfficiencyMap } from '../efficiency/efficiency.utils';
 import { formatSnapshot } from '../snapshots/snapshot.utils';
@@ -21,27 +20,6 @@ function formatPlayerDetails(player: Player, snapshot?: Snapshot, archive?: Play
   };
 }
 
-async function resolvePlayerId(username: string): Promise<number | null> {
-  if (!username || username.length === 0) {
-    throw new BadRequestError(`Parameter 'username' is undefined.`);
-  }
-
-  const cachedId = await getCachedPlayerId(username);
-  if (cachedId) return cachedId;
-
-  // Include username in the selected fields too, so that it can be cached for later
-  const player = await prisma.player.findFirst({
-    where: { username: standardize(username) },
-    select: { id: true, username: true }
-  });
-
-  if (!player) {
-    throw new NotFoundError('Player not found.');
-  }
-
-  return player.id;
-}
-
 async function resolvePlayer(username: string): Promise<Player | null> {
   if (!username || username.length === 0) {
     throw new BadRequestError('Undefined username.');
@@ -56,24 +34,6 @@ async function resolvePlayer(username: string): Promise<Player | null> {
   }
 
   return player;
-}
-
-async function getCachedPlayerId(username: string): Promise<number | null> {
-  if (!username || username.length === 0) return null;
-
-  const id = await redisService.getValue('player', standardize(username));
-  return id ? Number(id) : null;
-}
-
-async function setCachedPlayerId(username: string, id: number | null) {
-  if (!username || username.length === 0) return;
-
-  if (id !== null) {
-    // Store this username->ID in cache for an hour
-    await redisService.setValue('player', standardize(username), id, 3_600_000);
-  } else {
-    await redisService.deleteKey(`player:${standardize(username)}`);
-  }
 }
 
 /**
@@ -225,7 +185,5 @@ export {
   shouldImport,
   getBuild,
   resolvePlayer,
-  resolvePlayerId,
-  setCachedPlayerId,
   splitArchivalData
 };

--- a/server/src/api/modules/players/player.utils.ts
+++ b/server/src/api/modules/players/player.utils.ts
@@ -1,6 +1,5 @@
 import { Period, PeriodProps, PlayerBuild, PlayerDetails } from '../../../utils';
 import prisma, { Player, PlayerArchive, Snapshot } from '../../../prisma';
-import { BadRequestError, NotFoundError } from '../../errors';
 import * as snapshotUtils from '../snapshots/snapshot.utils';
 import { getPlayerEfficiencyMap } from '../efficiency/efficiency.utils';
 import { formatSnapshot } from '../snapshots/snapshot.utils';
@@ -18,22 +17,6 @@ function formatPlayerDetails(player: Player, snapshot?: Snapshot, archive?: Play
     archive: archive ? archive : null,
     latestSnapshot: formatSnapshot(snapshot, efficiency)
   };
-}
-
-async function resolvePlayer(username: string): Promise<Player | null> {
-  if (!username || username.length === 0) {
-    throw new BadRequestError('Undefined username.');
-  }
-
-  const player = await prisma.player.findFirst({
-    where: { username: standardize(username) }
-  });
-
-  if (!player) {
-    throw new NotFoundError('Player not found.');
-  }
-
-  return player;
 }
 
 /**
@@ -184,6 +167,5 @@ export {
   isValidUsername,
   shouldImport,
   getBuild,
-  resolvePlayer,
   splitArchivalData
 };

--- a/server/src/api/modules/players/services/ArchivePlayerService.ts
+++ b/server/src/api/modules/players/services/ArchivePlayerService.ts
@@ -100,8 +100,6 @@ async function archivePlayer(player: Player, createNewPlayer = true): Promise<Ar
       throw new ServerError('Failed to archive player');
     });
 
-  await playerUtils.setCachedPlayerId(player.username, null);
-
   playerEvents.onPlayerArchived(result.archivedPlayer, player.displayName);
 
   return result;

--- a/server/src/api/modules/players/services/ArchivePlayerService.ts
+++ b/server/src/api/modules/players/services/ArchivePlayerService.ts
@@ -3,7 +3,7 @@ import { ServerError } from '../../../../api/errors';
 import logger from '../../../util/logging';
 import prisma, { NameChangeStatus, Player, setHooksEnabled } from '../../../../prisma';
 import * as discordService from '../../../services/external/discord.service';
-import * as playerUtils from '../player.utils';
+import { splitArchivalData } from '../player.utils';
 import * as playerEvents from '../player.events';
 import { findPlayerSnapshot } from '../../snapshots/services/FindPlayerSnapshotService';
 
@@ -13,13 +13,13 @@ interface ArchivePlayerResult {
 }
 
 async function archivePlayer(player: Player, createNewPlayer = true): Promise<ArchivePlayerResult> {
-  let splitData: Awaited<ReturnType<typeof playerUtils.splitArchivalData>> | null = null;
+  let splitData: Awaited<ReturnType<typeof splitArchivalData>> | null = null;
 
   if (createNewPlayer) {
     const latestSnapshot = await findPlayerSnapshot({ id: player.id });
 
     // Get all the memberships and participations that should be transfered to the new player
-    splitData = await playerUtils.splitArchivalData(player.id, latestSnapshot.createdAt);
+    splitData = await splitArchivalData(player.id, latestSnapshot.createdAt);
   }
 
   // Find a free random username for the archived player (archive#####)

--- a/server/src/api/modules/players/services/DeletePlayerService.ts
+++ b/server/src/api/modules/players/services/DeletePlayerService.ts
@@ -1,16 +1,13 @@
 import prisma, { Player } from '../../../../prisma';
 import { NotFoundError } from '../../../errors';
 import logger from '../../../util/logging';
-import { setCachedPlayerId, standardize } from '../player.utils';
+import { standardize } from '../player.utils';
 
 async function deletePlayer(username: string): Promise<Player> {
   try {
     const deletedPlayer = await prisma.player.delete({
       where: { username: standardize(username) }
     });
-
-    // Clear this player's ID cache
-    await setCachedPlayerId(deletedPlayer.username, null);
 
     logger.moderation(`[Player:${deletedPlayer.username}] Deleted`);
 

--- a/server/src/prisma/hooks.ts
+++ b/server/src/prisma/hooks.ts
@@ -1,6 +1,5 @@
 import { Prisma } from '@prisma/client';
 import * as groupEvents from '../api/modules/groups/group.events';
-import * as playerUtils from '../api/modules/players/player.utils';
 import * as competitionEvents from '../api/modules/competitions/competition.events';
 import * as achievementEvents from '../api/modules/achievements/achievement.events';
 import { ActivityType } from './enum-adapter';
@@ -50,25 +49,4 @@ export function routeAfterHook(params: Prisma.MiddlewareParams, result: any) {
 
     return;
   }
-
-  if (params.model === 'Player') {
-    if (
-      params.action === 'findFirst' ||
-      params.action === 'findUnique' ||
-      params.action === 'create' ||
-      params.action === 'update'
-    ) {
-      updatePlayerIdCache(result);
-    }
-    return;
-  }
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function updatePlayerIdCache(result: any) {
-  if (!result || !result.id || !result.username) {
-    return;
-  }
-
-  playerUtils.setCachedPlayerId(result.username, result.id);
 }


### PR DESCRIPTION
Follow up to #1445 

By removing some instances of the player ID cache on #1445 , the performance does not seem to be affected as the graphs "request duration" graphs below show (it actually improved for Player Achievements, but for unrelated reasons).

I'm removing the player ID cache altogether as it adds complexity and potential points of failure for very little performance gain (classic over/early optimization)


Blue line is the deployment of #1445 
![image](https://github.com/wise-old-man/wise-old-man/assets/3278148/45d68bbc-0bd1-4081-b723-a411accea722)



