### PR TITLE
[api] Recalculate player achievements on name change approved

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.5.2",
+      "version": "2.5.3",
       "license": "ISC",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/modules/players/player.events.ts
+++ b/server/src/api/modules/players/player.events.ts
@@ -32,6 +32,11 @@ async function onPlayerTypeChanged(player: Player, previousType: PlayerType) {
 }
 
 async function onPlayerNameChanged(player: Player, previousDisplayName: string) {
+  // Reevaluate this player's achievements to try and find earlier completion dates as there might be new data
+  await metrics.trackEffect('reevaluatePlayerAchievements', async () => {
+    await reevaluatePlayerAchievements(player.id);
+  });
+
   // Dispatch a "Player name changed" event to our discord bot API.
   await metrics.trackEffect('dispatchNameChanged', async () => {
     await discordService.dispatchNameChanged(player, previousDisplayName);


### PR DESCRIPTION
When a name change is approved (by merging profiles or restoring archived profiles), new snapshots might be available, so it's a good idea to recalculate players' achievements as we might be able to calc achievement dates with more accuracy with this new data.