### PR TITLE
#1459 Build both a cjs and esm bundle

### DIFF
--- a/client-js/package.json
+++ b/client-js/package.json
@@ -16,8 +16,18 @@
     "type": "git",
     "url": "https://github.com/wise-old-man/wise-old-man.git"
   },
-  "main": "dist/index.js",
+  "main": "dist/cjs/index.cjs",
   "types": "dist/index.d.ts",
+  "module": "dist/es/index.js",
+  "type": "module",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/es/index.mjs",
+      "default": "./dist/cjs/index.cjs"
+    }
+  },
   "files": [
     "dist"
   ],

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "3.1.16",
+  "version": "3.1.17",
   "description": "A JavaScript/TypeScript client that interfaces and consumes the Wise Old Man API, an API that tracks and measures players' progress in Old School Runescape.",
   "keywords": [
     "wiseoldman",

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -18,7 +18,6 @@
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "type": "module",
   "files": [
     "dist"
   ],

--- a/client-js/rollup.config.js
+++ b/client-js/rollup.config.js
@@ -2,11 +2,42 @@ import dts from 'rollup-plugin-dts';
 import typescript from '@rollup/plugin-typescript';
 
 export default [
+  //commonJs
   {
     input: 'src/index.ts',
     output: {
-      dir: 'dist',
+      file: 'dist/cjs/index.cjs',
       format: 'cjs',
+      external: ['dayjs'],
+      sourcemap: false
+    },
+    plugins: [
+      typescript({
+        tsconfig: './tsconfig.json'
+      })
+    ]
+  },
+  // ES Modules
+  {
+    input: 'src/index.ts',
+    output: {
+      file: 'dist/es/index.js',
+      format: 'es',
+      external: ['dayjs'],
+      sourcemap: false
+    },
+    plugins: [
+      typescript({
+        tsconfig: './tsconfig.json'
+      })
+    ]
+  },
+  // ES for browsers
+  {
+    input: 'src/index.ts',
+    output: {
+      file: 'dist/es/index.mjs',
+      format: 'es',
       external: ['dayjs'],
       sourcemap: false
     },


### PR DESCRIPTION
Since we are still only building a commonJS bundle and no esm bundle we should remove the module declaration so projects using esm don't blow up.

Future steps:
export both bundles