### PR TITLE
[api] Fix merging name changes on name chsange approved

### DIFF
--- a/server/__tests__/suites/integration/names.test.ts
+++ b/server/__tests__/suites/integration/names.test.ts
@@ -355,6 +355,19 @@ describe('Names API', () => {
       });
     });
 
+    it('should fetch details (valid newStats, newPlayer not tracked)', async () => {
+      const updateResponse = await api.post(`/names`).send({ oldName: 'Psikoi', newName: 'vessel' });
+      expect(updateResponse.status).toBe(201);
+
+      // Get the name change details
+      const response = await api.get(`/names/${updateResponse.body.id}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.data.oldStats).not.toBeNull();
+      // Even if newPlayer cannot be found on our db, newStats might still be gathered from newName's hiscores
+      expect(response.body.data.newStats).not.toBeNull();
+    });
+
     it('should fetch details (approved name change, no data)', async () => {
       const response = await api.get(`/names/${globalData.secondNameChangeId}`);
 
@@ -393,11 +406,11 @@ describe('Names API', () => {
       const response = await api.get(`/names`);
 
       expect(response.status).toBe(200);
-      expect(response.body.length).toBe(6);
-      expect(response.body.filter(n => n.status === 'pending').length).toBe(4);
+      expect(response.body.length).toBe(7);
+      expect(response.body.filter(n => n.status === 'pending').length).toBe(5);
       expect(response.body.filter(n => n.status === 'approved').length).toBe(2);
-      expect(response.body.filter(n => n.oldName === 'Zezima').length).toBe(1);
-      expect(response.body.filter(n => n.oldName === 'psikoi').length).toBe(2);
+      expect(response.body.filter(n => n.oldName.toLowerCase() === 'zezima').length).toBe(1);
+      expect(response.body.filter(n => n.oldName.toLowerCase() === 'psikoi').length).toBe(3);
     });
 
     it('should fetch list (filtered by status)', async () => {
@@ -1325,8 +1338,8 @@ describe('Names API', () => {
         .send({ adminPassword: process.env.ADMIN_PASSWORD });
 
       expect(response.status).toBe(200);
-      expect(response.body.count).toBe(5);
-      expect(response.body.message).toMatch('Successfully deleted 5 name changes.');
+      expect(response.body.count).toBe(6);
+      expect(response.body.message).toMatch('Successfully deleted 6 name changes.');
 
       const fetchResponse = await api.get(`/players/usbc/names`);
       expect(fetchResponse.status).toBe(200);

--- a/server/__tests__/suites/integration/names.test.ts
+++ b/server/__tests__/suites/integration/names.test.ts
@@ -822,6 +822,22 @@ describe('Names API', () => {
         metric: 'herblore'
       });
 
+      // Check if none of the pre-transition name changes have been transfered
+      const mainNameChangesResponse = await api.get(`/players/USBC/names`);
+
+      expect(mainNameChangesResponse.status).toBe(200);
+      expect(mainNameChangesResponse.body.length).toBe(2);
+      expect(mainNameChangesResponse.body[0]).toMatchObject({
+        newName: 'usbc',
+        oldName: 'wtv post',
+        status: 'approved'
+      });
+      expect(mainNameChangesResponse.body[1]).toMatchObject({
+        newName: 'USBC',
+        oldName: 'psikoi',
+        status: 'approved'
+      });
+
       const detailsResponse = await api.get(`/players/USBC`);
 
       expect(detailsResponse.status).toBe(200);
@@ -1190,7 +1206,7 @@ describe('Names API', () => {
       const fetchResponse = await api.get(`/groups/${globalData.testGroupId}/name-changes`);
 
       expect(fetchResponse.status).toBe(200);
-      expect(fetchResponse.body.length).toBe(4); // 3 name changes from Jakesterwars, 1 from USBC
+      expect(fetchResponse.body.length).toBe(5); // 3 name changes from Jakesterwars, 2 from USBC
       expect(fetchResponse.body[0].player.username).toBe('usbc');
 
       const fetchResponseLimited = await api
@@ -1309,8 +1325,8 @@ describe('Names API', () => {
         .send({ adminPassword: process.env.ADMIN_PASSWORD });
 
       expect(response.status).toBe(200);
-      expect(response.body.count).toBe(4);
-      expect(response.body.message).toMatch('Successfully deleted 4 name changes.');
+      expect(response.body.count).toBe(5);
+      expect(response.body.message).toMatch('Successfully deleted 5 name changes.');
 
       const fetchResponse = await api.get(`/players/usbc/names`);
       expect(fetchResponse.status).toBe(200);
@@ -1322,7 +1338,48 @@ describe('Names API', () => {
 async function seedPreTransitionData(oldPlayerId: number, newPlayerId: number) {
   const mockDate = new Date();
 
+  const newPlayer = await prisma.player.findFirst({
+    where: {
+      id: newPlayerId
+    }
+  });
+
+  if (!newPlayer) {
+    throw new Error('New player not found');
+  }
+
   await prisma.player.update({ where: { id: newPlayerId }, data: { country: 'PT' } });
+
+  // Pending name change
+  await prisma.nameChange.create({
+    data: {
+      oldName: 'idk',
+      newName: newPlayer.username,
+      playerId: newPlayerId
+    }
+  });
+
+  // Approved name change, 20 mins before the mock date
+  await prisma.nameChange.create({
+    data: {
+      oldName: 'wtv',
+      status: 'approved',
+      resolvedAt: new Date(mockDate.getTime() - 1_200_000),
+      newName: newPlayer.username,
+      playerId: newPlayerId
+    }
+  });
+
+  // Denied name change, 10 mins before the mock date
+  await prisma.nameChange.create({
+    data: {
+      oldName: 'pls',
+      status: 'denied',
+      resolvedAt: new Date(mockDate.getTime() - 600_000),
+      newName: newPlayer.username,
+      playerId: newPlayerId
+    }
+  });
 
   // Create a few pre-transition-date records
   await prisma.record.createMany({
@@ -1377,6 +1434,47 @@ async function seedPreTransitionData(oldPlayerId: number, newPlayerId: number) {
 }
 
 async function seedPostTransitionData(oldPlayerId: number, newPlayerId: number) {
+  const newPlayer = await prisma.player.findFirst({
+    where: {
+      id: newPlayerId
+    }
+  });
+
+  if (!newPlayer) {
+    throw new Error('New player not found');
+  }
+
+  // Pending name change
+  await prisma.nameChange.create({
+    data: {
+      oldName: 'idk post',
+      newName: newPlayer.username,
+      playerId: newPlayerId
+    }
+  });
+
+  // Approved name change
+  await prisma.nameChange.create({
+    data: {
+      oldName: 'wtv post',
+      status: 'approved',
+      resolvedAt: new Date(Date.now() + 300_000),
+      newName: newPlayer.username,
+      playerId: newPlayerId
+    }
+  });
+
+  // Denied name change
+  await prisma.nameChange.create({
+    data: {
+      oldName: 'pls post',
+      status: 'denied',
+      resolvedAt: new Date(Date.now() + 600_000),
+      newName: newPlayer.username,
+      playerId: newPlayerId
+    }
+  });
+
   // Create a few post-transition-date records
   await prisma.record.createMany({
     data: [

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "ISC",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/modules/name-changes/services/ApproveNameChangeService.ts
+++ b/server/src/api/modules/name-changes/services/ApproveNameChangeService.ts
@@ -169,6 +169,9 @@ async function transferPlayerData(
         // Transfer all participations from the newPlayer (post transition date) to the old player
         await transferParticipations(tx, oldPlayer.id, newPlayer.id, transitionDate);
 
+        // Transfer all approved name changes from the newPlayer (post transition date) to the old player
+        await transferNameChanges(tx, oldPlayer.id, newPlayer.id, transitionDate);
+
         // Transfer all records from the newPlayer (post transition date) to the old player
         await transferRecords(tx, oldPlayer.id, oldRecords, newRecords);
 
@@ -299,6 +302,25 @@ function transferSnapshots(
     where: {
       playerId: newPlayerId,
       createdAt: { gte: transitionDate }
+    },
+    data: {
+      playerId: oldPlayerId
+    }
+  });
+}
+
+function transferNameChanges(
+  transaction: PrismaTypes.TransactionClient,
+  oldPlayerId: number,
+  newPlayerId: number,
+  transitionDate: Date
+) {
+  // Transfer all approved name changes (post transition) to the old player id
+  return transaction.nameChange.updateMany({
+    where: {
+      playerId: newPlayerId,
+      status: NameChangeStatus.APPROVED,
+      resolvedAt: { gte: transitionDate }
     },
     data: {
       playerId: oldPlayerId

--- a/server/src/api/modules/name-changes/services/FetchNameChangeDetailsService.ts
+++ b/server/src/api/modules/name-changes/services/FetchNameChangeDetailsService.ts
@@ -138,7 +138,7 @@ async function fetchNameChangeDetails(id: number): Promise<NameChangeDetails> {
       ehpDiff: newStats.ehpValue - oldStats.ehpValue,
       ehbDiff: newStats.ehbValue - oldStats.ehbValue,
       oldStats: formatSnapshot(oldStats, getPlayerEfficiencyMap(oldStats, oldPlayer)),
-      newStats: newPlayer ? formatSnapshot(newStats, getPlayerEfficiencyMap(newStats, newPlayer)) : null
+      newStats: formatSnapshot(newStats, getPlayerEfficiencyMap(newStats, newPlayer ?? oldPlayer))
     }
   };
 }


### PR DESCRIPTION
Fixes #1460 

- When merging data from two player profiles (post name change approval), also include newPlayer's approved name changes
- Fix `newStats` returning null for all non-tracked players on the name change details endpoint

Next steps:
- Possibly auto-fix name change history on every new approval, more context at https://discord.com/channels/679454777708380161/696219254076342312/1213628359834075197