### PR TITLE
[api] Optimize competition search queries

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.5.5",
+      "version": "2.5.6",
       "license": "ISC",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",


### PR DESCRIPTION
Currently Prisma is slow at joining multiple tables, as it does that by querying multiple times (and over fetching) and then joining the results on the Rust engine, this will soon be improved by their `relationJoins` feature (currently in preview).

But for now, to avoid using this preview feature, I'll just query the things I need separately, as I can be a bit more intentional with the data I need to query for.





