### PR TITLE
[api] Prevent duplicated data entry on name change approvals

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.5.6",
+      "version": "2.5.7",
       "license": "ISC",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",


### PR DESCRIPTION
Prisma doesn't support `skipDuplicates` for `updateMany` operations, so to prevent duplicating memberships and participations when merging two player profiles, we must dedupe that manually.