### PR TITLE
[api] Add new experimental class-based job queue manager

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.5.8",
+  "version": "2.5.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.5.8",
+      "version": "2.5.9",
       "license": "ISC",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.5.8",
+  "version": "2.5.9",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -5,6 +5,7 @@ import express, { Express } from 'express';
 import { RateLimiterRedis } from 'rate-limiter-flexible';
 import userAgent from 'express-useragent';
 import { jobManager } from './jobs';
+import experimentalJobManager from '../jobs/job.manager';
 import router from './routing';
 import metricsService from './services/external/metrics.service';
 import redisService from './services/external/redis.service';
@@ -28,6 +29,7 @@ class API {
     this.express = express();
 
     jobManager.init();
+    experimentalJobManager.init();
 
     if (process.env.NODE_ENV !== 'test') {
       this.setupServices();
@@ -38,8 +40,9 @@ class API {
   }
 
   async shutdown() {
-    redisService.shutdown();
     await jobManager.shutdown();
+    await experimentalJobManager.shutdown();
+    redisService.shutdown();
   }
 
   private setupMiddlewares() {

--- a/server/src/api/jobs/instances/CheckPlayerRankedJob.ts
+++ b/server/src/api/jobs/instances/CheckPlayerRankedJob.ts
@@ -2,8 +2,9 @@ import prisma from '../../../prisma';
 import { PlayerStatus } from '../../../utils';
 import { BadRequestError } from '../../errors';
 import * as jagexService from '../../services/external/jagex.service';
-import jobManager from '../job.manager';
 import { JobType, JobDefinition, JobOptions } from '../job.types';
+import experimentalJobManager from '../../../jobs/job.manager';
+import { CheckPlayerBannedJob } from '../../../jobs/instances/CheckPlayerBannedJob';
 
 export interface CheckPlayerRankedPayload {
   username: string;
@@ -51,10 +52,7 @@ class CheckPlayerRankedJob implements JobDefinition<CheckPlayerRankedPayload> {
 
     // Being unranked could also mean a player is banned, so if we determine
     // that they're not on the hiscores, check if they're banned on RuneMetrics.
-    jobManager.add({
-      type: JobType.CHECK_PLAYER_BANNED,
-      payload: { username: data.username }
-    });
+    await experimentalJobManager.add(new CheckPlayerBannedJob(data.username));
   }
 }
 

--- a/server/src/api/jobs/job.manager.ts
+++ b/server/src/api/jobs/job.manager.ts
@@ -61,10 +61,10 @@ const CRON_JOBS = [
     type: JobType.SCHEDULE_COMPETITION_EVENTS,
     interval: '* * * * *' // every 1 min
   },
-  {
-    type: JobType.SYNC_API_KEYS,
-    interval: '* * * * *' // every 1 min
-  },
+  // {
+  //   type: JobType.SYNC_API_KEYS, // moved to the experimental job manager, for monitoring
+  //   interval: '* * * * *' // every 1 min
+  // },
   {
     type: JobType.SYNC_PATRONS,
     interval: '* * * * *' // every 1 min

--- a/server/src/api/services/external/metrics.service.ts
+++ b/server/src/api/services/external/metrics.service.ts
@@ -88,14 +88,14 @@ class MetricsService {
     logger.info(`Effect: ${effectName} (${Date.now() - startTime} ms)`);
   }
 
-  async trackJob(jobType: JobType, handler: () => Promise<void>) {
+  async trackJob(jobType: JobType | string, handler: () => Promise<void>) {
     const endTimer = this.jobHistogram.startTimer();
 
     try {
       await handler();
-      endTimer({ jobName: jobType.toString(), status: 1 });
+      endTimer({ jobName: String(jobType), status: 1 });
     } catch (error) {
-      endTimer({ jobName: jobType.toString(), status: 0 });
+      endTimer({ jobName: String(jobType), status: 0 });
       throw error;
     }
   }

--- a/server/src/jobs/instances/CheckPlayerBannedJob.ts
+++ b/server/src/jobs/instances/CheckPlayerBannedJob.ts
@@ -1,0 +1,47 @@
+import { standardize } from '../../api/modules/players/player.utils';
+import { checkIsBanned } from '../../api/services/external/jagex.service';
+import prisma from '../../prisma';
+import { PlayerStatus } from '../../utils';
+import { Job } from '../job.utils';
+
+class CheckPlayerBannedJob extends Job {
+  private username: string;
+
+  constructor(username: string) {
+    super(username);
+    this.username = username;
+
+    this.options = {
+      rateLimiter: { max: 1, duration: 5000 }
+    };
+  }
+
+  async execute() {
+    const username = standardize(this.username);
+
+    const player = await prisma.player.findFirst({
+      where: { username }
+    });
+
+    if (!player) return;
+
+    const isBanned = await checkIsBanned(username);
+
+    if (player.status === PlayerStatus.UNRANKED && isBanned) {
+      await prisma.player.update({
+        where: { username },
+        data: { status: PlayerStatus.BANNED }
+      });
+      return;
+    }
+
+    if (player.status === PlayerStatus.BANNED && !isBanned) {
+      await prisma.player.update({
+        where: { username },
+        data: { status: PlayerStatus.UNRANKED }
+      });
+    }
+  }
+}
+
+export { CheckPlayerBannedJob };

--- a/server/src/jobs/instances/SyncApiKeysJob.ts
+++ b/server/src/jobs/instances/SyncApiKeysJob.ts
@@ -1,0 +1,16 @@
+import redisService from '../../api/services/external/redis.service';
+import prisma from '../../prisma';
+import { Job } from '../job.utils';
+
+class SyncApiKeysJob extends Job {
+  async execute() {
+    const apiKeys = await prisma.apiKey.findMany();
+
+    // Cache all these api keys in Redis, so that they can be quickly accessed on every API request
+    for (const key of apiKeys) {
+      await redisService.setValue('api-key', key.id, String(key.master));
+    }
+  }
+}
+
+export { SyncApiKeysJob };

--- a/server/src/jobs/job.manager.ts
+++ b/server/src/jobs/job.manager.ts
@@ -1,0 +1,155 @@
+import { Job as BullJob, Queue, QueueScheduler, Worker } from 'bullmq';
+import metricsService from '../api/services/external/metrics.service';
+import logger from '../api/util/logging';
+import redisConfig from '../config/redis.config';
+import { getThreadIndex } from '../env';
+import { CheckPlayerBannedJob } from './instances/CheckPlayerBannedJob';
+import { SyncApiKeysJob } from './instances/SyncApiKeysJob';
+import { Job, JobPriority } from './job.utils';
+
+const JOBS: (typeof Job)[] = [SyncApiKeysJob, CheckPlayerBannedJob];
+
+const CRON_CONFIG = [
+  {
+    interval: '* * * * *',
+    job: SyncApiKeysJob
+  }
+];
+
+class JobManager {
+  private queues: Queue[];
+  private workers: Worker[];
+  private schedulers: QueueScheduler[];
+
+  constructor() {
+    this.queues = [];
+    this.workers = [];
+    this.schedulers = [];
+  }
+
+  async add(job: Job) {
+    if (process.env.NODE_ENV === 'test') return;
+
+    const matchingQueue = this.queues.find(queue => queue.name === job.jobName);
+
+    if (!matchingQueue) {
+      throw new Error(`No job implementation found for "${job.jobName}".`);
+    }
+
+    const opts = {
+      ...job.options,
+      priority: job.options.priority || JobPriority.MEDIUM
+    };
+
+    if (job.instanceId) {
+      opts.jobId = job.instanceId;
+    }
+
+    await matchingQueue.add(job.jobName, job, opts);
+
+    logger.info(`Added job: ${job.jobName}`, job.instanceId, true);
+  }
+
+  private async processJob(bullJob: BullJob, jobType: typeof Job) {
+    const instance = new jobType();
+    Object.assign(instance, bullJob.data);
+
+    const maxAttempts = bullJob.opts.attempts || 1;
+    const attemptTag = maxAttempts > 1 ? `(#${bullJob.attemptsMade})` : '';
+
+    try {
+      logger.info(`Executing job: ${bullJob.name} ${attemptTag}`, instance.instanceId, true);
+
+      await metricsService.trackJob(bullJob.name, async () => {
+        await instance.execute();
+      });
+
+      instance.onSuccess();
+    } catch (error) {
+      logger.error(`Failed job: ${bullJob.name}`, { ...bullJob.data, error }, true);
+
+      if (bullJob.attemptsMade >= maxAttempts) {
+        instance.onFailedAllAttempts(error);
+      }
+
+      instance.onFailure(error);
+    }
+  }
+
+  async init() {
+    for (const jobType of JOBS) {
+      const { jobName, options } = new jobType();
+
+      const scheduler = new QueueScheduler(jobName, {
+        connection: redisConfig
+      });
+
+      const queue = new Queue(jobName, {
+        connection: redisConfig,
+        defaultJobOptions: { removeOnComplete: true, removeOnFail: true, ...(options || {}) }
+      });
+
+      const worker = new Worker(
+        jobName,
+        bullJob => {
+          return this.processJob(bullJob, jobType);
+        },
+        {
+          limiter: options?.rateLimiter,
+          connection: redisConfig,
+          autorun: false
+        }
+      );
+
+      this.schedulers.push(scheduler);
+      this.queues.push(queue);
+      this.workers.push(worker);
+    }
+
+    for (const worker of this.workers) {
+      worker.run();
+    }
+
+    for (const queue of this.queues) {
+      const activeJobs = await queue.getRepeatableJobs();
+
+      for (const job of activeJobs) {
+        await queue.removeRepeatableByKey(job.key);
+      }
+    }
+
+    // If running through pm2 (production), only run cronjobs on the first CPU core.
+    // Otherwise, on a 4 core server, every cronjob would run 4x as often.
+    if (getThreadIndex() !== 0 && process.env.NODE_ENV !== 'development') {
+      return;
+    }
+
+    for (const cron of CRON_CONFIG) {
+      const { jobName } = new cron.job();
+      const matchingQueue = this.queues.find(q => q.name === jobName);
+
+      if (!matchingQueue) {
+        throw new Error(`No job implementation found for type "${jobName}".`);
+      }
+
+      logger.info('Scheduling cron job', { jobName, interval: cron.interval }, true);
+      matchingQueue.add(jobName, {}, { repeat: { pattern: cron.interval } });
+    }
+  }
+
+  async shutdown() {
+    for (const queue of this.queues) {
+      await queue.close();
+    }
+
+    for (const worker of this.workers) {
+      await worker.close();
+    }
+
+    for (const scheduler of this.schedulers) {
+      await scheduler.close();
+    }
+  }
+}
+
+export default new JobManager();

--- a/server/src/jobs/job.utils.ts
+++ b/server/src/jobs/job.utils.ts
@@ -1,0 +1,44 @@
+import { JobsOptions, RateLimiterOptions } from 'bullmq';
+
+export enum JobPriority {
+  LOW = 3,
+  MEDIUM = 2,
+  HIGH = 1
+}
+
+interface Options extends JobsOptions {
+  rateLimiter?: RateLimiterOptions;
+}
+
+export class Job {
+  public jobName: string;
+  public options: Options;
+  public instanceId: string | undefined;
+
+  constructor(instanceId?: unknown) {
+    this.jobName = this.constructor.name;
+    this.options = {};
+
+    if (instanceId) {
+      // Any job that provides an instanceId will be deduplicated in the queue
+      // Ex: if two instances of UpdatePlayerJob("psikoi") were to be added,
+      // the second one would be discarded while the first one is still in queue or processing.
+      this.instanceId = String(instanceId);
+    }
+  }
+
+  async execute(): Promise<void> {}
+  async onSuccess(): Promise<void> {}
+  async onFailure(_error: Error): Promise<void> {}
+  async onFailedAllAttempts(_error: Error): Promise<void> {}
+
+  public setDelay(milliseconds: number): Job {
+    this.options.delay = milliseconds;
+    return this;
+  }
+
+  public setPriority(priority: JobPriority): Job {
+    this.options.priority = priority;
+    return this;
+  }
+}


### PR DESCRIPTION
The goal is to separate the API and the Job runner into their own containers/services to make it easier to monitor and optimise each one individually.

This is a small first step, which includes rewriting the job manager to allow job instances to be class based, which should be a familiar syntax for most developers.

This class-based approach will also improve the testability of these job instances.

Example usage:

```typescript
import jobManager from '../../jobs/job.manager';

await jobManager.init();
jobManager.add(new UpdatePlayerJob('psikoi').setDelay(2000)); // will run after 2 seconds
jobManager.add(new UpdatePlayerJob('psikoi')); // will not run, as it's a duplicate instance
jobManager.add(new UpdateCompetitionScoreJob(123)); // gets executed immediately
jobManager.add(new UpdatePlayerJob('zezima').setDelay(5000)); // will run after 5 seconds
jobManager.add(new UpdateCompetitionScoreJob(456)); // gets executed after the 123 instance
await jobManager.shutdown();
```

since this is experimental, I've moved 1 cron job (SyncApiKeysJob) and 1 job (CheckPlayerBannedJob) to this new system, and I'll be closely monitoring these two jobs, to make sure they function as expected. All other jobs should still run as usual on the "old" system.

Once this system is confirmed to be fully functional, I'll move all jobs and crons to it, and delete the old system's code.