### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/api-deploy.yml
+++ b/.github/workflows/api-deploy.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Get current npm version
         id: package-version

--- a/.github/workflows/api-lint.yml
+++ b/.github/workflows/api-lint.yml
@@ -16,10 +16,10 @@ jobs:
         working-directory: ./server
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.16.0
 

--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -42,10 +42,10 @@ jobs:
       CORE_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/ci-database
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.16.0
 
@@ -62,10 +62,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.16.0
 

--- a/.github/workflows/api-version-check.yml
+++ b/.github/workflows/api-version-check.yml
@@ -16,7 +16,7 @@ jobs:
         working-directory: ./server
     steps:
       - name: Checkout master branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: master
 
@@ -27,7 +27,7 @@ jobs:
           path: server
 
       - name: Checkout current branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get current npm version
         id: current-package-version

--- a/.github/workflows/client-js-lint.yml
+++ b/.github/workflows/client-js-lint.yml
@@ -16,10 +16,10 @@ jobs:
         working-directory: ./server
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.16.0
 

--- a/.github/workflows/client-js-publish.yml
+++ b/.github/workflows/client-js-publish.yml
@@ -14,10 +14,10 @@ jobs:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       - name: Checkout current branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.16.0
 

--- a/.github/workflows/client-js-version-check.yml
+++ b/.github/workflows/client-js-version-check.yml
@@ -16,7 +16,7 @@ jobs:
         working-directory: ./client-js
     steps:
       - name: Checkout master branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: master
 
@@ -27,7 +27,7 @@ jobs:
           path: client-js
 
       - name: Checkout current branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get current npm version
         id: current-package-version

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -16,10 +16,10 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
 
       - name: Install dependencies
         run: cd docs && npm ci

--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -17,10 +17,10 @@ jobs:
         working-directory: ./docs
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
This PR bumps GitHub Actions to their latest major versions. Main change is they are now using Node 20 internally instead of 16, which was EOL as of April 2022:
 - Changelog for `actions/checkout` can be [found here](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
 - Releases for `actions/setup-node` can be [found here](https://github.com/actions/setup-node/releases)