### PR TITLE
[api]  Migrate cron jobs to new runner - pt 3

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.6.10",
+  "version": "2.6.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.6.10",
+      "version": "2.6.11",
       "license": "ISC",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.6.10",
+  "version": "2.6.11",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/jobs/instances/CalculateComputedMetricRankTablesJob.ts
+++ b/server/src/api/jobs/instances/CalculateComputedMetricRankTablesJob.ts
@@ -1,18 +1,5 @@
-import redisService from '../../../api/services/external/redis.service';
-import { getAlgorithmType } from '../../../api/modules/efficiency/efficiency.utils';
-import {
-  ComputedMetric,
-  EfficiencyAlgorithmType,
-  PLAYER_BUILDS,
-  PLAYER_TYPES,
-  PlayerType,
-  PlayerBuild
-} from '../../../utils';
-import prisma from '../../../prisma';
-import { JobType, JobDefinition } from '../job.types';
-
-// The higher the resolution, the more accurate the estimates are, but the more memory is used
-export const RANK_RESOLUTION = 10;
+import { CalculateComputedMetricRankTablesJob as NewCalculateComputedMetricRankTablesJob } from '../../../jobs/instances/CalculateComputedMetricRankTablesJob';
+import { JobDefinition, JobType } from '../job.types';
 
 class CalculateComputedMetricRankTablesJob implements JobDefinition<unknown> {
   type: JobType;
@@ -22,58 +9,11 @@ class CalculateComputedMetricRankTablesJob implements JobDefinition<unknown> {
   }
 
   async execute() {
-    await updateRankMaps(ComputedMetric.EHP);
-    await updateRankMaps(ComputedMetric.EHB);
+    // We're migrating to a new job manager, but jobs for the current one are still in-queue
+    // so to prevent duplicating code, just use the old job manager to execute the job on the new one.
+    // Once this old job is no longer in use, we can remove this entire file.
+    await new NewCalculateComputedMetricRankTablesJob().execute();
   }
-}
-
-async function updateRankMaps(metric: ComputedMetric) {
-  const map = new Map<EfficiencyAlgorithmType, Record<number, number>>();
-
-  for (const playerType of PLAYER_TYPES) {
-    if (playerType === PlayerType.UNKNOWN) continue;
-
-    for (const playerBuild of PLAYER_BUILDS) {
-      const entries = await getRankTableEntries(metric, playerType, playerBuild);
-
-      let sum = 0;
-      const obj: Record<number, number> = {};
-
-      entries.forEach(entry => {
-        obj[entry.threshold] = entry.count + sum;
-        sum += entry.count;
-      });
-
-      const algorithmType = getAlgorithmType({ type: playerType, build: playerBuild });
-
-      const data = map.get(algorithmType);
-
-      if (data) {
-        for (const [key, value] of Object.entries(obj)) {
-          if (data[key]) {
-            data[key] += value;
-          } else {
-            data[key] = value;
-          }
-        }
-      } else {
-        map.set(algorithmType, obj);
-      }
-    }
-  }
-
-  for (const [algorithmType, data] of Array.from(map.entries())) {
-    await redisService.setValue(`${metric}_rank_table`, algorithmType, JSON.stringify(data));
-  }
-}
-
-async function getRankTableEntries(metric: ComputedMetric, type: PlayerType, build: PlayerBuild) {
-  return await prisma.$queryRawUnsafe<Array<{ threshold: number; count: number }>>(`
-    SELECT (FLOOR("${metric}" / ${RANK_RESOLUTION}) * ${RANK_RESOLUTION})::int AS "threshold", COUNT(*)::int FROM public.players
-    WHERE "type" = '${type}' AND "build" = '${build}'
-    GROUP BY "threshold"
-    ORDER BY "threshold" DESC
-  `);
 }
 
 export default new CalculateComputedMetricRankTablesJob();

--- a/server/src/api/jobs/instances/ScheduleGroupScoreUpdatesJob.ts
+++ b/server/src/api/jobs/instances/ScheduleGroupScoreUpdatesJob.ts
@@ -1,7 +1,5 @@
-import prisma from '../../../prisma';
-import { Period, PeriodProps } from '../../..//utils';
+import { ScheduleGroupScoreUpdatesJob as NewScheduleGroupScoreUpdatesJob } from '../../../jobs/instances/ScheduleGroupScoreUpdatesJob';
 import { JobType, JobDefinition } from '../job.types';
-import { jobManager } from '..';
 
 class ScheduleGroupScoreUpdatesJob implements JobDefinition<unknown> {
   type: JobType;
@@ -11,19 +9,10 @@ class ScheduleGroupScoreUpdatesJob implements JobDefinition<unknown> {
   }
 
   async execute() {
-    const allGroups = await prisma.group.findMany({
-      select: { id: true }
-    });
-
-    // Distribute these evenly throughout the day, with a variable cooldown between each
-    const cooldown = Math.floor(PeriodProps[Period.DAY].milliseconds / allGroups.length);
-
-    allGroups.forEach((group, i) => {
-      jobManager.add(
-        { type: JobType.UPDATE_GROUP_SCORE, payload: { groupId: group.id } },
-        { delay: i * cooldown }
-      );
-    });
+    // We're migrating to a new job manager, but jobs for the current one are still in-queue
+    // so to prevent duplicating code, just use the old job manager to execute the job on the new one
+    // Once this old job is no longer in use, we can remove this entire file.
+    await new NewScheduleGroupScoreUpdatesJob().execute();
   }
 }
 

--- a/server/src/api/jobs/job.manager.ts
+++ b/server/src/api/jobs/job.manager.ts
@@ -87,10 +87,10 @@ const CRON_JOBS = [
   //   type: JobType.SCHEDULE_FLAGGED_PLAYER_REVIEW,
   //   interval: '0 * * * *' // every hour
   // },
-  {
-    type: JobType.SCHEDULE_GROUP_SCORE_UPDATES,
-    interval: '0 8 * * *' // everyday at 8AM
-  },
+  // {
+  //   type: JobType.SCHEDULE_GROUP_SCORE_UPDATES,
+  //   interval: '0 8 * * *' // everyday at 8AM
+  // },
   {
     type: JobType.SCHEDULE_NAME_CHANGE_REVIEWS,
     interval: '0 8 * * *' // everyday at 8AM

--- a/server/src/api/jobs/job.manager.ts
+++ b/server/src/api/jobs/job.manager.ts
@@ -98,11 +98,11 @@ const CRON_JOBS = [
   {
     type: JobType.SCHEDULE_BANNED_PLAYER_CHECKS,
     interval: '0 8 * * *' // everyday at 8AM
-  },
-  {
-    type: JobType.CALCULATE_COMPUTED_METRIC_RANK_TABLES,
-    interval: '0 8 * * *' // everyday at 8AM
   }
+  // {
+  //   type: JobType.CALCULATE_COMPUTED_METRIC_RANK_TABLES,
+  //   interval: '0 8 * * *' // everyday at 8AM
+  // }
   // {
   // type: JobType.SCHEDULE_TREND_CALCS,
   // interval: '0 */12 * * *' // every 12 hours

--- a/server/src/api/modules/competitions/competition.events.ts
+++ b/server/src/api/modules/competitions/competition.events.ts
@@ -48,7 +48,7 @@ async function onCompetitionStarted(competition: Competition) {
   });
 
   // Trigger a score update job, without any instance id, so that it doesn't get deduplicated.
-  experimentalJobManager.add(new UpdateCompetitionScoreJob(competition.id).unsetInstanceId());
+  await experimentalJobManager.add(new UpdateCompetitionScoreJob(competition.id).unsetInstanceId());
 }
 
 async function onCompetitionEnded(competition: Competition) {
@@ -61,7 +61,7 @@ async function onCompetitionEnded(competition: Competition) {
   });
 
   // Trigger a score update job, without any instance id, so that it doesn't get deduplicated.
-  experimentalJobManager.add(new UpdateCompetitionScoreJob(competition.id).unsetInstanceId());
+  await experimentalJobManager.add(new UpdateCompetitionScoreJob(competition.id).unsetInstanceId());
 }
 
 async function onCompetitionStarting(competition: Competition, period: EventPeriodDelay) {

--- a/server/src/api/modules/efficiency/services/ComputeEfficiencyRankService.ts
+++ b/server/src/api/modules/efficiency/services/ComputeEfficiencyRankService.ts
@@ -1,3 +1,5 @@
+import { RANK_RESOLUTION } from '../../../../jobs/instances/CalculateComputedMetricRankTablesJob';
+import prisma from '../../../../prisma';
 import {
   ComputedMetric,
   PLAYER_BUILDS,
@@ -8,8 +10,6 @@ import {
   PlayerType
 } from '../../../../utils';
 import redisService from '../../../services/external/redis.service';
-import prisma from '../../../../prisma';
-import { RANK_RESOLUTION } from '../../../jobs/instances/CalculateComputedMetricRankTablesJob';
 import { getAlgorithmType } from '../efficiency.utils';
 
 async function computeEfficiencyRank(

--- a/server/src/api/modules/groups/group.events.ts
+++ b/server/src/api/modules/groups/group.events.ts
@@ -1,17 +1,21 @@
+import { UpdateGroupScoreJob } from '../../../jobs/instances/UpdateGroupScoreJob';
+import experimentalJobManager from '../../../jobs/job.manager';
 import prisma from '../../../prisma';
 import { MemberJoinedEvent, MemberLeftEvent, MemberRoleChangeEvent, PlayerType } from '../../../utils';
-import { jobManager, JobType } from '../../jobs';
-import metrics from '../../services/external/metrics.service';
+import { JobType, jobManager } from '../../jobs';
 import * as discordService from '../../services/external/discord.service';
+import metrics from '../../services/external/metrics.service';
 import { addToGroupCompetitions } from '../competitions/services/AddToGroupCompetitionsService';
 import { removeFromGroupCompetitions } from '../competitions/services/RemoveFromGroupCompetitionsService';
 
-function onGroupUpdated(groupId: number) {
-  jobManager.add({ type: JobType.UPDATE_GROUP_SCORE, payload: { groupId } });
+async function onGroupUpdated(groupId: number) {
+  // Trigger a score update job, without any instance id, so that it doesn't get deduplicated.
+  await experimentalJobManager.add(new UpdateGroupScoreJob(groupId).unsetInstanceId());
 }
 
-function onGroupCreated(groupId: number) {
-  jobManager.add({ type: JobType.UPDATE_GROUP_SCORE, payload: { groupId } });
+async function onGroupCreated(groupId: number) {
+  // Trigger a score update job, without any instance id, so that it doesn't get deduplicated.
+  await experimentalJobManager.add(new UpdateGroupScoreJob(groupId).unsetInstanceId());
 }
 
 async function onMembersRolesChanged(events: MemberRoleChangeEvent[]) {

--- a/server/src/api/modules/patrons/services/ClaimPatreonBenefitsService.ts
+++ b/server/src/api/modules/patrons/services/ClaimPatreonBenefitsService.ts
@@ -1,5 +1,6 @@
+import { SyncPatronsJob } from '../../../../jobs/instances/SyncPatronsJob';
+import experimentalJobManager from '../../../../jobs/job.manager';
 import prisma, { Patron } from '../../../../prisma';
-import { JobType, jobManager } from '../../../jobs';
 import { BadRequestError, ForbiddenError, NotFoundError } from '../../../errors';
 import { standardize } from '../../players/player.utils';
 
@@ -58,7 +59,7 @@ async function claimPatreonBenefits(
     }
   });
 
-  jobManager.add({ type: JobType.SYNC_PATRONS });
+  experimentalJobManager.add(new SyncPatronsJob());
 
   return updatedPatron;
 }

--- a/server/src/api/modules/players/player.router.ts
+++ b/server/src/api/modules/players/player.router.ts
@@ -1,10 +1,10 @@
 import { Router } from 'express';
 import { z } from 'zod';
+import { ScheduleFlaggedPlayerReviewJob } from '../../../jobs/instances/ScheduleFlaggedPlayerReviewJob';
+import experimentalJobManager from '../../../jobs/job.manager';
 import prisma from '../../../prisma';
 import { CompetitionStatus, Metric, Period } from '../../../utils';
 import { NotFoundError, ServerError } from '../../errors';
-import { JobType } from '../../jobs';
-import jobManager from '../../jobs/job.manager';
 import { checkAdminPermission, detectRuneLiteNameChange } from '../../util/middlewares';
 import { executeRequest, validateRequest } from '../../util/routing';
 import { getDateSchema, getPaginationSchema } from '../../util/validation';
@@ -222,7 +222,7 @@ router.post(
       throw new ServerError('Failed to update new player post-archive.');
     }
 
-    jobManager.add({ type: JobType.SCHEDULE_FLAGGED_PLAYER_REVIEW }, { delay: 10_000 });
+    experimentalJobManager.add(new ScheduleFlaggedPlayerReviewJob().setDelay(10_000));
 
     res.status(200).json(archivedPlayer);
   })

--- a/server/src/jobs/instances/CalculateComputedMetricRankTablesJob.ts
+++ b/server/src/jobs/instances/CalculateComputedMetricRankTablesJob.ts
@@ -1,0 +1,73 @@
+import { getAlgorithmType } from '../../api/modules/efficiency/efficiency.utils';
+import redisService from '../../api/services/external/redis.service';
+import prisma from '../../prisma';
+import {
+  ComputedMetric,
+  EfficiencyAlgorithmType,
+  PLAYER_BUILDS,
+  PLAYER_TYPES,
+  PlayerBuild,
+  PlayerType
+} from '../../utils';
+import { Job } from '../job.utils';
+
+// The higher the resolution, the more accurate the estimates are, but the more memory is used
+export const RANK_RESOLUTION = 10;
+
+class CalculateComputedMetricRankTablesJob extends Job {
+  async execute() {
+    await updateRankMaps(ComputedMetric.EHP);
+    await updateRankMaps(ComputedMetric.EHB);
+  }
+}
+
+async function updateRankMaps(metric: ComputedMetric) {
+  const map = new Map<EfficiencyAlgorithmType, Record<number, number>>();
+
+  for (const playerType of PLAYER_TYPES) {
+    if (playerType === PlayerType.UNKNOWN) continue;
+
+    for (const playerBuild of PLAYER_BUILDS) {
+      const entries = await getRankTableEntries(metric, playerType, playerBuild);
+
+      let sum = 0;
+      const obj: Record<number, number> = {};
+
+      entries.forEach(entry => {
+        obj[entry.threshold] = entry.count + sum;
+        sum += entry.count;
+      });
+
+      const algorithmType = getAlgorithmType({ type: playerType, build: playerBuild });
+
+      const data = map.get(algorithmType);
+
+      if (data) {
+        for (const [key, value] of Object.entries(obj)) {
+          if (data[key]) {
+            data[key] += value;
+          } else {
+            data[key] = value;
+          }
+        }
+      } else {
+        map.set(algorithmType, obj);
+      }
+    }
+  }
+
+  for (const [algorithmType, data] of Array.from(map.entries())) {
+    await redisService.setValue(`${metric}_rank_table`, algorithmType, JSON.stringify(data));
+  }
+}
+
+async function getRankTableEntries(metric: ComputedMetric, type: PlayerType, build: PlayerBuild) {
+  return await prisma.$queryRawUnsafe<Array<{ threshold: number; count: number }>>(`
+      SELECT (FLOOR("${metric}" / ${RANK_RESOLUTION}) * ${RANK_RESOLUTION})::int AS "threshold", COUNT(*)::int FROM public.players
+      WHERE "type" = '${type}' AND "build" = '${build}'
+      GROUP BY "threshold"
+      ORDER BY "threshold" DESC
+    `);
+}
+
+export { CalculateComputedMetricRankTablesJob };

--- a/server/src/jobs/instances/ScheduleGroupScoreUpdatesJob.ts
+++ b/server/src/jobs/instances/ScheduleGroupScoreUpdatesJob.ts
@@ -1,0 +1,22 @@
+import { Period, PeriodProps } from '../../utils';
+import prisma from '../../prisma';
+import { Job } from '../job.utils';
+import jobManager from '../job.manager';
+import { UpdateGroupScoreJob } from './UpdateGroupScoreJob';
+
+class ScheduleGroupScoreUpdatesJob extends Job {
+  async execute() {
+    const groups = await prisma.group.findMany({
+      select: { id: true }
+    });
+
+    // Distribute these evenly throughout the day, with a variable cooldown between each
+    const cooldown = Math.floor(PeriodProps[Period.DAY].milliseconds / groups.length);
+
+    for (let i = 0; i < groups.length; i++) {
+      await jobManager.add(new UpdateGroupScoreJob(groups[i].id).setDelay(i * cooldown));
+    }
+  }
+}
+
+export { ScheduleGroupScoreUpdatesJob };

--- a/server/src/jobs/instances/UpdateGroupScoreJob.ts
+++ b/server/src/jobs/instances/UpdateGroupScoreJob.ts
@@ -1,0 +1,114 @@
+import { findGroupCompetitions } from '../../api/modules/competitions/services/FindGroupCompetitionsService';
+import { fetchGroupDetails } from '../../api/modules/groups/services/FetchGroupDetailsService';
+import prisma from '../../prisma';
+import { GroupDetails, PRIVELEGED_GROUP_ROLES } from '../../utils';
+import { Job } from '../job.utils';
+
+class UpdateGroupScoreJob extends Job {
+  private groupId: number;
+
+  constructor(groupId: number) {
+    super(groupId);
+    this.groupId = groupId;
+  }
+
+  async execute() {
+    const groupDetails = await fetchGroupDetails(this.groupId);
+
+    const currentScore = groupDetails.score;
+    const newScore = await calculateScore(groupDetails);
+
+    if (newScore === currentScore) return;
+
+    await prisma.group.update({
+      where: { id: this.groupId },
+      data: { score: newScore }
+    });
+  }
+}
+
+async function calculateScore(group: GroupDetails): Promise<number> {
+  let score = 0;
+
+  const now = new Date();
+  const { memberships } = group;
+
+  if (!memberships || memberships.length === 0) {
+    return score;
+  }
+
+  const competitions = await findGroupCompetitions(group.id);
+  const averageOverallExp = memberships.reduce((acc, cur) => acc + cur.player.exp, 0) / memberships.length;
+
+  // If has atleast one leader
+  if (memberships.filter(m => PRIVELEGED_GROUP_ROLES.includes(m.role)).length >= 1) {
+    score += 30;
+  }
+
+  // If has atleast 10 players
+  if (memberships.length >= 10) {
+    score += 20;
+
+    // If has atleast 50 players
+    if (memberships.length >= 50) {
+      score += 40;
+    }
+  }
+
+  // If average member overall exp > 30m
+  if (averageOverallExp >= 30_000_000) {
+    score += 30;
+
+    // If average member overall exp > 100m
+    if (averageOverallExp >= 100_000_000) {
+      score += 60;
+    }
+  }
+
+  // If has a clan chat
+  if (group.clanChat && group.clanChat.length > 0) {
+    score += 50;
+  }
+
+  // If has a description
+  if (group.description && group.description.length > 0) {
+    score += 40;
+  }
+
+  // If has a homeworld
+  if (group.homeworld && group.homeworld > 0) {
+    score += 20;
+  }
+
+  // If is verified (clan leader is in our discord)
+  if (group.verified) {
+    score += 100;
+  }
+
+  // If is a patreon supporter
+  if (group.patron) {
+    score += 50;
+
+    if (group.profileImage) {
+      score += 20;
+    }
+
+    if (group.bannerImage) {
+      score += 10;
+    }
+  }
+
+  // If has atleast one ongoing competition
+  if (competitions.filter(c => c.startsAt <= now && c.endsAt >= now).length >= 1) {
+    score += 50;
+  }
+
+  // If has atleast one upcoming competition
+  if (competitions.filter(c => c.startsAt >= now).length >= 1) {
+    score += 30;
+  }
+
+  return score;
+}
+
+export { UpdateGroupScoreJob };

--- a/server/src/jobs/job.manager.ts
+++ b/server/src/jobs/job.manager.ts
@@ -11,14 +11,17 @@ import { ScheduleDeltaInvalidationsJob } from './instances/ScheduleDeltaInvalida
 import { ScheduleFlaggedPlayerReviewJob } from './instances/ScheduleFlaggedPlayerReviewJob';
 import { SyncApiKeysJob } from './instances/SyncApiKeysJob';
 import { SyncPatronsJob } from './instances/SyncPatronsJob';
+import { ScheduleGroupScoreUpdatesJob } from './instances/ScheduleGroupScoreUpdatesJob';
 import { ScheduleCompetitionScoreUpdatesJob } from './instances/ScheduleCompetitionScoreUpdatesJob';
 import { UpdateCompetitionScoreJob } from './instances/UpdateCompetitionScoreJob';
+import { UpdateGroupScoreJob } from './instances/UpdateGroupScoreJob';
 import { Job, JobPriority } from './job.utils';
 
 const DISPATCHABLE_JOBS = [
   CheckPlayerBannedJob,
   SyncApiKeysJob,
   SyncPatronsJob,
+  UpdateGroupScoreJob,
   UpdateCompetitionScoreJob
 ] as const;
 
@@ -52,8 +55,12 @@ const CRON_CONFIG = [
     job: ScheduleDeltaInvalidationsJob
   },
   {
-    interval: '0 */12 * * *', // every 12 hours
+    interval: '0 8 * * *', // everyday at 8AM
     job: ScheduleCompetitionScoreUpdatesJob
+  },
+  {
+    interval: '0 8 * * *', // everyday at 8AM
+    job: ScheduleGroupScoreUpdatesJob
   }
 ] as const;
 

--- a/server/src/jobs/job.manager.ts
+++ b/server/src/jobs/job.manager.ts
@@ -5,6 +5,7 @@ import redisConfig from '../config/redis.config';
 import { getThreadIndex } from '../env';
 import { AutoUpdatePatronGroupsJob } from './instances/AutoUpdatePatronGroupsJob';
 import { AutoUpdatePatronPlayersJob } from './instances/AutoUpdatePatronPlayersJob';
+import { CalculateComputedMetricRankTablesJob } from './instances/CalculateComputedMetricRankTablesJob';
 import { CheckPlayerBannedJob } from './instances/CheckPlayerBannedJob';
 import { ScheduleCompetitionEventsJob } from './instances/ScheduleCompetitionEventsJob';
 import { ScheduleDeltaInvalidationsJob } from './instances/ScheduleDeltaInvalidationsJob';
@@ -61,6 +62,10 @@ const CRON_CONFIG = [
   {
     interval: '0 8 * * *', // everyday at 8AM
     job: ScheduleGroupScoreUpdatesJob
+  },
+  {
+    interval: '0 8 * * *', // everyday at 8AM
+    job: CalculateComputedMetricRankTablesJob
   }
 ] as const;
 

--- a/server/src/jobs/job.utils.ts
+++ b/server/src/jobs/job.utils.ts
@@ -41,4 +41,9 @@ export class Job {
     this.options.priority = priority;
     return this;
   }
+
+  public unsetInstanceId() {
+    this.instanceId = undefined;
+    return this;
+  }
 }


### PR DESCRIPTION
Follow-up to https://github.com/wise-old-man/wise-old-man/pull/1487

- Migrated `ScheduleGroupScoreUpdatesJob` and `UpdateGroupScoreJob`
- Migrated `CalculateComputedMetricRankTablesJob`
- Removed some usages of the old runner