### PR TITLE
Add tagged union field to group hiscores items 

### DIFF
--- a/client-js/package-lock.json
+++ b/client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wise-old-man/utils",
-      "version": "3.2.3",
+      "version": "3.2.4",
       "license": "ISC",
       "dependencies": {
         "dayjs": "^1.11.5"

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "A JavaScript/TypeScript client that interfaces and consumes the Wise Old Man API, an API that tracks and measures players' progress in Old School Runescape.",
   "keywords": [
     "wiseoldman",

--- a/docs/docs/groups-api/group-endpoints.mdx
+++ b/docs/docs/groups-api/group-endpoints.mdx
@@ -1497,7 +1497,8 @@ const hiscores = await client.groups.getGroupHiscores(123, Metric.AGILITY, { lim
     "data": {
       "rank": 42,
       "experience": 70286706,
-      "level": 99
+      "level": 99,
+      "type": "skill"
     }
   },
   {
@@ -1523,7 +1524,8 @@ const hiscores = await client.groups.getGroupHiscores(123, Metric.AGILITY, { lim
     "data": {
       "rank": 155,
       "experience": 31302967,
-      "level": 99
+      "level": 99,
+      "type": "skill"
     }
   }
 ]

--- a/docs/docs/groups-api/group-type-definitions.md
+++ b/docs/docs/groups-api/group-type-definitions.md
@@ -126,6 +126,7 @@ Used as an input for group modification endpoints (create, edit, add members, et
 
 | Field      | Type    | Description                                  |
 | :--------- | :------ | :------------------------------------------- |
+| type       | string  | The type of this hiscores item ('skill').    |
 | rank       | integer | The player's rank in a specific skill.       |
 | level      | integer | The player's level in a specific skill.      |
 | experience | long    | The player's experience in a specific skill. |
@@ -134,19 +135,21 @@ Used as an input for group modification endpoints (create, edit, add members, et
 
 ### `(Object)` Group Hiscores Boss Item
 
-| Field | Type    | Description                             |
-| :---- | :------ | :-------------------------------------- |
-| rank  | integer | The player's rank in a specific boss.   |
-| kills | integer | The player's kills for a specific boss. |
+| Field | Type    | Description                              |
+| :---- | :------ | :--------------------------------------- |
+| type  | string  | The type of this hiscores item ('boss'). |
+| rank  | integer | The player's rank in a specific boss.    |
+| kills | integer | The player's kills for a specific boss.  |
 
 <br />
 
 ### `(Object)` Group Hiscores Activity Item
 
-| Field | Type    | Description                                |
-| :---- | :------ | :----------------------------------------- |
-| rank  | integer | The player's rank in a specific activity.  |
-| score | integer | The player's score in a specific activity. |
+| Field | Type    | Description                                  |
+| :---- | :------ | :------------------------------------------- |
+| type  | string  | The type of this hiscores item ('activity'). |
+| rank  | integer | The player's rank in a specific activity.    |
+| score | integer | The player's score in a specific activity.   |
 
 <br />
 
@@ -154,6 +157,7 @@ Used as an input for group modification endpoints (create, edit, add members, et
 
 | Field | Type    | Description                                       |
 | :---- | :------ | :------------------------------------------------ |
+| type  | string  | The type of this hiscores item ('computed').      |
 | rank  | integer | The player's rank in a specific computed metric.  |
 | value | integer | The player's value in a specific computed metric. |
 

--- a/server/__tests__/suites/integration/groups.test.ts
+++ b/server/__tests__/suites/integration/groups.test.ts
@@ -2227,7 +2227,6 @@ describe('Group API', () => {
 
       expect(anotherTrackResponse.body.ttm).toBe(0);
       expect(anotherTrackResponse.body.ehp).toBeGreaterThan(trackResponse.body.ehp);
-      expect(anotherTrackResponse.body.ehp).toBeGreaterThan(trackResponse.body.ehp);
 
       const skillHiscoresResponse = await api
         .get(`/groups/${globalData.testGroupOneLeader.id}/hiscores`)

--- a/server/__tests__/suites/integration/groups.test.ts
+++ b/server/__tests__/suites/integration/groups.test.ts
@@ -2227,6 +2227,7 @@ describe('Group API', () => {
 
       expect(anotherTrackResponse.body.ttm).toBe(0);
       expect(anotherTrackResponse.body.ehp).toBeGreaterThan(trackResponse.body.ehp);
+      expect(anotherTrackResponse.body.ehp).toBeGreaterThan(trackResponse.body.ehp);
 
       const skillHiscoresResponse = await api
         .get(`/groups/${globalData.testGroupOneLeader.id}/hiscores`)
@@ -2238,6 +2239,7 @@ describe('Group API', () => {
       expect(skillHiscoresResponse.body[0]).toMatchObject({
         player: { username: 'alexsuperfly' },
         data: {
+          type: 'skill',
           experience: 200_000_000,
           level: 99
         }
@@ -2246,6 +2248,7 @@ describe('Group API', () => {
       expect(skillHiscoresResponse.body[1]).toMatchObject({
         player: { username: 'psikoi' },
         data: {
+          type: 'skill',
           experience: 19_288_604,
           level: 99
         }
@@ -2254,6 +2257,7 @@ describe('Group API', () => {
       expect(skillHiscoresResponse.body[2]).toMatchObject({
         player: { username: 'zezima' },
         data: {
+          type: 'skill',
           experience: 5_500_000,
           level: 90
         }
@@ -2272,6 +2276,7 @@ describe('Group API', () => {
       expect(activityHiscoresResponse.body.length).toBe(3);
       expect(activityHiscoresResponse.body[0].data.score).toBeDefined();
       expect(activityHiscoresResponse.body[0].data.rank).toBeDefined();
+      expect(activityHiscoresResponse.body[0].data.type).toBe('activity');
 
       const computedMetricsHiscoresResponse = await api
         .get(`/groups/${globalData.testGroupOneLeader.id}/hiscores`)
@@ -2281,6 +2286,7 @@ describe('Group API', () => {
       expect(computedMetricsHiscoresResponse.body.length).toBe(3);
       expect(computedMetricsHiscoresResponse.body[0].data.value).toBeDefined();
       expect(computedMetricsHiscoresResponse.body[0].data.rank).toBeDefined();
+      expect(computedMetricsHiscoresResponse.body[0].data.type).toBe('computed');
     });
 
     it('should view hiscores (w/ limit & offset)', async () => {
@@ -2294,6 +2300,7 @@ describe('Group API', () => {
       expect(response.body[0]).toMatchObject({
         player: { username: 'zezima' },
         data: {
+          type: 'boss',
           kills: 100
         }
       });

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.6.11",
+  "version": "2.6.12",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/modules/groups/group.types.ts
+++ b/server/src/api/modules/groups/group.types.ts
@@ -27,22 +27,26 @@ export interface MemberInput {
 }
 
 export interface GroupHiscoresSkillItem {
+  type: 'skill';
   rank: number;
   level: number;
   experience: number;
 }
 
 export interface GroupHiscoresBossItem {
+  type: 'boss';
   rank: number;
   kills: number;
 }
 
 export interface GroupHiscoresActivityItem {
+  type: 'activity';
   rank: number;
   score: number;
 }
 
 export interface GroupHiscoresComputedMetricItem {
+  type: 'computed';
   rank: number;
   value: number;
 }

--- a/server/src/api/modules/groups/services/FetchGroupHiscoresService.ts
+++ b/server/src/api/modules/groups/services/FetchGroupHiscoresService.ts
@@ -57,13 +57,13 @@ async function fetchGroupHiscores(
 
       if (measure === MetricMeasure.EXPERIENCE) {
         const lvl = metric === Metric.OVERALL ? getTotalLevel(snapshot) : getLevel(value);
-        data = { rank, experience: value, level: lvl };
+        data = { rank, experience: value, level: lvl, type: 'skill' };
       } else if (measure === MetricMeasure.KILLS) {
-        data = { rank, kills: value };
+        data = { rank, kills: value, type: 'boss' };
       } else if (measure === MetricMeasure.SCORE) {
-        data = { rank, score: value };
+        data = { rank, score: value, type: 'activity' };
       } else {
-        data = { rank, value: value };
+        data = { rank, value: value, type: 'computed' };
       }
 
       return {


### PR DESCRIPTION
This allows for 3rd parties to just check the `type` field, and handle the object accordingly without checking for the existence of `experience` on the object, and if its not there checking for `kills` etc.

Bumped server and client-js versions.
Updated tests.
Updated docs.

Before:

```json
[
  {
    "player": {
      // ...
    },
    "data": {
      "rank": 42,
      "experience": 70286706,
      "level": 99
    }
  },
  // ...
]
```

After:

```json
[
  {
    "player": {
      // ...
    },
    "data": {
      "type": "skill",
      "rank": 42,
      "experience": 70286706,
      "level": 99
    }
  },
  // ...
]
```
