### PR TITLE
[api] Fix name change review EHP/EHB  calcs

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "ISC",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/modules/name-changes/services/FetchNameChangeDetailsService.ts
+++ b/server/src/api/modules/name-changes/services/FetchNameChangeDetailsService.ts
@@ -1,5 +1,5 @@
 import prisma, { NameChangeStatus } from '../../../../prisma';
-import { PlayerType } from '../../../../utils';
+import { PlayerType, PlayerBuild } from '../../../../utils';
 import { NotFoundError, ServerError } from '../../../errors';
 import * as jagexService from '../../../services/external/jagex.service';
 import { getPlayerEfficiencyMap } from '../../efficiency/efficiency.utils';
@@ -84,7 +84,14 @@ async function fetchNameChangeDetails(id: number): Promise<NameChangeDetails> {
   const timeDiff = afterDate.getTime() - oldStats.createdAt.getTime();
   const hoursDiff = timeDiff / 1000 / 60 / 60;
 
-  const oldPlayerComputedMetrics = await computePlayerMetrics(oldPlayer, oldStats);
+  const oldPlayerComputedMetrics = await computePlayerMetrics(
+    {
+      id: -1,
+      type: PlayerType.REGULAR,
+      build: PlayerBuild.MAIN
+    },
+    oldStats
+  );
 
   oldStats.ehpValue = oldPlayerComputedMetrics.ehpValue;
   oldStats.ehpRank = oldPlayerComputedMetrics.ehpRank;
@@ -113,7 +120,11 @@ async function fetchNameChangeDetails(id: number): Promise<NameChangeDetails> {
   }
 
   const newPlayerComputedMetrics = await computePlayerMetrics(
-    newPlayer || { ...oldPlayer, id: -1 },
+    {
+      id: -1,
+      type: PlayerType.REGULAR,
+      build: PlayerBuild.MAIN
+    },
     newStats
   );
 


### PR DESCRIPTION
We only care how different two player accounts are, we don't necessarily care about accurate values. So to prevent current issues where two similar accounts are compared using different rates, it's best to just use regular EHP/EHB rates.