### PR TITLE
Add "All Time" option to gained period

### DIFF
--- a/app/src/components/Combobox.tsx
+++ b/app/src/components/Combobox.tsx
@@ -192,7 +192,7 @@ export const ComboboxSeparator = CommandSeparator;
 export function ComboboxItemsContainer(props: { className?: string } & PropsWithChildren) {
   return (
     <div
-      className={cn("custom-scroll max-h-[16rem] overflow-y-auto overflow-x-hidden", props.className)}
+      className={cn("custom-scroll max-h-[18rem] overflow-y-auto overflow-x-hidden", props.className)}
     >
       {props.children}
     </div>

--- a/app/src/components/groups/GroupGainedTable.tsx
+++ b/app/src/components/groups/GroupGainedTable.tsx
@@ -75,7 +75,7 @@ export function GroupGainedTable(props: GroupGainedTableProps) {
     router.replace(`/groups/${group.id}/gained?${nextParams.toString()}`, { scroll: false });
   }
 
-  function handlePeriodChanged(newPeriod: Period | "custom") {
+  function handlePeriodChanged(newPeriod: Period | "custom" | "all_time") {
     const nextParams = new URLSearchParams(searchParams);
 
     // Reset pagination if params change
@@ -83,6 +83,11 @@ export function GroupGainedTable(props: GroupGainedTableProps) {
 
     if (newPeriod === "custom") {
       nextParams.set("dialog", "custom_period");
+    } else if (newPeriod === "all_time") {
+      nextParams.delete("period");
+      nextParams.delete("dialog");
+      nextParams.set("startDate", group.createdAt.toISOString());
+      nextParams.set("endDate", new Date().toISOString());
     } else if (newPeriod) {
       nextParams.set("period", newPeriod);
       nextParams.delete("startDate");
@@ -299,7 +304,7 @@ function MetricSelect(props: MetricSelectProps) {
 
 interface PeriodSelectProps {
   period?: Period;
-  onPeriodSelected: (period: Period | "custom") => void;
+  onPeriodSelected: (period: Period | "custom" | "all_time") => void;
 }
 
 function PeriodSelect(props: PeriodSelectProps) {
@@ -314,7 +319,7 @@ function PeriodSelect(props: PeriodSelectProps) {
         startTransition(() => {
           if (val === undefined) {
             onPeriodSelected(Period.WEEK);
-          } else if (isPeriod(val) || val === "custom") {
+          } else if (isPeriod(val) || val === "custom" || val === "all_time") {
             onPeriodSelected(val);
           }
         });
@@ -333,6 +338,7 @@ function PeriodSelect(props: PeriodSelectProps) {
                 {PeriodProps[period].name}
               </ComboboxItem>
             ))}
+            <ComboboxItem value="all_time">All Time</ComboboxItem>
             <ComboboxItem value="custom">Select custom period...</ComboboxItem>
           </ComboboxItemGroup>
         </ComboboxItemsContainer>

--- a/app/src/components/players/PlayerGainedTable.tsx
+++ b/app/src/components/players/PlayerGainedTable.tsx
@@ -19,7 +19,7 @@ import {
   SkillDelta,
   isPeriod,
 } from "@wise-old-man/utils";
-import { formatDatetime, minDate } from "~/utils/dates";
+import { formatDatetime } from "~/utils/dates";
 import { TimeRangeFilter } from "~/services/wiseoldman";
 import { getBuildHiddenMetrics } from "~/utils/metrics";
 import {

--- a/app/src/components/players/PlayerGainedTable.tsx
+++ b/app/src/components/players/PlayerGainedTable.tsx
@@ -19,7 +19,7 @@ import {
   SkillDelta,
   isPeriod,
 } from "@wise-old-man/utils";
-import { formatDatetime } from "~/utils/dates";
+import { formatDatetime, minDate } from "~/utils/dates";
 import { TimeRangeFilter } from "~/services/wiseoldman";
 import { getBuildHiddenMetrics } from "~/utils/metrics";
 import {
@@ -73,11 +73,16 @@ export function PlayerGainedTable(props: PropsWithChildren<PlayerGainedTableProp
     router.replace(`/players/${player.username}/gained?${nextParams.toString()}`, { scroll: false });
   }
 
-  function handlePeriodSelected(newPeriod: Period | "custom") {
+  function handlePeriodSelected(newPeriod: Period | "custom" | "all_time") {
     const nextParams = new URLSearchParams(searchParams);
 
     if (newPeriod === "custom") {
       nextParams.set("dialog", "custom_period");
+    } else if (newPeriod === "all_time") {
+      nextParams.delete("period");
+      nextParams.delete("dialog");
+      nextParams.set("startDate", player.registeredAt.toISOString());
+      nextParams.set("endDate", new Date().toISOString());
     } else if (newPeriod === Period.WEEK) {
       nextParams.delete("period");
       nextParams.delete("startDate");
@@ -438,7 +443,7 @@ function MetricTypeSelect(props: MetricTypeSelectProps) {
 
 interface PeriodSelectProps {
   period?: Period;
-  onPeriodSelected: (period: Period | "custom") => void;
+  onPeriodSelected: (period: Period | "custom" | "all_time") => void;
 }
 
 function PeriodSelect(props: PeriodSelectProps) {
@@ -453,7 +458,7 @@ function PeriodSelect(props: PeriodSelectProps) {
         startTransition(() => {
           if (val === undefined) {
             onPeriodSelected(Period.WEEK);
-          } else if (isPeriod(val) || val === "custom") {
+          } else if (isPeriod(val) || val === "custom" || val === "all_time") {
             onPeriodSelected(val);
           }
         });
@@ -472,6 +477,7 @@ function PeriodSelect(props: PeriodSelectProps) {
                 {PeriodProps[period].name}
               </ComboboxItem>
             ))}
+            <ComboboxItem value="all_time">All Time</ComboboxItem>
             <ComboboxItem value="custom">Select custom period...</ComboboxItem>
           </ComboboxItemGroup>
         </ComboboxItemsContainer>


### PR DESCRIPTION
Adds #888 

If on player page, sets custom period to player's first snapshot using `player.registeredAt`
If on group page, sets custom period to group's first snapshot using `group.createdAt`
Increased max height of combobox to prevent scrollbar appearing

Note: because this solution uses "custom" period url params, the filter selector shows "Custom period" instead of "All Time", which could be confusing but imo isn't a huge deal.


https://github.com/wise-old-man/wise-old-man/assets/43260193/4e639554-82f1-45e7-89f8-9787a1cd0b41

