### PR TITLE
feat: Prototype feature to allow excluding initial data load from gains heatmap

### DIFF
--- a/app/src/app/players/[username]/gained/page.tsx
+++ b/app/src/app/players/[username]/gained/page.tsx
@@ -30,13 +30,10 @@ import {
   PlayerGainedBarchart,
   PlayerGainedBarchartSkeleton,
 } from "~/components/players/PlayerGainedBarchart";
-import {
-  PlayerGainedHeatmap,
-  PlayerGainedHeatmapSkeleton,
-} from "~/components/players/PlayerGainedHeatmap";
 import { Await } from "~/components/Await";
 import { ChartViewSelect } from "~/components/players/ChartViewSelect";
 import { calculateGainBuckets } from "~/utils/calcs";
+import { YearlyHeatmapPanel } from "~/components/players/YearlyHeatmapPanel";
 
 export const dynamic = "force-dynamic";
 
@@ -50,6 +47,7 @@ interface PageProps {
     startDate?: string;
     endDate?: string;
     view?: string;
+    excludeInitial?: string;
   };
 }
 
@@ -65,6 +63,7 @@ export default async function PlayerGainedPage(props: PageProps) {
   const { params, searchParams } = props;
 
   const username = decodeURI(params.username);
+  const excludeInitialHeatmapData = props.searchParams.excludeInitial === "true";
 
   const metric = getMetricParam(searchParams.metric) || Metric.OVERALL;
   const view = searchParams.view === "ranks" ? "ranks" : "values";
@@ -99,7 +98,12 @@ export default async function PlayerGainedPage(props: PageProps) {
               timeRange={timeRange}
               metric={metric}
             />
-            <YearlyHeatmapPanel username={username} metric={metric} view={view} />
+            <YearlyHeatmapPanel
+              username={username}
+              metric={metric}
+              view={view}
+              excludeInitial={excludeInitialHeatmapData}
+            />
           </div>
         </PlayerGainedTable>
       </div>
@@ -234,62 +238,6 @@ function BucketedDailyGainsPanel(props: BucketedDailyGainsPanelProps) {
                 data={bucketedData.map((b) => ({
                   date: b.date,
                   value: b.gained != null ? b.gained * (isShowingRanks ? -1 : 1) : 0,
-                }))}
-              />
-            );
-          }}
-        </Await>
-      </Suspense>
-    </ExpandableChartPanel>
-  );
-}
-
-interface YearlyHeatmapPanelProps {
-  username: string;
-  metric: Metric;
-  view: "values" | "ranks";
-}
-
-function YearlyHeatmapPanel(props: YearlyHeatmapPanelProps) {
-  const { username, metric, view } = props;
-
-  const isShowingRanks = view === "ranks";
-
-  const promise = getSnapshotTimelineByPeriod(username, metric, Period.YEAR);
-
-  return (
-    <ExpandableChartPanel
-      id="year-heatmap"
-      className="w-[56rem] !max-w-[calc(100vw-4rem)]"
-      titleSlot={<>Gains heatmap</>}
-      descriptionSlot={
-        <>
-          A heatmap of the past <span className="text-white">year&apos;s</span>&nbsp;
-          {MetricProps[metric].name} {isShowingRanks ? "rank" : MetricProps[metric].measure} gains
-        </>
-      }
-    >
-      <Suspense fallback={<PlayerGainedHeatmapSkeleton />}>
-        <Await promise={promise}>
-          {(data) => {
-            const minDate = new Date(Date.now() - PeriodProps[Period.YEAR].milliseconds);
-            const maxDate = new Date();
-
-            // Convert the timeseries data into daily (bucket) gains
-            const bucketedData = calculateGainBuckets(
-              (isShowingRanks
-                ? data.map((d) => ({ date: d.date, value: d.rank }))
-                : [...data]
-              ).reverse(),
-              minDate,
-              maxDate
-            );
-
-            return (
-              <PlayerGainedHeatmap
-                data={bucketedData.map((b) => ({
-                  date: b.date,
-                  value: b.gained != null ? b.gained * (isShowingRanks ? -1 : 1) : null,
                 }))}
               />
             );

--- a/app/src/components/players/ExpandableChartPanel.tsx
+++ b/app/src/components/players/ExpandableChartPanel.tsx
@@ -9,12 +9,24 @@ import { Dialog, DialogContent } from "../Dialog";
 
 import ExpandIcon from "~/assets/expand.svg";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../Tooltip";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "../Dropdown";
+
+import TableCogIcon from "~/assets/table_cog.svg";
+import { Checkbox } from "../Checkbox";
+import { Label } from "../Label";
 
 interface ExpandableChartPanelProps extends PropsWithChildren {
   id: string;
   className?: string;
   titleSlot: React.ReactNode;
   descriptionSlot: React.ReactNode;
+  optionsSlot?: React.ReactNode;
 }
 
 export function ExpandableChartPanel(props: ExpandableChartPanelProps) {
@@ -62,16 +74,19 @@ function ChartPanel(props: ExpandableChartPanelProps & { isExpanded: boolean }) 
           <p className="text-xs text-gray-200 md:text-body">{props.descriptionSlot}</p>
         </div>
         {!props.isExpanded && (
-          <QueryLink query={{ expand: props.id }} scroll={false}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button variant="outline" iconButton className="!h-8">
-                  <ExpandIcon className="h-4 w-4 text-gray-200" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>Expand</TooltipContent>
-            </Tooltip>
-          </QueryLink>
+          <div>
+            {props.optionsSlot && <span className={cn("px-5")}> {props.optionsSlot}</span>}
+            <QueryLink query={{ expand: props.id }} scroll={false}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button variant="outline" iconButton className="!h-8">
+                    <ExpandIcon className="h-4 w-4 text-gray-200" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Expand</TooltipContent>
+              </Tooltip>
+            </QueryLink>
+          </div>
         )}
       </div>
       {props.children}

--- a/app/src/components/players/HeatmapOptionsMenu.tsx
+++ b/app/src/components/players/HeatmapOptionsMenu.tsx
@@ -1,0 +1,60 @@
+"use client";
+import { Button } from "~/components/Button";
+import { Label } from "~/components/Label";
+import { Checkbox } from "~/components/Checkbox";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "~/components/Dropdown";
+import TableCogIcon from "~/assets/table_cog.svg";
+import { useRouter, useSearchParams } from "next/navigation";
+
+export interface HeatmapOptionsMenuProps {
+  excludeInitialLoad: boolean;
+  username: string;
+}
+export function HeatmapOptionsMenu(props: HeatmapOptionsMenuProps) {
+  const { excludeInitialLoad, username } = props;
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  function handleExcludeInitialLoadChanged(value: boolean) {
+    const nextParams = new URLSearchParams(searchParams);
+
+    if (value === true) {
+      nextParams.set("excludeInitial", "true");
+    } else {
+      nextParams.delete("excludeInitial");
+    }
+
+    router.replace(`/players/${username}/gained?${nextParams.toString()}`, { scroll: false });
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button iconButton className="relative">
+          <TableCogIcon className="h-5 w-5" />
+          {excludeInitialLoad && (
+            <div className="absolute -right-px -top-px h-2 w-2 rounded-full bg-blue-500" />
+          )}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-52">
+        <DropdownMenuLabel>Options</DropdownMenuLabel>
+        <DropdownMenuItem onSelect={(e) => e.preventDefault()} className="focus:bg-transparent">
+          <Checkbox
+            id="virtual_levels"
+            checked={excludeInitialLoad}
+            onCheckedChange={(val) => handleExcludeInitialLoadChanged(Boolean(val))}
+          />
+          <Label htmlFor="virtual_levels" className="ml-2 block w-full">
+            Exclude initial load
+          </Label>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/app/src/components/players/PlayerGainedHeatmap.tsx
+++ b/app/src/components/players/PlayerGainedHeatmap.tsx
@@ -4,6 +4,8 @@ import { CalendarHeatmap } from "../CalendarHeatmap";
 
 interface PlayerGainedHeatmapProps {
   data: Array<{ date: Date; value: number | null }>;
+  username: string;
+  excludeInitial: boolean;
 }
 
 export function PlayerGainedHeatmap(props: PlayerGainedHeatmapProps) {
@@ -18,7 +20,15 @@ export function PlayerGainedHeatmap(props: PlayerGainedHeatmapProps) {
     );
   }
 
-  return <CalendarHeatmap data={data} />;
+  const valueToExclude = props.excludeInitial ? data.find((x) => x.value !== null) : null;
+  const includedData = data.map((item) => {
+    if (valueToExclude && item.date === valueToExclude.date) {
+      return { ...item, value: null };
+    }
+    return item;
+  });
+
+  return <CalendarHeatmap data={includedData} />;
 }
 
 export function PlayerGainedHeatmapSkeleton() {

--- a/app/src/components/players/YearlyHeatmapPanel.tsx
+++ b/app/src/components/players/YearlyHeatmapPanel.tsx
@@ -1,0 +1,71 @@
+import { Suspense } from "react";
+import { Metric, MetricProps, Period, PeriodProps } from "@wise-old-man/utils";
+import { getSnapshotTimelineByPeriod } from "~/services/wiseoldman";
+import { ExpandableChartPanel } from "~/components/players/ExpandableChartPanel";
+import {
+  PlayerGainedHeatmap,
+  PlayerGainedHeatmapSkeleton,
+} from "~/components/players/PlayerGainedHeatmap";
+import { Await } from "~/components/Await";
+import { calculateGainBuckets } from "~/utils/calcs";
+import { HeatmapOptionsMenu } from "./HeatmapOptionsMenu";
+
+interface YearlyHeatmapPanelProps {
+  username: string;
+  metric: Metric;
+  excludeInitial: boolean;
+  view: "values" | "ranks";
+}
+export function YearlyHeatmapPanel(props: YearlyHeatmapPanelProps) {
+  const { username, metric, view, excludeInitial } = props;
+
+  const isShowingRanks = view === "ranks";
+
+  const promise = getSnapshotTimelineByPeriod(username, metric, Period.YEAR);
+
+  return (
+    <ExpandableChartPanel
+      id="year-heatmap"
+      className="w-[56rem] !max-w-[calc(100vw-4rem)]"
+      titleSlot={<>Gains heatmap</>}
+      optionsSlot={<HeatmapOptionsMenu username={username} excludeInitialLoad={excludeInitial} />}
+      descriptionSlot={
+        <>
+          A heatmap of the past <span className="text-white">year&apos;s</span>&nbsp;
+          {MetricProps[metric].name} {isShowingRanks ? "rank" : MetricProps[metric].measure} gains
+        </>
+      }
+    >
+      <Suspense fallback={<PlayerGainedHeatmapSkeleton />}>
+        <Await promise={promise}>
+          {(data) => {
+            const minDate = new Date(Date.now() - PeriodProps[Period.YEAR].milliseconds);
+            const maxDate = new Date();
+
+            // Convert the timeseries data into daily (bucket) gains
+            const bucketedData = calculateGainBuckets(
+              (isShowingRanks
+                ? data
+                    .filter((x) => x.date === new Date(2024, 0, 10))
+                    .map((d) => ({ date: d.date, value: d.rank }))
+                : [...data]
+              ).reverse(),
+              minDate,
+              maxDate
+            );
+            return (
+              <PlayerGainedHeatmap
+                excludeInitial={props.excludeInitial}
+                username={props.username}
+                data={bucketedData.map((b) => ({
+                  date: b.date,
+                  value: b.gained != null ? b.gained * (isShowingRanks ? -1 : 1) : null,
+                }))}
+              ></PlayerGainedHeatmap>
+            );
+          }}
+        </Await>
+      </Suspense>
+    </ExpandableChartPanel>
+  );
+}


### PR DESCRIPTION
Added an option to the gains heatmap that allows you to exclude the initial data point from the analysis. This is for players who have not used WOM from the creation of their account but instead began using it much after the accounts creation which leads to a large amount of EXP gained on their initial data load which dominates other data from their heatmap.

To use the feature visit the gained tab and select the option menu to the left of the expand button within the heatmap panel and check the box to "exclude initial load"