### PR TITLE
[app] Display level on efficiency page

### DIFF
--- a/app/src/components/rates/ExperienceRatesTable.tsx
+++ b/app/src/components/rates/ExperienceRatesTable.tsx
@@ -1,13 +1,19 @@
 "use client";
 
 import { ColumnDef } from "@tanstack/react-table";
-import { MAX_SKILL_EXP, SkillMetaMethod } from "@wise-old-man/utils";
+import { MAX_SKILL_EXP, SkillMetaMethod, getLevel } from "@wise-old-man/utils";
 import { TableTitle } from "../Table";
 import { DataTable } from "../DataTable";
 import { FormattedNumber } from "../FormattedNumber";
 
 function getColumnDefinitions(methods: SkillMetaMethod[]): ColumnDef<SkillMetaMethod>[] {
   return [
+    {
+      id: "level",
+      header: () => "Level",
+      cell: ({ row }) =>
+        `${getLevel(row.original.startExp)} - ${getLevel(row.getValue("endExp"), true)}`,
+    },
     {
       id: "startExp",
       header: () => "Starting exp.",


### PR DESCRIPTION
To make it a little easier to quickly make out what the level requirements for the different metas are, we can show the levels. I opted for a level range for each row because we also display the ending exp for each row. We could remove the ending exp from each row and only show the starting level or we can just display the starting level without removing the ending exp. The ending exp for each method is the next method's starting exp anyway.
![image](https://github.com/wise-old-man/wise-old-man/assets/5983417/5c75bcba-0d40-4476-9d54-7141849d33bd)
