### PR TITLE
fix some bugs in f2p-im rates

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.7.8",
+  "version": "2.7.9",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/modules/efficiency/configs/ehp/f2p_ironman.ehp.ts
+++ b/server/src/api/modules/efficiency/configs/ehp/f2p_ironman.ehp.ts
@@ -35,7 +35,7 @@ export default [
         description: 'Hill Giants'
       },
       {
-        startExp: 1_629_200,
+        startExp: 1_986_068,
         rate: 48_600,
         description: 'Hill Giants'
       },
@@ -87,25 +87,17 @@ export default [
         originSkill: Skill.ATTACK,
         bonusSkill: Skill.PRAYER,
         startExp: 737_627,
-        endExp: 1_629_200,
+        endExp: 1_986_068,
         end: true,
         ratio: 0.1254
       },
       {
         originSkill: Skill.ATTACK,
         bonusSkill: Skill.PRAYER,
-        startExp: 1_629_200,
+        startExp: 1_986_068,
         endExp: 5_346_332,
         end: true,
         ratio: 0.1233
-      },
-      {
-        originSkill: Skill.ATTACK,
-        bonusSkill: Skill.PRAYER,
-        startExp: 2_192_818,
-        endExp: 3_972_294,
-        end: true,
-        ratio: 0.1234
       },
       {
         originSkill: Skill.ATTACK,
@@ -129,7 +121,7 @@ export default [
         startExp: 37_224,
         endExp: 13_034_431,
         end: true,
-        ratio: 0.0071
+        ratio: 0.0047
       },
       {
         originSkill: Skill.ATTACK,
@@ -229,7 +221,7 @@ export default [
         description: 'Hill Giants'
       },
       {
-        startExp: 1_629_200,
+        startExp: 1_986_068,
         rate: 42_000,
         description: 'Hill Giants'
       },
@@ -291,9 +283,17 @@ export default [
         originSkill: Skill.STRENGTH,
         bonusSkill: Skill.PRAYER,
         startExp: 737_627,
-        endExp: 3_258_594,
+        endExp: 1_986_068,
         end: true,
         ratio: 0.1285
+      },
+      {
+        originSkill: Skill.STRENGTH,
+        bonusSkill: Skill.PRAYER,
+        startExp: 1_986_068,
+        endExp: 3_258_594,
+        end: true,
+        ratio: 0.1258
       },
       {
         originSkill: Skill.STRENGTH,
@@ -341,7 +341,7 @@ export default [
         startExp: 13_034_431,
         endExp: 200_000_000,
         end: true,
-        ratio: 0.1117
+        ratio: 0.0086
       }
     ]
   },


### PR DESCRIPTION
follow-on from https://github.com/wise-old-man/wise-old-man/pull/1519 to fix a few mistakes in the f2p-im rates

- attack & str have the wrong xp value for lvl 80. it's at 1.6m but should be 1,986,068. that was my bad - mistake on my sheet. this affects both the ehp rates and bxp start/end values
- attack has a pray ratio of .1234 from 2192k to 3972k xp that should be removed
- attack's crafting ratio from 37k to 13034k should be 0.0047, not 0.0071
- strength is missing a pray bxp ratio between 1986k and 3258k xp of 0.1258
- strength's crafting ratio at 99+ should be 0.0086, not 0.1117