### PR TITLE
Correct an error in f2p-im ehp rates at 99 atk/str/def

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.7.9",
+  "version": "2.7.10",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/modules/efficiency/configs/ehp/f2p_ironman.ehp.ts
+++ b/server/src/api/modules/efficiency/configs/ehp/f2p_ironman.ehp.ts
@@ -46,7 +46,7 @@ export default [
       },
       {
         startExp: 13_034_431,
-        rate: 50_500,
+        rate: 50_100,
         description: 'Ogresses & Hill Giants'
       }
     ],
@@ -148,7 +148,7 @@ export default [
       },
       {
         startExp: 37_224,
-        rate: 50_300,
+        rate: 50_000,
         description: 'Ogresses & Hill Giants'
       }
     ],
@@ -242,7 +242,7 @@ export default [
       },
       {
         startExp: 13_034_431,
-        rate: 51_000,
+        rate: 50_600,
         description: 'Ogresses & Hill Giants'
       }
     ],

--- a/server/src/api/modules/efficiency/configs/ehp/f2p_ironman.ehp.ts
+++ b/server/src/api/modules/efficiency/configs/ehp/f2p_ironman.ehp.ts
@@ -113,7 +113,7 @@ export default [
         startExp: 13_034_431,
         endExp: 200_000_000,
         end: true,
-        ratio: 0.112
+        ratio: 0.1117
       },
       {
         originSkill: Skill.ATTACK,
@@ -167,7 +167,7 @@ export default [
         startExp: 37_224,
         endExp: 200_000_000,
         end: true,
-        ratio: 0.1127
+        ratio: 0.1125
       },
       {
         originSkill: Skill.DEFENCE,
@@ -325,7 +325,7 @@ export default [
         startExp: 13_034_431,
         endExp: 200_000_000,
         end: true,
-        ratio: 0.1118
+        ratio: 0.1115
       },
       {
         originSkill: Skill.STRENGTH,

--- a/server/src/api/modules/efficiency/configs/ehp/f2p_ironman.ehp.ts
+++ b/server/src/api/modules/efficiency/configs/ehp/f2p_ironman.ehp.ts
@@ -113,7 +113,7 @@ export default [
         startExp: 13_034_431,
         endExp: 200_000_000,
         end: true,
-        ratio: 0.1119
+        ratio: 0.112
       },
       {
         originSkill: Skill.ATTACK,
@@ -167,7 +167,7 @@ export default [
         startExp: 37_224,
         endExp: 200_000_000,
         end: true,
-        ratio: 0.1126
+        ratio: 0.1127
       },
       {
         originSkill: Skill.DEFENCE,
@@ -325,7 +325,7 @@ export default [
         startExp: 13_034_431,
         endExp: 200_000_000,
         end: true,
-        ratio: 0.1117
+        ratio: 0.1118
       },
       {
         originSkill: Skill.STRENGTH,


### PR DESCRIPTION
The rates at 99 for these skills are an average of mostly hill giants with some ogresses. I forgot to apply the 93.5% perfect-tick rate to the ogress rate used in this average, so the final rates were slightly too high. There was another error in my calc which is that the pray ratio at 99 used the averaged 99 rate for the hill giant small bone calcs, but it should have been using the 99 rate of only hill giants for that part. This means that the pray ratios end up being a bit lower too.