### PR TITLE
Force en-US locale for number formats

### DIFF
--- a/server/src/utils/strings.ts
+++ b/server/src/utils/strings.ts
@@ -3,11 +3,11 @@ function formatNumber(num: number, withLetters = false, decimalPrecision = 2) {
 
   // If number is float
   if (num % 1 !== 0) {
-    return (Math.round(num * 100) / 100).toLocaleString();
+    return (Math.round(num * 100) / 100).toLocaleString('en-US');
   }
 
   if ((num < 10000 && num > -10000) || !withLetters) {
-    return num.toLocaleString();
+    return num.toLocaleString('en-US');
   }
 
   // < 100k


### PR DESCRIPTION
My machine was using commas thus failing the tests