### PR TITLE
Allow name change capitalization multiple times

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.7.28",
+  "version": "2.7.29",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/modules/name-changes/services/SubmitNameChangeService.ts
+++ b/server/src/api/modules/name-changes/services/SubmitNameChangeService.ts
@@ -66,7 +66,7 @@ async function submitNameChange(oldName: string, newName: string): Promise<NameC
       orderBy: { createdAt: 'desc' }
     });
 
-    if (lastChange && standardize(lastChange.oldName) === stOldName) {
+    if (lastChange && lastChange.newName === newName) {
       throw new BadRequestError(`Cannot submit a duplicate (approved) name change. (Id: ${lastChange.id})`);
     }
   }


### PR DESCRIPTION
Compare the new names case insensitively instead of old names. If they the last change's new name is capitalized the same as the newly submitted new name, then no change should be made and no name change is submitted. But if the last change's new name (aka the current display name of the profile) is different from the one currently submitted, then the capitalization changed and we allow a name change submission.

Fixes #1567