### PR TITLE
[app] Prevent accidental closing of verification code dialog

### DIFF
--- a/app/src/components/competitions/SaveCompetitionVerificationCodeDialog.tsx
+++ b/app/src/components/competitions/SaveCompetitionVerificationCodeDialog.tsx
@@ -46,7 +46,7 @@ export function SaveCompetitionVerificationCodeDialog(
         if (!val) props.onClose();
       }}
     >
-      <DialogContent className="w-[22rem]">
+      <DialogContent className="w-[22rem]" hideClose onPointerDownOutside={(e) => e.preventDefault()}>
         {isGroupCompetition ? (
           <>
             <DialogHeader>

--- a/app/src/components/groups/SaveGroupVerificationCodeDialog.tsx
+++ b/app/src/components/groups/SaveGroupVerificationCodeDialog.tsx
@@ -43,7 +43,7 @@ export function SaveGroupVerificationCodeDialog(props: SaveGroupVerificationCode
         if (!val) props.onClose();
       }}
     >
-      <DialogContent className="w-[22rem]">
+      <DialogContent className="w-[22rem]" hideClose onPointerDownOutside={(e) => e.preventDefault()}>
         <DialogHeader>
           <DialogTitle className="text-center">Done!</DialogTitle>
           <span className="text-center text-sm text-blue-400">


### PR DESCRIPTION
- Removes the close button from group and competition verification code copy dialog.
- Makes it so copy verification code dialog can't be closed by clicking outside of the dialog to prevent accidental closes.