### PR TITLE
[api] Fix malformed verification code checks

### DIFF
--- a/server/__tests__/suites/integration/groups.test.ts
+++ b/server/__tests__/suites/integration/groups.test.ts
@@ -378,6 +378,34 @@ describe('Group API', () => {
       expect(onMembersJoinedEvent).not.toHaveBeenCalled();
     });
 
+    it('should not edit (no dashes in verification code, but empty params)', async () => {
+      const dashlessCode = globalData.testGroupNoMembers.verificationCode.replaceAll('-', '');
+
+      const response = await api
+        .put(`/groups/${globalData.testGroupNoMembers.id}`)
+        .send({ verificationCode: dashlessCode });
+
+      expect(response.status).toBe(400);
+      expect(response.body.message).toMatch('Nothing to update.');
+
+      expect(onMembersLeftEvent).not.toHaveBeenCalled();
+      expect(onMembersJoinedEvent).not.toHaveBeenCalled();
+    });
+
+    it('should not edit (white spaces in verification code, but empty params)', async () => {
+      const codeWithWhitespace = ` ${globalData.testGroupNoMembers.verificationCode} `;
+
+      const response = await api
+        .put(`/groups/${globalData.testGroupNoMembers.id}`)
+        .send({ verificationCode: codeWithWhitespace });
+
+      expect(response.status).toBe(400);
+      expect(response.body.message).toMatch('Nothing to update.');
+
+      expect(onMembersLeftEvent).not.toHaveBeenCalled();
+      expect(onMembersJoinedEvent).not.toHaveBeenCalled();
+    });
+
     it('should not edit (empty params)', async () => {
       const response = await api
         .put(`/groups/${globalData.testGroupNoMembers.id}`)

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.7.30",
+  "version": "2.7.31",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.7.30",
+      "version": "2.7.31",
       "license": "ISC",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.7.30",
+  "version": "2.7.31",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/services/external/crypt.service.ts
+++ b/server/src/api/services/external/crypt.service.ts
@@ -40,12 +40,29 @@ export async function generateVerification(): Promise<[string, string]> {
  * Checks if a given hash matches a given code.
  */
 export async function verifyCode(hash: string, code: string): Promise<boolean> {
+  const trimmedCode = code.trim();
+
   const verified = await new Promise((resolve, reject) => {
-    compare(code, hash, (err, result) => {
+    compare(trimmedCode, hash, (err, result) => {
       if (err) reject(err);
       resolve(result);
     });
   });
 
-  return !!verified;
+  if (verified) {
+    return true;
+  }
+
+  /**
+   * Sometimes users might input the code without the dashes,
+   * this double checks by re-inserting the dashes and trying again.
+   */
+  if (trimmedCode.length === 9) {
+    return verifyCode(
+      hash,
+      trimmedCode.slice(0, 3) + '-' + trimmedCode.slice(3, 6) + '-' + trimmedCode.slice(6, 9)
+    );
+  }
+
+  return false;
 }


### PR DESCRIPTION
- The API now trims any leading or trailing whitespace from verification codes before validating
- The API now accepts verification codes without dashes (some users exclude them)