### PR TITLE
[app] Fix app search firing off too frequently

### DIFF
--- a/app/src/components/PlayerSearch.tsx
+++ b/app/src/components/PlayerSearch.tsx
@@ -31,14 +31,14 @@ export function PlayerSearch(props: PlayerSearchProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const focusParentRef = useRef<HTMLDivElement>(null);
 
-  const debouncedSearchQuery = useDebouncedValue(query, 250);
+  const debouncedSearchQuery = useDebouncedValue(query, 400);
 
   const { recentSearches, addSearchTerm } = useRecentSearches({
     enabled: open,
   });
 
   const { data: players } = useSearchPlayers(debouncedSearchQuery, {
-    enabled: open && debouncedSearchQuery.length > 0,
+    enabled: debouncedSearchQuery.length > 0,
   });
 
   const hasExactMatch = players?.some((player) => isExactMatch(query, player.username));

--- a/app/src/hooks/useChangelog.ts
+++ b/app/src/hooks/useChangelog.ts
@@ -11,7 +11,7 @@ export default function useChangelog() {
     queryFn: () => {
       return localStorage.getItem(LOCAL_STORAGE_KEY);
     },
-    staleTime: 300,
+    staleTime: 300_000,
   });
 
   const latestChangelog = changelog[0] as Changelog | undefined;

--- a/app/src/hooks/useRecentSearches.ts
+++ b/app/src/hooks/useRecentSearches.ts
@@ -16,7 +16,7 @@ export default function useRecentSearches({ enabled }: { enabled?: boolean }) {
       }
     },
     enabled: enabled === undefined || enabled,
-    staleTime: 300,
+    staleTime: 300_000,
   });
 
   const addSearchTermMutation = useMutation({

--- a/app/src/hooks/useSearchGroups.ts
+++ b/app/src/hooks/useSearchGroups.ts
@@ -8,6 +8,6 @@ export default function useSearchGroups(query: string, options: { enabled?: bool
     queryKey: ["groups", query],
     queryFn: () => client.groups.searchGroups(query),
     enabled: options.enabled === undefined || options.enabled,
-    staleTime: 30,
+    staleTime: 30_000,
   });
 }

--- a/app/src/hooks/useSearchPlayers.ts
+++ b/app/src/hooks/useSearchPlayers.ts
@@ -3,11 +3,12 @@ import { useWOMClient } from "./useWOMClient";
 
 export default function useSearchPlayers(query: string, options: { enabled?: boolean }) {
   const client = useWOMClient();
+  const trimmedQuery = query.toLowerCase().trim();
 
   return useQuery({
-    queryKey: ["players", query],
-    queryFn: () => client.players.searchPlayers(query),
+    queryKey: ["players", trimmedQuery],
+    queryFn: () => client.players.searchPlayers(trimmedQuery),
     enabled: options.enabled === undefined || options.enabled,
-    staleTime: 30,
+    staleTime: 30_000,
   });
 }


### PR DESCRIPTION
We're getting about 25k search results per 24h which seemed strangely high when compared to the number of daily page loads. Checked the network tab while doing some searches on the website and noticed a few different bugs with search that caused requests to be sent out too frequently.

- The search results were getting invalidated after 30ms instead of 30s
- The component would re-fetch everytime it was opened
- The component would re-fetch with different capitalization once it found a result
- Increased query debounce from 250ms to 400ms