### PR TITLE
Prevent group verification code dialog from closing until timer elapses

### DIFF
--- a/app/src/components/groups/SaveGroupVerificationCodeDialog.tsx
+++ b/app/src/components/groups/SaveGroupVerificationCodeDialog.tsx
@@ -54,7 +54,7 @@ export function SaveGroupVerificationCodeDialog(props: SaveGroupVerificationCode
         if (!val) onClose();
       }}
     >
-      <DialogContent className="w-[22rem]" hideClose={!canClose}>
+      <DialogContent className="w-[22rem]" hideClose={true}>
         <DialogHeader>
           <DialogTitle className="text-center">Done!</DialogTitle>
           <span className="text-center text-sm text-blue-400">

--- a/app/src/components/groups/SaveGroupVerificationCodeDialog.tsx
+++ b/app/src/components/groups/SaveGroupVerificationCodeDialog.tsx
@@ -19,7 +19,7 @@ interface SaveGroupVerificationCodeDialogProps {
 }
 
 export function SaveGroupVerificationCodeDialog(props: SaveGroupVerificationCodeDialogProps) {
-  const { isOpen, onClose, verificationCode } = props;
+  const { isOpen, verificationCode } = props;
 
   const toast = useToast();
   const inputRef = useRef<HTMLInputElement>(null);
@@ -36,14 +36,25 @@ export function SaveGroupVerificationCodeDialog(props: SaveGroupVerificationCode
   const timeEllapsed = openedTimestamp ? Math.ceil((Date.now() - openedTimestamp) / 1000) : 0;
   const hasWaited = timeEllapsed >= MIN_WAIT_PERIOD_SECONDS;
 
+  const canClose = hasWaited && !isTransitioning;
+  function onClose() {
+    if (!canClose) {
+      return;
+    }
+
+    startTransition(() => {
+      props.onClose();
+    });
+  }
+
   return (
     <Dialog
       open={isOpen}
       onOpenChange={(val) => {
-        if (!val) props.onClose();
+        if (!val) onClose();
       }}
     >
-      <DialogContent className="w-[22rem]">
+      <DialogContent className="w-[22rem]" hideClose={!canClose}>
         <DialogHeader>
           <DialogTitle className="text-center">Done!</DialogTitle>
           <span className="text-center text-sm text-blue-400">
@@ -82,7 +93,7 @@ export function SaveGroupVerificationCodeDialog(props: SaveGroupVerificationCode
           size="lg"
           variant="blue"
           className="mt-4 justify-center tabular-nums"
-          disabled={!hasWaited || isTransitioning}
+          disabled={!canClose}
           onClick={() => {
             startTransition(() => {
               onClose();


### PR DESCRIPTION
# This PR fixes #1616 by:

- Wrapping the dialog's `onClose` prop in a fn that checks if the timer has completed. The wrapped onClose is then passed into the `DialogPrimative`'s `onOpenChange` handler and the 'Ok, I got it' button's `onClick` handler.
- Hides the dialog close button as it doesn't feel appropriate for the context of this dialog

# Before:

Here I click the backdrop to close the dialog before the timer completes but also note the dialog's close button is also available to click.

https://github.com/user-attachments/assets/2a5db186-d93c-444e-a1d3-7cc05bb07648

# After:

Clicking the backdrop doesn't close the dialog and the close button ('x') doesn't appear.

https://github.com/user-attachments/assets/44b3cb55-4a71-44c4-9a8a-c8dc31354484

