### PR TITLE
Add some EHP fixes

### DIFF
--- a/app/src/components/rates/AccountTypeSelector.tsx
+++ b/app/src/components/rates/AccountTypeSelector.tsx
@@ -73,6 +73,8 @@ function getLabel(type: EfficiencyAlgorithmType) {
       return "F2P & Level 3";
     case EfficiencyAlgorithmType.F2P_LVL3_IRONMAN:
       return "F2P & Level 3 Ironman";
+    case EfficiencyAlgorithmType.DEF1:
+      return "1 Defence Pure";
     default:
       return "Unknown";
   }

--- a/server/__tests__/suites/integration/players.test.ts
+++ b/server/__tests__/suites/integration/players.test.ts
@@ -336,7 +336,7 @@ describe('Player API', () => {
       });
 
       // Using the test "main" rates, we should get this number for regular accs
-      expect(response.body.ehp).toBeCloseTo(610.1157424782884, 4);
+      expect(response.body.ehp).toBeCloseTo(630.6918952334495, 4);
 
       expect(onPlayerUpdatedEvent).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -615,7 +615,7 @@ describe('Player API', () => {
       // IM rates should have been used, so the output EHP should be different than the one
       // calculate for the regular player (Psikoi)
       expect(response.body.ehp).not.toBeCloseTo(694.4541800000006, 4);
-      expect(response.body.ehp).toBeCloseTo(1211.526534283978, 4);
+      expect(response.body.ehp).toBeCloseTo(1226.188183430856, 4);
 
       expect(response.body.latestSnapshot).not.toBeNull();
 

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.7.40",
+  "version": "2.7.41",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/modules/efficiency/EfficiencyAlgorithm.ts
+++ b/server/src/api/modules/efficiency/EfficiencyAlgorithm.ts
@@ -179,11 +179,11 @@ class EfficiencyAlgorithm {
         }
 
         if (!isStart && b.originSkill === Skill.FIREMAKING && b.bonusSkill === Skill.THIEVING) {
-          // Apply special BXP scaling function for fire bwan firemaking/cooking
-          const fireBwanBonus = this.getFireBwanScaledBonus(stats);
+          // Apply special BXP scaling function for firefact firemaking/thieving
+          const firefactBonus = this.getFirefactScaledBonus(stats);
 
-          if (fireBwanBonus) {
-            map.set(Skill.THIEVING, map.get(Skill.THIEVING)! + fireBwanBonus);
+          if (firefactBonus) {
+            map.set(Skill.THIEVING, map.get(Skill.THIEVING)! + firefactBonus);
             return;
           }
         }
@@ -224,13 +224,13 @@ class EfficiencyAlgorithm {
     );
   }
 
-  private getFireBwanScaledBonus(stats: Map<Skill, number>) {
+  private getFirefactScaledBonus(stats: Map<Skill, number>) {
     return this.getScaledMaxBonus(
       stats,
       Skill.FIREMAKING,
-      Skill.COOKING,
+      Skill.THIEVING,
       this.skillMetas.find(sm => sm.skill === Skill.FIREMAKING)?.methods.find(m => !!m.realRate),
-      this.skillMetas.find(sm => sm.skill === Skill.COOKING)?.methods.at(-1),
+      this.skillMetas.find(sm => sm.skill === Skill.THIEVING)?.methods.at(-1),
       this.skillMetas.find(sm => sm.skill === Skill.FIREMAKING)?.bonuses[0]?.ratio
     );
   }

--- a/server/src/api/modules/efficiency/EfficiencyAlgorithm.ts
+++ b/server/src/api/modules/efficiency/EfficiencyAlgorithm.ts
@@ -178,6 +178,16 @@ class EfficiencyAlgorithm {
           }
         }
 
+        if (!isStart && b.originSkill === Skill.FIREMAKING && b.bonusSkill === Skill.THIEVING) {
+          // Apply special BXP scaling function for fire bwan firemaking/cooking
+          const fireBwanBonus = this.getFireBwanScaledBonus(stats);
+
+          if (fireBwanBonus) {
+            map.set(Skill.THIEVING, map.get(Skill.THIEVING)! + fireBwanBonus);
+            return;
+          }
+        }
+
         const expCap = Math.min(b.endExp, MAX_SKILL_EXP);
 
         const originStart =
@@ -211,6 +221,17 @@ class EfficiencyAlgorithm {
       this.skillMetas.find(sm => sm.skill === Skill.THIEVING)?.methods.find(m => !!m.realRate),
       this.skillMetas.find(sm => sm.skill === Skill.AGILITY)?.methods.at(-1),
       this.skillMetas.find(sm => sm.skill === Skill.THIEVING)?.bonuses[0]?.ratio
+    );
+  }
+
+  private getFireBwanScaledBonus(stats: Map<Skill, number>) {
+    return this.getScaledMaxBonus(
+      stats,
+      Skill.FIREMAKING,
+      Skill.COOKING,
+      this.skillMetas.find(sm => sm.skill === Skill.FIREMAKING)?.methods.find(m => !!m.realRate),
+      this.skillMetas.find(sm => sm.skill === Skill.COOKING)?.methods.at(-1),
+      this.skillMetas.find(sm => sm.skill === Skill.FIREMAKING)?.bonuses[0]?.ratio
     );
   }
 

--- a/server/src/api/modules/efficiency/configs/ehp/def1.ehp.ts
+++ b/server/src/api/modules/efficiency/configs/ehp/def1.ehp.ts
@@ -715,6 +715,7 @@ export default [
       {
         startExp: 933_979,
         rate: 265_000,
+        realRate: 118_535,
         description: 'Drift net fishing (118.5k hunter & 89.9k fishing xp/h), scales to black chinchompas'
       }
     ],

--- a/server/src/api/modules/efficiency/configs/ehp/def1.ehp.ts
+++ b/server/src/api/modules/efficiency/configs/ehp/def1.ehp.ts
@@ -237,6 +237,7 @@ export default [
       {
         startExp: 13_034_431,
         rate: 794_566,
+        realRate: 310_000,
         description:
           'Artefacts with firemaking (260k thieving & 310k firemaking xp/h), scales to firebwan (505k firemaking & 353.5k cooking xp/h)'
       }

--- a/server/src/api/modules/efficiency/configs/ehp/f2p.ehp.ts
+++ b/server/src/api/modules/efficiency/configs/ehp/f2p.ehp.ts
@@ -353,7 +353,7 @@ export default [
         bonusSkill: Skill.COOKING,
         startExp: 13_363,
         endExp: 200_000_000,
-        end: true,
+        end: false,
         ratio: 1.15
       }
     ]

--- a/server/src/api/modules/efficiency/configs/ehp/f2p_ironman.ehp.ts
+++ b/server/src/api/modules/efficiency/configs/ehp/f2p_ironman.ehp.ts
@@ -526,7 +526,7 @@ export default [
         bonusSkill: Skill.COOKING,
         startExp: 0,
         endExp: 200_000_000,
-        end: true,
+        end: false,
         ratio: 1.15
       }
     ]

--- a/server/src/api/modules/efficiency/configs/ehp/f2p_lvl3.ehp.ts
+++ b/server/src/api/modules/efficiency/configs/ehp/f2p_lvl3.ehp.ts
@@ -133,7 +133,7 @@ export default [
         bonusSkill: Skill.COOKING,
         startExp: 13_363,
         endExp: 200_000_000,
-        end: true,
+        end: false,
         ratio: 1.15
       }
     ]

--- a/server/src/api/modules/efficiency/configs/ehp/f2p_lvl3_ironman.ehp.ts
+++ b/server/src/api/modules/efficiency/configs/ehp/f2p_lvl3_ironman.ehp.ts
@@ -123,7 +123,7 @@ export default [
         bonusSkill: Skill.COOKING,
         startExp: 0,
         endExp: 200_000_000,
-        end: true,
+        end: false,
         ratio: 1.15
       }
     ]

--- a/server/src/api/modules/efficiency/configs/ehp/ironman.ehp.ts
+++ b/server/src/api/modules/efficiency/configs/ehp/ironman.ehp.ts
@@ -266,8 +266,16 @@ export default [
         originSkill: Skill.FISHING,
         bonusSkill: Skill.AGILITY,
         startExp: 737_627,
-        endExp: 200_000_000,
+        endExp: 13_034_431,
         end: false,
+        ratio: 0.0885
+      },
+      {
+        originSkill: Skill.FISHING,
+        bonusSkill: Skill.AGILITY,
+        startExp: 13_034_431,
+        endExp: 200_000_000,
+        end: true,
         ratio: 0.0885
       }
     ]

--- a/server/src/api/modules/efficiency/configs/ehp/lvl3.ehp.ts
+++ b/server/src/api/modules/efficiency/configs/ehp/lvl3.ehp.ts
@@ -210,6 +210,7 @@ export default [
       {
         startExp: 5_346_332,
         rate: 794_566,
+        realRate: 310_000,
         description: 'Firebwan (Redwood logs) - 505k firemaking, 353.5k cooking'
       }
     ],

--- a/server/src/api/modules/efficiency/configs/ehp/lvl3.ehp.ts
+++ b/server/src/api/modules/efficiency/configs/ehp/lvl3.ehp.ts
@@ -690,6 +690,7 @@ export default [
       {
         startExp: 933_979,
         rate: 255_000,
+        realRate: 118_535,
         description: 'Drift net fishing (118.5k hunter & 89.9k fishing xp/h, scales to black chinchompas)'
       }
     ],

--- a/server/src/api/modules/efficiency/configs/ehp/main.ehp.ts
+++ b/server/src/api/modules/efficiency/configs/ehp/main.ehp.ts
@@ -342,6 +342,7 @@ export default [
       {
         startExp: 13_034_431,
         rate: 794_566,
+        realRate: 505_000,
         description:
           'Artefacts with firemaking (260k thieving & 310k firemaking xp/h), scales to firebwan (505k firemaking & 353.5k cooking xp/h)'
       }
@@ -941,6 +942,7 @@ export default [
       {
         startExp: 933_979,
         rate: 265_000,
+        realRate: 118_535,
         description: 'Drift net fishing (118.5k hunter & 89.9k fishing xp/h), scales to black chinchompas'
       }
     ],

--- a/server/src/api/modules/efficiency/configs/ehp/main.ehp.ts
+++ b/server/src/api/modules/efficiency/configs/ehp/main.ehp.ts
@@ -342,7 +342,7 @@ export default [
       {
         startExp: 13_034_431,
         rate: 794_566,
-        realRate: 505_000,
+        realRate: 310_000,
         description:
           'Artefacts with firemaking (260k thieving & 310k firemaking xp/h), scales to firebwan (505k firemaking & 353.5k cooking xp/h)'
       }

--- a/server/src/api/modules/efficiency/configs/ehp/ultimate.ehp.ts
+++ b/server/src/api/modules/efficiency/configs/ehp/ultimate.ehp.ts
@@ -300,8 +300,17 @@ export default [
         originSkill: Skill.FISHING,
         bonusSkill: Skill.AGILITY,
         startExp: 737_627,
-        endExp: 13_034_431,
+        endExp: 2_183_968,
         end: false,
+        ratio: 0.091
+      },
+
+      {
+        originSkill: Skill.FISHING,
+        bonusSkill: Skill.AGILITY,
+        startExp: 2_183_968,
+        endExp: 13_034_431,
+        end: true,
         ratio: 0.091
       },
       {
@@ -309,7 +318,7 @@ export default [
         bonusSkill: Skill.AGILITY,
         startExp: 13_034_431,
         endExp: 200_000_000,
-        end: false,
+        end: true,
         ratio: 0.0885
       },
       {

--- a/server/src/utils/metrics.ts
+++ b/server/src/utils/metrics.ts
@@ -206,10 +206,10 @@ const BOSSES = Object.values(Boss) as Boss[];
 const ACTIVITIES = Object.values(Activity) as Activity[];
 const COMPUTED_METRICS = Object.values(ComputedMetric) as ComputedMetric[];
 
-const REAL_SKILLS = SKILLS.filter(s => s !== Skill.OVERALL);
-const F2P_BOSSES = BOSSES.filter(b => !MetricProps[b].isMembers);
-const MEMBER_SKILLS = SKILLS.filter(s => MetricProps[s].isMembers);
-const COMBAT_SKILLS = SKILLS.filter(s => MetricProps[s].isCombat);
+const REAL_SKILLS = SKILLS.filter(s => s !== Skill.OVERALL) as Skill[];
+const F2P_BOSSES = BOSSES.filter(b => !MetricProps[b].isMembers) as Boss[];
+const MEMBER_SKILLS = SKILLS.filter(s => MetricProps[s].isMembers) as Skill[];
+const COMBAT_SKILLS = SKILLS.filter(s => MetricProps[s].isCombat) as Skill[];
 const REAL_METRICS = [...SKILLS, ...BOSSES, ...ACTIVITIES];
 
 function findMetric(metricName: string): Metric | null {


### PR DESCRIPTION
**App**
- Add 1 defence pure ehp/ehb selection to dop down.

**API**
- Fix hunter `realRate` for main, lvl3 and 1def metas.
- Fix the cooking bonus from fishing for f2p accounts
- Fix agility bonus gained from fishing for regular ironman and ultimate ironman accounts.
- Adds firefacts (artefacts+thieving) method.

**What's still wrong**
