### PR TITLE
[api] Fix unranked achievements and records

### DIFF
--- a/server/__tests__/suites/integration/achievements.test.ts
+++ b/server/__tests__/suites/integration/achievements.test.ts
@@ -365,7 +365,9 @@ describe('Achievements API', () => {
       // Change attack to 50.5m
       const modifiedRawData = modifyRawHiscoresData(globalData.hiscoresRawDataA, [
         { metric: Metric.ATTACK, value: 50_585_985 },
-        { metric: Metric.GUARDIANS_OF_THE_RIFT, value: 51 }
+        { metric: Metric.GUARDIANS_OF_THE_RIFT, value: 51 },
+        { metric: Metric.SOUL_WARS_ZEAL, value: 5500 }, // This should trigger a new achievement
+        { metric: Metric.COLLECTIONS_LOGGED, value: 653 } // This should trigger a new achievement with unknown date (added to the hiscores way after release)
       ]);
 
       registerHiscoresMock(axiosMock, {
@@ -386,13 +388,28 @@ describe('Achievements API', () => {
       const fetchResponse = await api.get(`/players/psikoi/achievements`);
 
       expect(fetchResponse.status).toBe(200);
-      expect(fetchResponse.body.length).toBe(38);
-      expect(fetchResponse.body.filter(a => new Date(a.createdAt).getTime() === 0).length).toBe(20);
+      expect(fetchResponse.body.length).toBe(40); // 2 new achievements
+      expect(fetchResponse.body.filter(a => new Date(a.createdAt).getTime() === 0).length).toBe(21); // 1 new "unknown" date achievement
 
-      expect(fetchResponse.body.map(a => a.name)).toContain('50m Attack');
-      expect(fetchResponse.body.find(a => a.name === '50m Attack').createdAt).not.toBe(0);
+      const attackAchievement = fetchResponse.body.find(a => a.name === '50m Attack');
+
+      expect(attackAchievement).not.toBeUndefined();
+      expect(new Date(attackAchievement.createdAt).getTime()).not.toBe(0);
       // accuracy should be less than 10 seconds, since we just updated the player (plus/minus async request delays and such)
-      expect(fetchResponse.body.find(a => a.name === '50m Attack').accuracy).toBeLessThan(10_000);
+      expect(attackAchievement.accuracy).toBeLessThan(10_000);
+
+      const soulWarsAchievement = fetchResponse.body.find(a => a.name === '5k Soul Wars Zeal');
+
+      expect(soulWarsAchievement).not.toBeUndefined();
+      expect(new Date(soulWarsAchievement.createdAt).getTime()).not.toBe(0);
+      // accuracy should be less than 10 seconds, since we just updated the player (plus/minus async request delays and such)
+      expect(soulWarsAchievement.accuracy).toBeLessThan(10_000);
+
+      const collectionLogAchievement = fetchResponse.body.find(a => a.name === '500 Collections Logged');
+
+      expect(collectionLogAchievement).not.toBeUndefined();
+      expect(new Date(collectionLogAchievement.createdAt).getTime()).toBe(0);
+      expect(collectionLogAchievement.accuracy).toBeNull();
     });
 
     it('should not count very-close achievements as complete', async () => {

--- a/server/__tests__/suites/integration/deltas.test.ts
+++ b/server/__tests__/suites/integration/deltas.test.ts
@@ -149,9 +149,21 @@ describe('Deltas API', () => {
       // Only week, month and year deltas were updated, since the previous update was 3 days ago (> day & five_min)
       expect(onDeltaUpdatedEvent).toHaveBeenCalledTimes(3);
       // On a player's first update, all their deltas are potential records
-      expect(onDeltaUpdatedEvent).toHaveBeenCalledWith(expect.objectContaining({ period: 'week' }), true);
-      expect(onDeltaUpdatedEvent).toHaveBeenCalledWith(expect.objectContaining({ period: 'month' }), true);
-      expect(onDeltaUpdatedEvent).toHaveBeenCalledWith(expect.objectContaining({ period: 'year' }), true);
+      expect(onDeltaUpdatedEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ period: 'week' }),
+        expect.objectContaining({ smithingExperience: 6_177_978 }),
+        true
+      );
+      expect(onDeltaUpdatedEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ period: 'month' }),
+        expect.objectContaining({ smithingExperience: 6_177_978 }),
+        true
+      );
+      expect(onDeltaUpdatedEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ period: 'year' }),
+        expect.objectContaining({ smithingExperience: 6_177_978 }),
+        true
+      );
 
       jest.resetAllMocks();
 
@@ -201,11 +213,31 @@ describe('Deltas API', () => {
       // All (5) new deltas are an improvement over the previous, so they should be considered for record checks
       expect(onDeltaUpdatedEvent).toHaveBeenCalledTimes(5);
       // The player has now been updated within seconds of the last update, so their day and five_min deltas should update
-      expect(onDeltaUpdatedEvent).toHaveBeenCalledWith(expect.objectContaining({ period: 'five_min' }), true);
-      expect(onDeltaUpdatedEvent).toHaveBeenCalledWith(expect.objectContaining({ period: 'day' }), true);
-      expect(onDeltaUpdatedEvent).toHaveBeenCalledWith(expect.objectContaining({ period: 'week' }), true);
-      expect(onDeltaUpdatedEvent).toHaveBeenCalledWith(expect.objectContaining({ period: 'month' }), true);
-      expect(onDeltaUpdatedEvent).toHaveBeenCalledWith(expect.objectContaining({ period: 'year' }), true);
+      expect(onDeltaUpdatedEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ period: 'five_min' }),
+        expect.objectContaining({ smithingExperience: 6_177_978 + 50_000 }),
+        true
+      );
+      expect(onDeltaUpdatedEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ period: 'day' }),
+        expect.objectContaining({ smithingExperience: 6_177_978 + 50_000 }),
+        true
+      );
+      expect(onDeltaUpdatedEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ period: 'week' }),
+        expect.objectContaining({ smithingExperience: 6_177_978 }),
+        true
+      );
+      expect(onDeltaUpdatedEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ period: 'month' }),
+        expect.objectContaining({ smithingExperience: 6_177_978 }),
+        true
+      );
+      expect(onDeltaUpdatedEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ period: 'year' }),
+        expect.objectContaining({ smithingExperience: 6_177_978 }),
+        true
+      );
 
       jest.resetAllMocks();
 

--- a/server/__tests__/suites/integration/records.test.ts
+++ b/server/__tests__/suites/integration/records.test.ts
@@ -169,7 +169,7 @@ describe('Records API', () => {
       expect(firstTrackResponse.status).toBe(201);
       expect(firstTrackResponse.body.latestSnapshot.data.bosses.zulrah.kills).toBe(1646);
 
-      const modifiedRawData = modifyRawHiscoresData(globalData.hiscoresRawData, [
+      let modifiedRawData = modifyRawHiscoresData(globalData.hiscoresRawData, [
         { metric: Metric.COLLECTIONS_LOGGED, value: 623 }
       ]);
 
@@ -184,9 +184,28 @@ describe('Records API', () => {
       // Wait for the deltas to update, followed by the records
       await sleep(500);
 
-      const recordsResponse = await api.get(`/players/eren/records`);
-      expect(recordsResponse.status).toBe(200);
-      expect(recordsResponse.body.length).toBe(0);
+      const firstRecordsResponse = await api.get(`/players/eren/records`);
+      expect(firstRecordsResponse.status).toBe(200);
+      expect(firstRecordsResponse.body.length).toBe(0);
+
+      modifiedRawData = modifyRawHiscoresData(globalData.hiscoresRawData, [
+        { metric: Metric.COLLECTIONS_LOGGED, value: 627 }
+      ]);
+
+      registerHiscoresMock(axiosMock, {
+        [PlayerType.REGULAR]: { statusCode: 200, rawData: modifiedRawData },
+        [PlayerType.IRONMAN]: { statusCode: 404 }
+      });
+
+      const thirdTrackResponse = await api.post(`/players/eren`);
+      expect(thirdTrackResponse.status).toBe(200);
+
+      // Wait for the deltas to update, followed by the records
+      await sleep(500);
+
+      const secondRecordsResponse = await api.get(`/players/eren/records`);
+      expect(secondRecordsResponse.status).toBe(200);
+      expect(secondRecordsResponse.body.length).toBe(0);
     });
   });
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.7.41",
+  "version": "2.7.42",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.7.41",
+      "version": "2.7.42",
       "license": "ISC",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.1",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.7.40",
+  "version": "2.7.41",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.7.40",
+      "version": "2.7.41",
       "license": "ISC",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.7.41",
+  "version": "2.7.42",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/modules/achievements/services/SyncPlayerAchievementsService.ts
+++ b/server/src/api/modules/achievements/services/SyncPlayerAchievementsService.ts
@@ -1,6 +1,7 @@
 import prisma, { Snapshot } from '../../../../prisma';
-import { getMetricValueKey, Metric } from '../../../../utils';
+import { getMetricValueKey } from '../../../../utils';
 import { findPlayerSnapshots } from '../../snapshots/services/FindPlayerSnapshotsService';
+import { POST_RELEASE_HISCORE_ADDITIONS } from '../../snapshots/snapshot.utils';
 import { onAchievementsCreated } from '../achievement.events';
 import { calculatePastDates, getAchievementDefinitions } from '../achievement.utils';
 
@@ -73,11 +74,9 @@ async function syncPlayerAchievements(playerId: number, previous: Snapshot | und
     // this causes players to go from -1 to achievement thresholds in a single update,
     // which incorrectly attributes the achievement to the current date.
     // To fix these, any achievements for these metrics that were previously -1, are set to an "unknown" date.
-    const metricsToSkip = [Metric.ARTIO, Metric.CALVARION, Metric.SPINDEL, Metric.COLLECTIONS_LOGGED];
-
     let forceUnknownDate = false;
 
-    if (previous[getMetricValueKey(metric)] === -1 && metricsToSkip.includes(metric)) {
+    if (previous[getMetricValueKey(metric)] === -1 && POST_RELEASE_HISCORE_ADDITIONS.includes(metric)) {
       forceUnknownDate = true;
     }
 

--- a/server/src/api/modules/deltas/delta.events.ts
+++ b/server/src/api/modules/deltas/delta.events.ts
@@ -1,13 +1,13 @@
-import { Delta } from '../../../prisma';
+import { Delta, Snapshot } from '../../../prisma';
 import prometheus from '../../services/external/prometheus.service';
 import { syncPlayerRecords } from '../records/services/SyncPlayerRecordsService';
 
-async function onDeltaUpdated(delta: Delta, isPotentialRecord: boolean) {
+async function onDeltaUpdated(delta: Delta, previousSnapshot: Snapshot, isPotentialRecord: boolean) {
   if (!isPotentialRecord) return;
 
   // Check if this new delta is an all time record for this player
   await prometheus.trackEffect('syncPlayerRecords', async () => {
-    await syncPlayerRecords(delta);
+    await syncPlayerRecords(delta, previousSnapshot);
   });
 }
 

--- a/server/src/api/modules/deltas/services/SyncPlayerDeltasService.ts
+++ b/server/src/api/modules/deltas/services/SyncPlayerDeltasService.ts
@@ -80,7 +80,7 @@ async function syncPlayerDeltas(player: Player, latestSnapshot: Snapshot): Promi
       create: newDelta
     });
 
-    deltaEvents.onDeltaUpdated(updatedDelta, !currentDelta || hasImprovements);
+    deltaEvents.onDeltaUpdated(updatedDelta, startSnapshot, !currentDelta || hasImprovements);
   }
 
   // Execute all update promises, sequentially

--- a/server/src/api/modules/records/services/SyncPlayerRecordsService.ts
+++ b/server/src/api/modules/records/services/SyncPlayerRecordsService.ts
@@ -22,7 +22,7 @@ async function syncPlayerRecords(delta: Delta, previousSnapshot: Snapshot) {
       continue;
     }
 
-    // Some metrics (such as collection logs, and some wildy bosses) were added to the hiscores after the initial release.
+    // Some metrics (such as collection logs, and some wildy bosses) were added to the hiscores after their in-game release.
     // Which meant a lot of players jumped from unranked (-1) to their current kc at the time, this generated a lot of records.
     // which can likely never be beaten. To avoid this, we skip adding records for these metrics if the previous snapshot value was -1.
     if (

--- a/server/src/api/modules/snapshots/snapshot.utils.ts
+++ b/server/src/api/modules/snapshots/snapshot.utils.ts
@@ -35,6 +35,15 @@ import {
 // Skip Deadman Points and Legacy Bounty Hunter (hunter/rogue)
 export const SKIPPED_ACTIVITY_INDICES = [1, 4, 5];
 
+// These metrics were added to the hiscores long after their in-game release,
+// causing players to go from unranked to very high values in a single update.
+export const POST_RELEASE_HISCORE_ADDITIONS = [
+  Metric.COLLECTIONS_LOGGED,
+  Metric.SPINDEL,
+  Metric.CALVARION,
+  Metric.ARTIO
+];
+
 // On this date, the Bounty Hunter was updated and scores were reset.
 const BOUNTY_HUNTER_UPDATE_DATE = new Date('2023-05-24T10:30:00.000Z');
 


### PR DESCRIPTION
Some metrics (such as collections logged, spindel, artio and calvarion) are added to the hiscores long after their in-game release. This causes players to go from unranked (-1) to a very high number, which creates incorrectly dated achievements and impossibly high records.

This PR ensures that any achievement for these metrics is set to "unknown date" if the previous value was -1, and similarily, records for these metrics are ignored if the previous value was -1.