### PR TITLE
[api] Fix achievement threshold formatting

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.7.43",
+  "version": "2.7.44",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/modules/achievements/achievement.utils.ts
+++ b/server/src/api/modules/achievements/achievement.utils.ts
@@ -5,7 +5,8 @@ import {
   getLevel,
   SKILL_EXP_AT_99,
   isMetric,
-  REAL_SKILLS
+  REAL_SKILLS,
+  formatNumber
 } from '../../../utils';
 import { Achievement, Snapshot } from '../../../prisma';
 import { ACHIEVEMENT_TEMPLATES } from './achievement.templates';
@@ -36,16 +37,13 @@ function getAchievemenName(name: string, threshold: number): string {
 
 function formatThreshold(threshold: number): string {
   if (threshold < 1000) return String(threshold);
-  if (threshold <= 100_000) return `${Math.floor(threshold / 1000)}k`;
+  if (threshold <= 10_000) return `${threshold / 1000}k`;
 
   if ([273_742, 737_627, 1_986_068, 5_346_332, 13_034_431].includes(threshold)) {
     return getLevel(threshold).toString();
   }
 
-  if (threshold < 1_000_000_000)
-    return `${Math.round((threshold / 1_000_000 + Number.EPSILON) * 100) / 100}m`;
-
-  return `${Math.round((threshold / 1_000_000_000 + Number.EPSILON) * 100) / 100}b`;
+  return formatNumber(threshold, true).toString();
 }
 
 function getAchievementDefinitions(): AchievementDefinition[] {


### PR DESCRIPTION
Changes when achievement thresholds are rounded to allow achievements such as `1.2k Collections Logged` to be properly displayed in the discord bot announcements. It now also matches what is displayed on the website.

Before: ![image](https://github.com/user-attachments/assets/97af790e-3697-4bb4-8c8b-69c3dbf834e5)
After: ![image](https://github.com/user-attachments/assets/052fb9a2-216e-4483-b643-fa1c2557e6a0)