### PR TITLE
[app] Add previous button to step 2 of group creation

### DIFF
--- a/app/src/components/groups/CreateGroupForm.tsx
+++ b/app/src/components/groups/CreateGroupForm.tsx
@@ -246,6 +246,17 @@ function GroupImportOptions() {
           <ArrowRightIcon className="h-5 w-5" />
         </button>
       </div>
+      <div className="mt-10 flex justify-between gap-x-3">
+        <Button
+          variant="outline"
+          onClick={() => {
+            setStep("info");
+          }}
+        >
+          <ArrowRightIcon className="-ml-1.5 h-4 w-4 -rotate-180" />
+          Previous
+        </Button>
+      </div>      
     </div>
   );
 }


### PR DESCRIPTION
Adds a `Previous` button to the import step in the group creation process. For instance if you set a name for your new group and that name is already taken, you can't go back to the info page to change the name. You need to refresh the page and lose all the progress. This fixes that.