### PR TITLE
docs: remove unused query params

### DIFF
--- a/docs/docs/players-api/player-endpoints.mdx
+++ b/docs/docs/players-api/player-endpoints.mdx
@@ -671,8 +671,6 @@ Fetches all of the player's competition participations. Returns an array of [Pla
 | Field  | Type                                                                                        | Required | Description                                           |
 | ------ | ------------------------------------------------------------------------------------------- | -------- | ----------------------------------------------------- |
 | status | [CompetitionStatus](/competitions-api/competition-type-definitions#enum-competition-status) | `false`  | The competition status filter.                        |
-| limit  | integer                                                                                     | `false`  | The pagination limit. See [Pagination](/#pagination)  |
-| offset | integer                                                                                     | `false`  | The pagination offset. See [Pagination](/#pagination) |
 
 <br />
 


### PR DESCRIPTION
Pagination query params not used for that specific endpoint