### PR TITLE
Add alert to player page with the corresponding annotation

### DIFF
--- a/app/src/app/players/[username]/layout.tsx
+++ b/app/src/app/players/[username]/layout.tsx
@@ -357,9 +357,10 @@ function getHiscoresURL(displayName: string, playerType: PlayerType) {
 
 
 function PlayerAnnotationsAlert(props: {player: PlayerDetails }){
-  const { annotations, username } = props.player
-
+  const { annotations } = props.player
   const annotationTypes = annotations.map(a => a.type)
+
+  if (!annotationTypes.includes(PlayerAnnotationType.OPT_OUT) && !annotationTypes.includes(PlayerAnnotationType.BLOCKED)) return null
 
   if(annotationTypes.includes(PlayerAnnotationType.OPT_OUT)){
     return (
@@ -384,7 +385,7 @@ function PlayerAnnotationsAlert(props: {player: PlayerDetails }){
 
   if(annotationTypes.includes(PlayerAnnotationType.BLOCKED)){
     return (
-      <Alert variant="warn" className="border-yellow-700 bg-yellow-900/10">
+      <Alert variant="warn" className="border-blue-700 bg-blue-900/10">
         <AlertTitle>Blocked</AlertTitle>
         <AlertDescription>
               <p>
@@ -402,5 +403,4 @@ function PlayerAnnotationsAlert(props: {player: PlayerDetails }){
       </Alert>
     )
   }
-  return null
 }

--- a/app/src/app/players/[username]/layout.tsx
+++ b/app/src/app/players/[username]/layout.tsx
@@ -8,6 +8,7 @@ import {
   PlayerStatus,
   PlayerType,
   PlayerTypeProps,
+  PlayerAnnotationType
 } from "@wise-old-man/utils";
 import { formatDatetime, timeago } from "~/utils/dates";
 import { getPlayerDetails } from "~/services/wiseoldman";
@@ -48,6 +49,7 @@ export default async function PlayerLayout(props: PropsWithChildren<PageProps>) 
 
   const player = await getPlayerDetails(username).catch(() => null);
 
+
   if (!player) {
     // If it fails to fetch this player, fallback to only rendering the child node.
     // This child will be the Error boundary defined in error.tsx.
@@ -59,6 +61,11 @@ export default async function PlayerLayout(props: PropsWithChildren<PageProps>) 
       {player.status !== PlayerStatus.ACTIVE && (
         <div className="mb-7">
           <PlayerStatusAlert player={player} />
+        </div>
+      )}
+      {player.annotations.length > 0 && (
+        <div className="mb-7">
+          <PlayerAnnotationsAlert player={player} />
         </div>
       )}
       <Header {...player} />
@@ -346,4 +353,54 @@ function getHiscoresURL(displayName: string, playerType: PlayerType) {
     default:
       return `https://secure.runescape.com/m=hiscore_oldschool/hiscorepersonal.ws?user1=${displayName}`;
   }
+}
+
+
+function PlayerAnnotationsAlert(props: {player: PlayerDetails }){
+  const { annotations, username } = props.player
+
+  const annotationTypes = annotations.map(a => a.type)
+
+  if(annotationTypes.includes(PlayerAnnotationType.OPT_OUT)){
+    return (
+      <Alert variant="default" className="border-blue-700 bg-blue-900/10">
+        <AlertTitle>Opted out of tracking.</AlertTitle>
+        <AlertDescription>
+              <p>
+              This player has requested to be excluded from tracking. For more information {" " }
+               <a
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href="https://wiseoldman.net/discord"
+                  className="text-white underline"
+                >
+                contact us on Discord
+                </a>
+              </p>
+            </AlertDescription>
+      </Alert>
+    )
+  }
+
+  if(annotationTypes.includes(PlayerAnnotationType.BLOCKED)){
+    return (
+      <Alert variant="warn" className="border-yellow-700 bg-yellow-900/10">
+        <AlertTitle>Blocked</AlertTitle>
+        <AlertDescription>
+              <p>
+              This player has been blocked from tracking. For more information {" " }
+              <a
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href="https://wiseoldman.net/discord"
+                  className="text-white underline"
+                >
+                  contact us on Discord
+                </a>
+              </p>
+            </AlertDescription>
+      </Alert>
+    )
+  }
+  return null
 }

--- a/app/src/app/players/[username]/layout.tsx
+++ b/app/src/app/players/[username]/layout.tsx
@@ -1,14 +1,13 @@
 import React, { PropsWithChildren } from "react";
 import {
   CountryProps,
-  Player,
   PlayerBuild,
   PlayerBuildProps,
   PlayerDetails,
   PlayerStatus,
   PlayerType,
   PlayerTypeProps,
-  PlayerAnnotationType
+  PlayerAnnotationType,
 } from "@wise-old-man/utils";
 import { formatDatetime, timeago } from "~/utils/dates";
 import { getPlayerDetails } from "~/services/wiseoldman";
@@ -48,7 +47,6 @@ export default async function PlayerLayout(props: PropsWithChildren<PageProps>) 
   const username = decodeURI(params.username);
 
   const player = await getPlayerDetails(username).catch(() => null);
-
 
   if (!player) {
     // If it fails to fetch this player, fallback to only rendering the child node.
@@ -239,9 +237,9 @@ function PlayerStatusAlert(props: { player: PlayerDetails }) {
 
             <p className="mt-5">
               <span className="text-white">Note (November 13th):</span> There&apos;s currently an issue
-              with the Jagex hiscores due to a recent rollback that is causing some players to
-              get flagged. If you&apos;re affected, try to log out in-game (to update your
-              hiscores) and then update your WOM profile.
+              with the Jagex hiscores due to a recent rollback that is causing some players to get
+              flagged. If you&apos;re affected, try to log out in-game (to update your hiscores) and then
+              update your WOM profile.
             </p>
           </AlertDescription>
         </div>
@@ -355,52 +353,51 @@ function getHiscoresURL(displayName: string, playerType: PlayerType) {
   }
 }
 
+function PlayerAnnotationsAlert(props: { player: PlayerDetails }) {
+  const { annotations } = props.player;
+  const annotationTypes = annotations.map((a) => a.type);
 
-function PlayerAnnotationsAlert(props: {player: PlayerDetails }){
-  const { annotations } = props.player
-  const annotationTypes = annotations.map(a => a.type)
-
-  if (!annotationTypes.includes(PlayerAnnotationType.OPT_OUT) && !annotationTypes.includes(PlayerAnnotationType.BLOCKED)) return null
-
-  if(annotationTypes.includes(PlayerAnnotationType.OPT_OUT)){
+  if (annotationTypes.includes(PlayerAnnotationType.OPT_OUT)) {
     return (
       <Alert variant="default" className="border-blue-700 bg-blue-900/10">
-        <AlertTitle>Opted out of tracking.</AlertTitle>
+        <AlertTitle>Opted out of tracking</AlertTitle>
         <AlertDescription>
-              <p>
-              This player has requested to be excluded from tracking. For more information {" " }
-               <a
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  href="https://wiseoldman.net/discord"
-                  className="text-white underline"
-                >
-                contact us on Discord
-                </a>
-              </p>
-            </AlertDescription>
+          <p>
+            This player has requested to be excluded from tracking. For help or more information{" "}
+            <a
+              target="_blank"
+              rel="noopener noreferrer"
+              href="https://wiseoldman.net/discord"
+              className="text-white underline"
+            >
+              contact us on Discord
+            </a>
+          </p>
+        </AlertDescription>
       </Alert>
-    )
+    );
   }
 
-  if(annotationTypes.includes(PlayerAnnotationType.BLOCKED)){
+  if (annotationTypes.includes(PlayerAnnotationType.BLOCKED)) {
     return (
       <Alert variant="warn" className="border-blue-700 bg-blue-900/10">
         <AlertTitle>Blocked</AlertTitle>
         <AlertDescription>
-              <p>
-              This player has been blocked from tracking. For more information {" " }
-              <a
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  href="https://wiseoldman.net/discord"
-                  className="text-white underline"
-                >
-                  contact us on Discord
-                </a>
-              </p>
-            </AlertDescription>
+          <p>
+            This player has been blocked from tracking by the developers. For help or more information{" "}
+            <a
+              target="_blank"
+              rel="noopener noreferrer"
+              href="https://wiseoldman.net/discord"
+              className="text-white underline"
+            >
+              contact us on Discord
+            </a>
+          </p>
+        </AlertDescription>
       </Alert>
-    )
+    );
   }
+
+  return null;
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ae1f123f-1e82-4fc2-b58e-c11521b373e6)

Supported Annotations & Display Behavior

Currently, three annotations are supported:
blocked
opt_out
fake_f2p

There is no alert for fake_f2p.

When a player has multiple annotations, only one alert will appear, following this priority order:
opt_out > blocked

