### PR TITLE
[api] Skip syncing deltas on long outdated players

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.7.55",
+  "version": "2.7.56",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.7.55",
+      "version": "2.7.56",
       "license": "ISC",
       "dependencies": {
         "@attio/fetchable": "^0.0.1-experimental.4",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.7.55",
+  "version": "2.7.56",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/events/handlers/player-updated.event.ts
+++ b/server/src/api/events/handlers/player-updated.event.ts
@@ -1,5 +1,5 @@
 import { jobManager, JobType } from '../../../jobs-new';
-import { PERIODS } from '../../../utils';
+import { PeriodProps, PERIODS } from '../../../utils';
 import { EventPayloadMap } from '../types/event-payload.type';
 import { EventType } from '../types/event-type.enum';
 
@@ -7,7 +7,13 @@ function handler({ username, hasChanged, previousUpdatedAt }: EventPayloadMap[Ev
   jobManager.add(JobType.SYNC_PLAYER_COMPETITION_PARTICIPATIONS, { username });
 
   if (previousUpdatedAt !== null) {
+    const timeSinceLastUpdate = Date.now() - previousUpdatedAt.getTime();
+
     for (const period of PERIODS) {
+      if (timeSinceLastUpdate > PeriodProps[period].milliseconds) {
+        continue;
+      }
+
       jobManager.add(JobType.SYNC_PLAYER_DELTAS, { username, period });
     }
   }


### PR DESCRIPTION
If a player's last updated is over a month ago, we will now skip syncing their `five_min`, `day`, `week`, and `month` deltas. Potentially saving a good chunk of processing on infrequently updated players.