### PR TITLE
Fix "Nearest 99s" sorting incorrectly in some cases (#1640)

### DIFF
--- a/app/src/components/players/PlayerOverviewAchievements.tsx
+++ b/app/src/components/players/PlayerOverviewAchievements.tsx
@@ -23,12 +23,14 @@ export async function PlayerOverviewAchievements(props: PlayerOverviewAchievemen
       (a) =>
         isSkill(a.metric) &&
         !hiddenMetrics.includes(a.metric) &&
+        a.currentValue < SKILL_EXP_AT_99 &&
         a.threshold === SKILL_EXP_AT_99 &&
         !a.createdAt
+        
     )
-    .sort((a, b) => b.absoluteProgress - a.absoluteProgress)
+    .sort((a, b) => b.currentValue - a.currentValue)
     .slice(0, 3);
-
+    
   const recentAchievements = achievementsProgress
     .filter((a) => !!a.createdAt)
     .sort((a, b) => b.createdAt!.getTime() - a.createdAt!.getTime())

--- a/app/src/components/players/PlayerOverviewAchievements.tsx
+++ b/app/src/components/players/PlayerOverviewAchievements.tsx
@@ -30,7 +30,7 @@ export async function PlayerOverviewAchievements(props: PlayerOverviewAchievemen
     )
     .sort((a, b) => b.currentValue - a.currentValue)
     .slice(0, 3);
-    
+
   const recentAchievements = achievementsProgress
     .filter((a) => !!a.createdAt)
     .sort((a, b) => b.createdAt!.getTime() - a.createdAt!.getTime())


### PR DESCRIPTION
Addresses #1640 

- Ensures that negative XP isn't included in the "Nearest 99s" portion of overview
- Sorts the displayed achievements based on their current value to show the most progressed ones first (closest to 99)