### PR TITLE
[api] Unset group id if it's undefined

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.7.87",
+  "version": "2.7.88",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/modules/patrons/services/ClaimPatreonBenefitsService.ts
+++ b/server/src/api/modules/patrons/services/ClaimPatreonBenefitsService.ts
@@ -53,7 +53,7 @@ async function claimPatreonBenefits(
       id: patronage.id
     },
     data: {
-      groupId,
+      groupId: groupId ?? null,
       playerId
     }
   });


### PR DESCRIPTION
When a user claims T2 patreon benefits via Discord but don't provide a group id it will be unset the previously set group id. E.g. a user leaves a clan/group and don't want the benefits to be applied any group anymore.