### PR TITLE
Add home world to GroupCard

### DIFF
--- a/app/src/components/groups/GroupCard.tsx
+++ b/app/src/components/groups/GroupCard.tsx
@@ -5,6 +5,8 @@ import { cn } from "~/utils/styling";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../Tooltip";
 
 import VerifiedIcon from "~/assets/verified.svg";
+import GlobeIcon from "~/assets/globe.svg";
+import PeopleIcon from "~/assets/people-2.svg";
 
 export function GroupCard(props: GroupListItem) {
   return (
@@ -34,9 +36,29 @@ export function GroupCard(props: GroupListItem) {
                 </Tooltip>
               )}
             </div>
-            <span className="text-xs text-gray-200">
-              {props.memberCount} {props.memberCount === 1 ? "member" : "members"}
-            </span>
+            <div className="mt-1 flex items-center gap-x-3 text-gray-200">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div className="flex items-center">
+                    <PeopleIcon className="mr-1 h-5 w-5 text-gray-200" />
+                    <span className="text-xs text-gray-200">{props.memberCount}</span>
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent>{props.memberCount} members</TooltipContent>
+              </Tooltip>
+
+              {props.homeworld && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div className="flex items-start">
+                      <GlobeIcon className="mr-1 h-4 w-4 text-gray-200" />
+                      <span className="text-xs text-gray-200">{props.homeworld}</span>
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent>Home world: {props.homeworld}</TooltipContent>
+                </Tooltip>
+              )}
+            </div>
           </div>
         </div>
         <p className="mt-4 line-clamp-2 text-sm leading-5 text-gray-200">{props.description}</p>


### PR DESCRIPTION
This is a small QOL improvement. Was looking for a new clan to join myself and kept having to click the card to see the clan's home world. When choosing a new group the home world is a pretty big determining factor as you want people to be in your same region for improved ping. I followed a similar design pattern for what we have in the group page.

Here's the before:
<img width="1377" height="1324" alt="Screenshot 2025-07-25 191940" src="https://github.com/user-attachments/assets/0cb3687d-89b7-403e-b633-c9bb83d50e39" />

Here's the after:
<img width="1372" height="1325" alt="Screenshot 2025-07-25 191917" src="https://github.com/user-attachments/assets/637ca783-aa4d-4e76-b986-68a93218ef56" />
