### PR TITLE
[api] Add total level to snapshots

### DIFF
--- a/server/__tests__/suites/unit/experience.test.ts
+++ b/server/__tests__/suites/unit/experience.test.ts
@@ -346,7 +346,15 @@ describe('Util - Experience', () => {
 
     expect(
       getTotalLevel({
-        overallLevel: 277,
+        overallLevel: 200, // lower than the computed total level
+        attackExperience: MAX_SKILL_EXP,
+        strengthExperience: MAX_SKILL_EXP
+      } as Snapshot)
+    ).toBe(228);
+
+    expect(
+      getTotalLevel({
+        overallLevel: 277, // higher than the computed total level
         attackExperience: MAX_SKILL_EXP,
         strengthExperience: MAX_SKILL_EXP
       } as Snapshot)

--- a/server/__tests__/suites/unit/experience.test.ts
+++ b/server/__tests__/suites/unit/experience.test.ts
@@ -336,5 +336,20 @@ describe('Util - Experience', () => {
         Object.fromEntries(SKILLS.map(s => [getMetricValueKey(s), SKILL_EXP_AT_99])) as unknown as Snapshot
       )
     ).toBe(2277);
+
+    expect(
+      getTotalLevel({
+        attackExperience: MAX_SKILL_EXP,
+        strengthExperience: MAX_SKILL_EXP
+      } as Snapshot)
+    ).toBe(228); // 99 attack + 99 strength + 10 hitpoints + 1 all other skills
+
+    expect(
+      getTotalLevel({
+        overallLevel: 277,
+        attackExperience: MAX_SKILL_EXP,
+        strengthExperience: MAX_SKILL_EXP
+      } as Snapshot)
+    ).toBe(277);
   });
 });

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.8.0",
+      "version": "2.8.1",
       "license": "ISC",
       "dependencies": {
         "@attio/fetchable": "^0.0.1-experimental.4",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/prisma/migrations/20250811210413_add_overall_level_to_snapshots/migration.sql
+++ b/server/prisma/migrations/20250811210413_add_overall_level_to_snapshots/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "snapshots" ADD COLUMN     "overallLevel" INTEGER NOT NULL DEFAULT -1;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -408,6 +408,7 @@ model Snapshot {
   createdAt                             DateTime  @default(now()) @db.Timestamptz(6)
   overallRank                           Int       @default(-1)
   overallExperience                     BigInt    @default(-1)
+  overallLevel                          Int       @default(-1)
   attackRank                            Int       @default(-1)
   attackExperience                      Int       @default(-1)
   defenceRank                           Int       @default(-1)

--- a/server/src/api/modules/snapshots/snapshot.utils.ts
+++ b/server/src/api/modules/snapshots/snapshot.utils.ts
@@ -1,5 +1,5 @@
 import csv from 'csvtojson';
-import { ACTIVITIES, BOSSES, Metric, METRICS, SKILLS, Snapshot } from '../../../types';
+import { ACTIVITIES, BOSSES, Metric, METRICS, Skill, SKILLS, Snapshot } from '../../../types';
 import { getMetricRankKey } from '../../../utils/get-metric-rank-key.util';
 import { getMetricValueKey, MetricValueKey } from '../../../utils/get-metric-value-key.util';
 import {
@@ -48,7 +48,7 @@ async function parseHiscoresSnapshot(playerId: number, rawCSV: string, previous?
 
   // Populate the skills' values with the values from the csv
   SKILLS.forEach((s, i) => {
-    const [rank, , experience] = rows[i];
+    const [rank, level, experience] = rows[i];
     let expNum = parseInt(experience);
 
     if (s === Metric.OVERALL && expNum === 0) {
@@ -64,7 +64,11 @@ async function parseHiscoresSnapshot(playerId: number, rawCSV: string, previous?
     snapshotFields[getMetricRankKey(s)] = parseInt(rank);
     snapshotFields[getMetricValueKey(s)] = expNum;
 
-    if (s !== Metric.OVERALL) totalExp += Math.max(0, expNum);
+    if (s === Metric.OVERALL) {
+      snapshotFields.overallLevel = parseInt(level);
+    } else {
+      totalExp += Math.max(0, expNum);
+    }
   });
 
   // If this player is unranked in overall exp, we should set their overall exp to the total exp of all skills
@@ -225,7 +229,16 @@ function getCappedExp(snapshot: Snapshot, max: number) {
 }
 
 function getTotalLevel(snapshot: Snapshot) {
-  return REAL_SKILLS.map(s => getLevel(snapshot[getMetricValueKey(s)])).reduce((acc, cur) => acc + cur);
+  let totalLevelSum = 0;
+
+  for (const skill of REAL_SKILLS) {
+    const level = getLevel(snapshot[getMetricValueKey(skill)]);
+    const minLevel = skill === Skill.HITPOINTS ? 10 : 1;
+
+    totalLevelSum += Math.max(level, minLevel);
+  }
+
+  return Math.max(snapshot.overallLevel ?? -1, totalLevelSum);
 }
 
 function isF2p(snapshot: Snapshot) {

--- a/server/src/api/modules/snapshots/snapshot.utils.ts
+++ b/server/src/api/modules/snapshots/snapshot.utils.ts
@@ -65,7 +65,7 @@ async function parseHiscoresSnapshot(playerId: number, rawCSV: string, previous?
     snapshotFields[getMetricValueKey(s)] = expNum;
 
     if (s === Metric.OVERALL) {
-      snapshotFields.overallLevel = parseInt(level);
+      snapshotFields.overallLevel = level === '0' ? -1 : parseInt(level);
     } else {
       totalExp += Math.max(0, expNum);
     }

--- a/server/src/types/snapshot.type.ts
+++ b/server/src/types/snapshot.type.ts
@@ -6,6 +6,7 @@ export interface Snapshot {
 
   overallRank: number;
   overallExperience: number;
+  overallLevel: number;
 
   attackRank: number;
   attackExperience: number;


### PR DESCRIPTION
Total levels used to be computed from the sum of all ranked skills, but for some lower level players, this could end up being lower than their actual total level.

With this change, we're now storing (and using) the real total level provided by the hiscores, if it exists.