### PR TITLE
[api] Add snapshot date columns

### DIFF
--- a/server/__tests__/suites/integration/efficiency.test.ts
+++ b/server/__tests__/suites/integration/efficiency.test.ts
@@ -51,7 +51,10 @@ beforeAll(async () => {
 
     await prisma.player.update({
       where: { id: player.id },
-      data: { latestSnapshotId: snapshot.id }
+      data: {
+        latestSnapshotId: snapshot.id,
+        latestSnapshotDate: snapshot.createdAt
+      }
     });
   }
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.8.16",
+  "version": "2.8.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.8.16",
+      "version": "2.8.17",
       "license": "ISC",
       "dependencies": {
         "@attio/fetchable": "^0.0.1-experimental.4",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.8.16",
+  "version": "2.8.17",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/prisma/migrations/20250913214848_add_participation_snapshot_dates/migration.sql
+++ b/server/prisma/migrations/20250913214848_add_participation_snapshot_dates/migration.sql
@@ -1,0 +1,15 @@
+-- AlterTable
+ALTER TABLE "participations" ADD COLUMN     "endSnapshotDate" TIMESTAMP(3),
+ADD COLUMN     "startSnapshotDate" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "players" ADD COLUMN     "latestSnapshotDate" TIMESTAMPTZ(6);
+
+-- CreateIndex
+CREATE INDEX "participations_start_snapshot_date" ON "participations"("startSnapshotDate");
+
+-- CreateIndex
+CREATE INDEX "participations_end_snapshot_date" ON "participations"("endSnapshotDate");
+
+-- CreateIndex
+CREATE INDEX "players_latest_snapshot_date" ON "players"("latestSnapshotDate");

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -209,13 +209,15 @@ model NameChange {
 }
 
 model Participation {
-  playerId        Int
-  competitionId   Int
-  startSnapshotId Int?
-  endSnapshotId   Int?
-  teamName        String?  @db.VarChar(30)
-  createdAt       DateTime @default(now()) @db.Timestamptz(6)
-  updatedAt       DateTime @updatedAt @db.Timestamptz(6)
+  playerId          Int
+  competitionId     Int
+  startSnapshotId   Int?
+  endSnapshotId     Int?
+  teamName          String?   @db.VarChar(30)
+  startSnapshotDate DateTime?
+  endSnapshotDate   DateTime?
+  createdAt         DateTime  @default(now()) @db.Timestamptz(6)
+  updatedAt         DateTime  @updatedAt @db.Timestamptz(6)
 
   // Relations
   player        Player      @relation(fields: [playerId], references: [id], onDelete: Cascade, onUpdate: NoAction)
@@ -229,29 +231,32 @@ model Participation {
   @@index([competitionId], map: "participations_competition_id")
   @@index([endSnapshotId], map: "participations_end_snapshot_id")
   @@index([startSnapshotId], map: "participations_start_snapshot_id")
+  @@index([startSnapshotDate], map: "participations_start_snapshot_date")
+  @@index([endSnapshotDate], map: "participations_end_snapshot_date")
   // Map
   @@map("participations")
 }
 
 model Player {
-  id               Int          @id @default(autoincrement())
-  username         String       @unique @db.VarChar(12)
-  displayName      String       @db.VarChar(12)
-  type             PlayerType   @default(unknown)
-  build            PlayerBuild  @default(main)
-  status           PlayerStatus @default(active)
-  country          Country?
-  patron           Boolean      @default(false)
-  exp              BigInt       @default(0)
-  ehp              Float        @default(0)
-  ehb              Float        @default(0)
-  ttm              Float        @default(0)
-  tt200m           Float        @default(0)
-  registeredAt     DateTime     @default(now()) @db.Timestamptz(6)
-  updatedAt        DateTime?    @db.Timestamptz(6)
-  lastChangedAt    DateTime?    @db.Timestamptz(6)
-  lastImportedAt   DateTime?    @db.Timestamptz(6)
-  latestSnapshotId Int?
+  id                 Int          @id @default(autoincrement())
+  username           String       @unique @db.VarChar(12)
+  displayName        String       @db.VarChar(12)
+  type               PlayerType   @default(unknown)
+  build              PlayerBuild  @default(main)
+  status             PlayerStatus @default(active)
+  country            Country?
+  patron             Boolean      @default(false)
+  exp                BigInt       @default(0)
+  ehp                Float        @default(0)
+  ehb                Float        @default(0)
+  ttm                Float        @default(0)
+  tt200m             Float        @default(0)
+  registeredAt       DateTime     @default(now()) @db.Timestamptz(6)
+  updatedAt          DateTime?    @db.Timestamptz(6)
+  lastChangedAt      DateTime?    @db.Timestamptz(6)
+  lastImportedAt     DateTime?    @db.Timestamptz(6)
+  latestSnapshotId   Int?
+  latestSnapshotDate DateTime?    @db.Timestamptz(6)
 
   // Relations
   latestSnapshot Snapshot?          @relation("player_latest_snapshot", fields: [latestSnapshotId], references: [id], onDelete: SetNull, onUpdate: NoAction)
@@ -271,6 +276,7 @@ model Player {
   @@index([build], map: "players_build")
   @@index([country], map: "players_country")
   @@index([latestSnapshotId], map: "players_latest_snapshot_id")
+  @@index([latestSnapshotDate], map: "players_latest_snapshot_date")
   @@index([type, ehp(sort: Desc)], map: "players_type_ehp")
   @@index([type, ehb(sort: Desc)], map: "players_type_ehb")
   // Map
@@ -539,8 +545,8 @@ model Snapshot {
 
   // Relations
   player                     Player          @relation(fields: [playerId], references: [id], onDelete: Cascade, onUpdate: NoAction)
-  participationStartPointers Participation[] @relation("participations_endSnapshotIdTosnapshots")
-  participationEndPointers   Participation[] @relation("participations_startSnapshotIdTosnapshots")
+  participationStartPointers Participation[] @relation("participations_startSnapshotIdTosnapshots")
+  participationEndPointers   Participation[] @relation("participations_endSnapshotIdTosnapshots")
   Player                     Player[]        @relation("player_latest_snapshot")
 
   // Indices

--- a/server/src/api/modules/competitions/services/EditCompetitionService.ts
+++ b/server/src/api/modules/competitions/services/EditCompetitionService.ts
@@ -165,7 +165,12 @@ export async function editCompetition(
 async function invalidateParticipations(competitionId: number) {
   await prisma.participation.updateMany({
     where: { competitionId },
-    data: { startSnapshotId: null, endSnapshotId: null }
+    data: {
+      startSnapshotId: null,
+      endSnapshotId: null,
+      startSnapshotDate: null,
+      endSnapshotDate: null
+    }
   });
 }
 
@@ -189,7 +194,10 @@ async function recalculateParticipationsStart(competitionId: number, startDate: 
     for (const playerId of playerIds) {
       await transaction.participation.update({
         where: { playerId_competitionId: { competitionId, playerId } },
-        data: { startSnapshotId: snapshotMap.get(playerId)?.id ?? null }
+        data: {
+          startSnapshotId: snapshotMap.get(playerId)?.id ?? null,
+          startSnapshotDate: snapshotMap.get(playerId)?.createdAt ?? null
+        }
       });
     }
   });
@@ -215,7 +223,10 @@ async function recalculateParticipationsEnd(competitionId: number, endDate: Date
     for (const playerId of playerIds) {
       await transaction.participation.update({
         where: { playerId_competitionId: { competitionId, playerId } },
-        data: { endSnapshotId: snapshotMap.get(playerId)?.id ?? null }
+        data: {
+          endSnapshotId: snapshotMap.get(playerId)?.id ?? null,
+          endSnapshotDate: snapshotMap.get(playerId)?.createdAt ?? null
+        }
       });
     }
   });

--- a/server/src/api/modules/name-changes/services/ApproveNameChangeService.ts
+++ b/server/src/api/modules/name-changes/services/ApproveNameChangeService.ts
@@ -472,7 +472,9 @@ function transferParticipations(
     data: {
       playerId: oldPlayerId,
       startSnapshotId: null,
-      endSnapshotId: null
+      endSnapshotId: null,
+      startSnapshotDate: null,
+      endSnapshotDate: null
     }
   });
 }

--- a/server/src/api/modules/players/services/UpdatePlayerService.ts
+++ b/server/src/api/modules/players/services/UpdatePlayerService.ts
@@ -181,8 +181,9 @@ async function updatePlayer(
     data: currentStats
   });
 
-  updatedPlayerFields.latestSnapshotId = newSnapshot.id;
   updatedPlayerFields.updatedAt = newSnapshot.createdAt;
+  updatedPlayerFields.latestSnapshotId = newSnapshot.id;
+  updatedPlayerFields.latestSnapshotDate = newSnapshot.createdAt;
 
   if (hasChanged) updatedPlayerFields.lastChangedAt = newSnapshot.createdAt;
 

--- a/server/src/api/responses/participation.response.ts
+++ b/server/src/api/responses/participation.response.ts
@@ -7,7 +7,10 @@
 import { Participation } from '../../types';
 import { pick } from '../../utils/pick.util';
 
-export type ParticipationResponse = Omit<Participation, 'startSnapshotId' | 'endSnapshotId'>;
+export type ParticipationResponse = Omit<
+  Participation,
+  'startSnapshotId' | 'endSnapshotId' | 'startSnapshotDate' | 'endSnapshotDate'
+>;
 
 export function formatParticipationResponse(participation: Participation): ParticipationResponse {
   return pick(participation, 'playerId', 'competitionId', 'teamName', 'createdAt', 'updatedAt');

--- a/server/src/api/responses/player.response.ts
+++ b/server/src/api/responses/player.response.ts
@@ -7,7 +7,7 @@
 import { Player } from '../../types';
 import { pick } from '../../utils/pick.util';
 
-export type PlayerResponse = Omit<Player, 'latestSnapshotId'>;
+export type PlayerResponse = Omit<Player, 'latestSnapshotId' | 'latestSnapshotDate'>;
 
 export function formatPlayerResponse(player: Player): PlayerResponse {
   return pick(

--- a/server/src/jobs/handlers/sync-player-competition-participations.job.ts
+++ b/server/src/jobs/handlers/sync-player-competition-participations.job.ts
@@ -56,7 +56,8 @@ export class SyncPlayerCompetitionParticipationsJob extends Job<Payload> {
     for (const participation of participations) {
       // Update this participation's latest (end) snapshot
       const updatePayload: PrismaTypes.ParticipationUncheckedUpdateInput = {
-        endSnapshotId: player.latestSnapshotId
+        endSnapshotId: player.latestSnapshotId,
+        endSnapshotDate: player.latestSnapshotDate
       };
 
       // If this participation's starting snapshot has not been set,
@@ -68,7 +69,8 @@ export class SyncPlayerCompetitionParticipationsJob extends Job<Payload> {
             createdAt: { gte: participation.competition.startsAt }
           },
           select: {
-            id: true
+            id: true,
+            createdAt: true
           },
           orderBy: {
             createdAt: 'asc'
@@ -77,6 +79,7 @@ export class SyncPlayerCompetitionParticipationsJob extends Job<Payload> {
 
         if (startSnapshot) {
           updatePayload.startSnapshotId = startSnapshot.id;
+          updatePayload.startSnapshotDate = startSnapshot.createdAt;
         }
       }
 
@@ -89,7 +92,8 @@ export class SyncPlayerCompetitionParticipationsJob extends Job<Payload> {
             createdAt: { lte: participation.competition.endsAt }
           },
           select: {
-            id: true
+            id: true,
+            createdAt: true
           },
           orderBy: {
             createdAt: 'desc'
@@ -98,6 +102,7 @@ export class SyncPlayerCompetitionParticipationsJob extends Job<Payload> {
 
         if (endSnapshot) {
           updatePayload.endSnapshotId = endSnapshot.id;
+          updatePayload.endSnapshotDate = endSnapshot.createdAt;
         }
       }
 

--- a/server/src/types/participation.type.ts
+++ b/server/src/types/participation.type.ts
@@ -3,6 +3,8 @@ export interface Participation {
   competitionId: number;
   startSnapshotId: number | null;
   endSnapshotId: number | null;
+  startSnapshotDate: Date | null;
+  endSnapshotDate: Date | null;
   teamName: string | null;
   createdAt: Date;
   updatedAt: Date;

--- a/server/src/types/player.type.ts
+++ b/server/src/types/player.type.ts
@@ -22,4 +22,5 @@ export interface Player {
   lastChangedAt: Date | null;
   lastImportedAt: Date | null;
   latestSnapshotId: number | null;
+  latestSnapshotDate: Date | null;
 }


### PR DESCRIPTION
Snapshots currently have an integer primary key, I'm moving towards changing them to having a compound primary key on (playerId, createdAt), for that, we need to backfill all foreign keys on the `player` and `participation` tables