### PR TITLE
[api] Reduce thrown jobs

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.8.18",
+  "version": "2.8.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-server",
-      "version": "2.8.18",
+      "version": "2.8.19",
       "license": "ISC",
       "dependencies": {
         "@attio/fetchable": "^0.0.1-experimental.4",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.8.18",
+  "version": "2.8.19",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/jobs/handlers/check-player-banned.job.ts
+++ b/server/src/jobs/handlers/check-player-banned.job.ts
@@ -13,7 +13,14 @@ interface Payload {
 
 export class CheckPlayerBannedJob extends Job<Payload> {
   static options: JobOptions = {
-    rateLimiter: { max: 1, duration: 5000 }
+    rateLimiter: {
+      max: 1,
+      duration: 5000
+    },
+    backoff: {
+      type: 'exponential',
+      delay: 600_000
+    }
   };
 
   static getUniqueJobId(payload: Payload) {

--- a/server/src/jobs/handlers/check-player-ranked.job.ts
+++ b/server/src/jobs/handlers/check-player-ranked.job.ts
@@ -1,30 +1,29 @@
-import { isErrored } from '@attio/fetchable';
+import { isComplete } from '@attio/fetchable';
 import prisma from '../../prisma';
-import { fetchHiscoresData, HiscoresErrorSchema } from '../../services/jagex.service';
-import logger from '../../services/logging.service';
+import { fetchHiscoresData } from '../../services/jagex.service';
 import { PlayerStatus } from '../../types';
 import { assertNever } from '../../utils/assert-never.util';
 import { Job } from '../job.class';
 import { JobOptions } from '../types/job-options.type';
 import { JobType } from '../types/job-type.enum';
 
+const MAX_CHECK_ATTEMPTS = 5;
+
 interface Payload {
   username: string;
+  attempts?: number;
 }
 
 export class CheckPlayerRankedJob extends Job<Payload> {
   static options: JobOptions = {
-    rateLimiter: { max: 1, duration: 5_000 },
-    attempts: 3,
-    backoff: {
-      type: 'exponential',
-      // first attempt after 60 seconds, then 120, and then 240 (total: 7 minutes span)
-      delay: 60_000
+    rateLimiter: {
+      max: 1,
+      duration: 5_000
     }
   };
 
   static getUniqueJobId(payload: Payload) {
-    return payload.username;
+    return [payload.username, payload.attempts ?? 0].join('_');
   }
 
   async execute(payload: Payload) {
@@ -36,51 +35,58 @@ export class CheckPlayerRankedJob extends Job<Payload> {
     // So, to make sure a player is no longer ranked on the hiscores, we need to make a few attempts,
     // and if all of them fail, then we can be pretty sure that the player is no longer ranked.
 
-    // To avoid false positives due to a hiscores outage, this job has a exponential backoff strategy,
-    // meaning that it will retry a few times, with a longer delay between each attempt.
+    // To avoid false positives due to a hiscores outage, this job enqueues the next check
+    // with a exponential backoff strategy, meaning that it will retry a few times,
+    // with a longer delay between each attempt.
 
-    // Try to fetch stats for this player, let it throw an error if it fails.
     const fetchResult = await fetchHiscoresData(payload.username);
 
-    if (isErrored(fetchResult)) {
-      throw fetchResult.error;
-    }
-  }
-
-  async onFailedAllAttempts(payload: Payload, error: unknown) {
-    const parsedError = HiscoresErrorSchema.safeParse(error);
-
-    if (!parsedError.success) {
-      // This is an unexpected error
-      logger.error('Unexpected error in CheckPlayerRankedJob:', error);
+    if (isComplete(fetchResult)) {
       return;
     }
 
-    const errorCode = parsedError.data.code;
-
-    switch (errorCode) {
-      case 'HISCORES_USERNAME_NOT_FOUND': {
-        // If it fails every attempt with the "Failed to load hiscores" (400) error message,
-        // then we can be pretty sure that the player is unranked.
-        await prisma.player.update({
-          where: {
-            username: payload.username
-          },
-          data: {
-            status: PlayerStatus.UNRANKED
-          }
-        });
-
-        // Being unranked could also mean a player is banned, so if we determine
-        // that they're not on the hiscores, check if they're banned on RuneMetrics.
-        this.jobManager.add(JobType.CHECK_PLAYER_BANNED, { username: payload.username });
-        break;
-      }
+    switch (fetchResult.error.code) {
       case 'HISCORES_SERVICE_UNAVAILABLE':
       case 'HISCORES_UNEXPECTED_ERROR':
+        throw fetchResult.error;
+      case 'HISCORES_USERNAME_NOT_FOUND': {
+        this.handleNotFound(payload);
         break;
+      }
       default:
-        assertNever(errorCode);
+        return assertNever(fetchResult.error);
     }
+  }
+
+  async handleNotFound(payload: Payload) {
+    if ((payload.attempts ?? 0) + 1 >= MAX_CHECK_ATTEMPTS) {
+      // If it fails every attempt with the "Failed to load hiscores" (400) error message,
+      // then we can be pretty sure that the player is unranked.
+      await prisma.player.update({
+        where: {
+          username: payload.username
+        },
+        data: {
+          status: PlayerStatus.UNRANKED
+        }
+      });
+
+      // Being unranked could also mean a player is banned, so if we determine
+      // that they're not on the hiscores, check if they're banned on RuneMetrics.
+      this.jobManager.add(JobType.CHECK_PLAYER_BANNED, { username: payload.username });
+
+      return;
+    }
+
+    const nextDelay = 2 ** (payload.attempts ?? 0) * 60 * 1000; // Exponential backoff: 1m, 2m, 4m, 8m
+
+    this.jobManager.add(
+      JobType.CHECK_PLAYER_RANKED,
+      {
+        username: payload.username,
+        attempts: (payload.attempts ?? 0) + 1
+      },
+      { delay: nextDelay }
+    );
   }
 }

--- a/server/src/jobs/handlers/dispatch-competition-created-discord-event.job.ts
+++ b/server/src/jobs/handlers/dispatch-competition-created-discord-event.job.ts
@@ -11,7 +11,6 @@ interface Payload {
 
 export class DispatchCompetitionCreatedDiscordEventJob extends Job<Payload> {
   static options: JobOptions = {
-    attempts: 3,
     backoff: {
       type: 'exponential',
       delay: 30_000

--- a/server/src/jobs/handlers/dispatch-competition-ended-discord-event.job.ts
+++ b/server/src/jobs/handlers/dispatch-competition-ended-discord-event.job.ts
@@ -12,7 +12,6 @@ interface Payload {
 
 export class DispatchCompetitionEndedDiscordEventJob extends Job<Payload> {
   static options: JobOptions = {
-    attempts: 3,
     backoff: {
       type: 'exponential',
       delay: 30_000

--- a/server/src/jobs/handlers/dispatch-competition-ending-discord-event.job.ts
+++ b/server/src/jobs/handlers/dispatch-competition-ending-discord-event.job.ts
@@ -12,7 +12,6 @@ interface Payload {
 
 export class DispatchCompetitionEndingDiscordEventJob extends Job<Payload> {
   static options: JobOptions = {
-    attempts: 3,
     backoff: {
       type: 'exponential',
       delay: 30_000

--- a/server/src/jobs/handlers/dispatch-competition-started-discord-event.job.ts
+++ b/server/src/jobs/handlers/dispatch-competition-started-discord-event.job.ts
@@ -11,7 +11,6 @@ interface Payload {
 
 export class DispatchCompetitionStartedDiscordEventJob extends Job<Payload> {
   static options: JobOptions = {
-    attempts: 3,
     backoff: {
       type: 'exponential',
       delay: 30_000

--- a/server/src/jobs/handlers/dispatch-competition-starting-discord-event.job.ts
+++ b/server/src/jobs/handlers/dispatch-competition-starting-discord-event.job.ts
@@ -12,7 +12,6 @@ interface Payload {
 
 export class DispatchCompetitionStartingDiscordEventJob extends Job<Payload> {
   static options: JobOptions = {
-    attempts: 3,
     backoff: {
       type: 'exponential',
       delay: 30_000

--- a/server/src/jobs/handlers/dispatch-member-achievements-discord-event.job.ts
+++ b/server/src/jobs/handlers/dispatch-member-achievements-discord-event.job.ts
@@ -16,7 +16,6 @@ interface Payload {
 
 export class DispatchMemberAchievementsDiscordEventJob extends Job<Payload> {
   static options: JobOptions = {
-    attempts: 3,
     backoff: {
       type: 'exponential',
       delay: 30_000

--- a/server/src/jobs/handlers/dispatch-member-hcim-died-discord-event.job.ts
+++ b/server/src/jobs/handlers/dispatch-member-hcim-died-discord-event.job.ts
@@ -1,7 +1,7 @@
-import { DiscordBotEventType, dispatchDiscordBotEvent } from '../../services/discord.service';
-import prisma from '../../prisma';
-import { Job } from '../job.class';
 import { isErrored } from '@attio/fetchable';
+import prisma from '../../prisma';
+import { DiscordBotEventType, dispatchDiscordBotEvent } from '../../services/discord.service';
+import { Job } from '../job.class';
 import { JobOptions } from '../types/job-options.type';
 
 interface Payload {
@@ -10,7 +10,6 @@ interface Payload {
 
 export class DispatchMemberHcimDiedDiscordEventJob extends Job<Payload> {
   static options: JobOptions = {
-    attempts: 3,
     backoff: {
       type: 'exponential',
       delay: 30_000

--- a/server/src/jobs/handlers/dispatch-member-name-changed-discord-event.job.ts
+++ b/server/src/jobs/handlers/dispatch-member-name-changed-discord-event.job.ts
@@ -1,7 +1,7 @@
-import { DiscordBotEventType, dispatchDiscordBotEvent } from '../../services/discord.service';
-import prisma from '../../prisma';
-import { Job } from '../job.class';
 import { isErrored } from '@attio/fetchable';
+import prisma from '../../prisma';
+import { DiscordBotEventType, dispatchDiscordBotEvent } from '../../services/discord.service';
+import { Job } from '../job.class';
 import { JobOptions } from '../types/job-options.type';
 
 interface Payload {
@@ -11,7 +11,6 @@ interface Payload {
 
 export class DispatchMemberNameChangedDiscordEventJob extends Job<Payload> {
   static options: JobOptions = {
-    attempts: 3,
     backoff: {
       type: 'exponential',
       delay: 30_000

--- a/server/src/jobs/handlers/dispatch-members-joined-discord-event.job.ts
+++ b/server/src/jobs/handlers/dispatch-members-joined-discord-event.job.ts
@@ -15,7 +15,6 @@ interface Payload {
 
 export class DispatchMembersJoinedDiscordEventJob extends Job<Payload> {
   static options: JobOptions = {
-    attempts: 3,
     backoff: {
       type: 'exponential',
       delay: 30_000

--- a/server/src/jobs/handlers/dispatch-members-left-discord-event.job.ts
+++ b/server/src/jobs/handlers/dispatch-members-left-discord-event.job.ts
@@ -11,7 +11,6 @@ interface Payload {
 
 export class DispatchMembersLeftDiscordEventJob extends Job<Payload> {
   static options: JobOptions = {
-    attempts: 3,
     backoff: {
       type: 'exponential',
       delay: 30_000

--- a/server/src/jobs/handlers/dispatch-members-roles-changed-discord-event.job.ts
+++ b/server/src/jobs/handlers/dispatch-members-roles-changed-discord-event.job.ts
@@ -16,7 +16,6 @@ interface Payload {
 
 export class DispatchMembersRolesChangedDiscordEventJob extends Job<Payload> {
   static options: JobOptions = {
-    attempts: 3,
     backoff: {
       type: 'exponential',
       delay: 30_000

--- a/server/src/jobs/handlers/dispatch-player-flagged-discord-event.job.ts
+++ b/server/src/jobs/handlers/dispatch-player-flagged-discord-event.job.ts
@@ -12,7 +12,6 @@ interface Payload {
 
 export class DispatchPlayerFlaggedDiscordEventJob extends Job<Payload> {
   static options: JobOptions = {
-    attempts: 3,
     backoff: {
       type: 'exponential',
       delay: 30_000

--- a/server/src/jobs/handlers/review-name-change.job.ts
+++ b/server/src/jobs/handlers/review-name-change.job.ts
@@ -17,7 +17,14 @@ interface Payload {
 
 export class ReviewNameChangeJob extends Job<Payload> {
   static options: JobOptions = {
-    rateLimiter: { max: 1, duration: 5000 }
+    rateLimiter: {
+      max: 1,
+      duration: 5000
+    },
+    backoff: {
+      type: 'exponential',
+      delay: 30_000
+    }
   };
 
   static getUniqueJobId(payload: Payload) {

--- a/server/src/jobs/handlers/update-player.job.ts
+++ b/server/src/jobs/handlers/update-player.job.ts
@@ -32,6 +32,8 @@ export class UpdatePlayerJob extends Job<Payload> {
     }
 
     switch (updateResult.error.code) {
+      case 'PLAYER_IS_RATE_LIMITED':
+        return;
       case 'PLAYER_OPTED_OUT':
       case 'PLAYER_IS_FLAGGED':
       case 'PLAYER_IS_BLOCKED':
@@ -43,7 +45,6 @@ export class UpdatePlayerJob extends Job<Payload> {
         await redisClient.set(cooldownKey, 'true', 'PX', 86_400_000); // 24 hours
         break;
       }
-      case 'PLAYER_IS_RATE_LIMITED':
       case 'HISCORES_UNEXPECTED_ERROR':
       case 'HISCORES_SERVICE_UNAVAILABLE': {
         // These can be retried later

--- a/server/src/jobs/job-manager.ts
+++ b/server/src/jobs/job-manager.ts
@@ -119,6 +119,10 @@ class JobManager {
         await jobHandler.onFailedAllAttempts(bullJob.data, error);
       }
 
+      /**
+       * Bull-board only shows errors if they're instances of the Error class.
+       * If we throw a plain object, it won't show up in the UI.
+       */
       if (!(error instanceof Error)) {
         throw new Error(JSON.stringify(error));
       }

--- a/server/src/jobs/job-manager.ts
+++ b/server/src/jobs/job-manager.ts
@@ -102,22 +102,16 @@ class JobManager {
     const attemptTag = maxAttempts > 1 ? `(#${bullJob.attemptsMade})` : '';
 
     const endTimer = prometheus.trackJob();
+    logger.info(`[v2] Executing job: ${bullJob.name} ${attemptTag}`, bullJob.opts.jobId, true);
 
     try {
-      logger.info(`[v2] Executing job: ${bullJob.name} ${attemptTag}`, bullJob.opts.jobId, true);
-
       await jobHandler.execute(bullJob.data);
+
       endTimer({ jobName: bullJob.name, status: 1 });
-      await jobHandler.onSuccess(bullJob.data);
+      logger.error(`[v2] Completed job: ${bullJob.name}`, { ...bullJob.data }, true);
     } catch (error) {
       endTimer({ jobName: bullJob.name, status: 0 });
       logger.error(`[v2] Failed job: ${bullJob.name}`, { ...bullJob.data, error }, true);
-
-      await jobHandler.onFailure(bullJob.data, error);
-
-      if (bullJob.attemptsMade >= maxAttempts) {
-        await jobHandler.onFailedAllAttempts(bullJob.data, error);
-      }
 
       /**
        * Bull-board only shows errors if they're instances of the Error class.

--- a/server/src/jobs/job.class.ts
+++ b/server/src/jobs/job.class.ts
@@ -12,9 +12,6 @@ export class Job<T> {
   }
 
   async execute(payload: T): Promise<void> {}
-  async onSuccess(payload: T): Promise<void> {}
-  async onFailure(payload: T, error: unknown): Promise<void> {}
-  async onFailedAllAttempts(payload: T, error: unknown): Promise<void> {}
 
   static getUniqueJobId(payload: unknown): string | undefined {
     return undefined;

--- a/server/src/services/jagex.service.ts
+++ b/server/src/services/jagex.service.ts
@@ -70,7 +70,7 @@ export async function getRuneMetricsBannedStatus(username: string): AsyncResult<
   } as const);
 }
 
-export const HiscoresErrorSchema = z.union([
+const HiscoresErrorSchema = z.union([
   z.object({ code: z.literal('HISCORES_USERNAME_NOT_FOUND') }),
   z.object({ code: z.literal('HISCORES_SERVICE_UNAVAILABLE') }),
   z.object({ code: z.literal('HISCORES_UNEXPECTED_ERROR'), subError: z.unknown() })


### PR DESCRIPTION
Throwing inside job handlers should only happen for unexpected or retriable jobs. Previously we were using failure retrying as a hack for other things, not good.