### PR TITLE
[api] Fix userAgent when detecting runelite name changes

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.8.20",
+  "version": "2.8.21",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/api/util/middlewares.ts
+++ b/server/src/api/util/middlewares.ts
@@ -17,7 +17,11 @@ export async function detectRuneLiteNameChange(req: unknown, res: Response, next
   const { accountHash } = (req as Request).body;
   const { username } = (req as Request).params;
 
-  if ((userAgent !== 'RuneLite' && userAgent !== 'WiseOldMan RuneLite Plugin') || !accountHash) {
+  if (
+    (userAgent !== 'RuneLite' &&
+      !new RegExp(/^WiseOldManRuneLitePlugin\/([\d.]+) RuneLite\/([\d.]+)(?:-SNAPSHOT)?/).test(userAgent)) ||
+    !accountHash
+  ) {
     return next();
   }
 


### PR DESCRIPTION
Since https://github.com/wise-old-man/wiseoldman-runelite-plugin/pull/61 was added, detecting name changes for local player have been broken due to the userAgent not matching anymore. This fixes that.