### PR TITLE
[server] Fix achievement date search on players with lots of snapshots

### DIFF
--- a/server/src/jobs/handlers/recalculate-player-achievements.job.ts
+++ b/server/src/jobs/handlers/recalculate-player-achievements.job.ts
@@ -1,9 +1,8 @@
 import { eventEmitter, EventType } from '../../api/events';
 import {
-  calculatePastDates,
+  findMissingAchievementDates,
   getAchievementDefinitions
 } from '../../api/modules/achievements/achievement.utils';
-import { findPlayerSnapshots } from '../../api/modules/snapshots/services/FindPlayerSnapshotsService';
 import prisma from '../../prisma';
 import { JobHandler } from '../types/job-handler.type';
 
@@ -42,13 +41,12 @@ export const RecalculatePlayerAchievementsJobHandler: JobHandler<Payload> = {
     const unknownDefinitions = ALL_DEFINITIONS.filter(d => unknownAchievementNames.includes(d.name));
 
     // Search dates for previously unknown definitions, based on player history
-    const allSnapshots = await findPlayerSnapshots(player.id);
-    const pastDatesData = calculatePastDates(allSnapshots.reverse(), unknownDefinitions);
+    const missingPastDates = await findMissingAchievementDates(player.id, unknownDefinitions);
 
     // Attach new dates where possible, and filter out any (still) unknown achievements
     const toUpdate = unknownAchievements
       .map(a => {
-        const unknownAchievementData = pastDatesData[a.name];
+        const unknownAchievementData = missingPastDates[a.name];
 
         return {
           ...a,

--- a/server/src/jobs/handlers/sync-player-achievements.job.ts
+++ b/server/src/jobs/handlers/sync-player-achievements.job.ts
@@ -1,9 +1,8 @@
 import { eventEmitter, EventType } from '../../api/events';
 import {
-  calculatePastDates,
+  findMissingAchievementDates,
   getAchievementDefinitions
 } from '../../api/modules/achievements/achievement.utils';
-import { findPlayerSnapshots } from '../../api/modules/snapshots/services/FindPlayerSnapshotsService';
 import { POST_RELEASE_HISCORE_ADDITIONS } from '../../api/modules/snapshots/snapshot.utils';
 import prisma from '../../prisma';
 import { getMetricValueKey } from '../../utils/get-metric-value-key.util';
@@ -111,10 +110,7 @@ export const SyncPlayerAchievementsJobHandler: JobHandler<Payload> = {
       return;
     }
 
-    // Search dates for missing definitions, based on player history
-    const allSnapshots = await findPlayerSnapshots(playerId);
-
-    const missingPastDates = calculatePastDates(allSnapshots.reverse(), missingDefinitions);
+    const missingPastDates = await findMissingAchievementDates(playerId, missingDefinitions);
 
     // Create achievement instances for all the missing definitions
     const missingAchievements = missingDefinitions.map(({ name, metric, threshold }) => {


### PR DESCRIPTION
The achievement syncing jobs were eagerly loading too many snapshots when trying to determine a missed achievement's date. This caused issues for players with WAY too many snapshots (100k+)