### PR TITLE
[app] Disable hoverable content on gained heatmap tooltip

### DIFF
--- a/app/src/components/CalendarHeatmap.tsx
+++ b/app/src/components/CalendarHeatmap.tsx
@@ -80,7 +80,7 @@ export function CalendarHeatmap(props: CalendarHeatmapProps) {
               const y = rowIndex * (SIZE + GAP);
 
               return (
-                <Tooltip key={`${rowIndex}-${columnIndex}`} delayDuration={0}>
+                <Tooltip key={`${rowIndex}-${columnIndex}`} delayDuration={0} disableHoverableContent>
                   <TooltipTrigger asChild>
                     <g className="stroke stroke-transparent hover:stroke-white">
                       <rect


### PR DESCRIPTION
This makes it so the tooltip doesn't have hoverable content that makes the tooltip stay up when your mouse exits the tile you're hovering over in the heatmap. Previously you could hover over a few tiles before the tooltip went away.
Before
![before](https://github.com/user-attachments/assets/7c85efa2-04db-4398-898b-cc4fac8e19a4)
After
![after](https://github.com/user-attachments/assets/bf592954-c8c3-493e-88b1-3b14de467eba)
