### PR TITLE
Add 1-hour grace period to group update

### DIFF
--- a/server/__tests__/suites/integration/groups.test.ts
+++ b/server/__tests__/suites/integration/groups.test.ts
@@ -2862,7 +2862,8 @@ describe('Group API', () => {
     });
 
     it('should update all', async () => {
-      const dayOldDate = new Date(Date.now() - 1000 - 24 * 60 * 60 * 1000);
+      const dayOldDate = new Date(Date.now() - 24 * 60 * 60 * 1000);
+      const withinCooldown = new Date(Date.now() - 22 * 60 * 60 * 1000);
 
       // Force this player's last update timestamp to be a day ago
       await prisma.player.update({
@@ -2879,7 +2880,7 @@ describe('Group API', () => {
       // Force these players last update timestamps to be recent
       await prisma.player.update({
         where: { username: 'swampletics' },
-        data: { updatedAt: new Date() }
+        data: { updatedAt: withinCooldown }
       });
       await prisma.player.update({
         where: { username: 'rorro' },

--- a/server/src/api/modules/groups/services/UpdateAllMembersService.ts
+++ b/server/src/api/modules/groups/services/UpdateAllMembersService.ts
@@ -32,7 +32,8 @@ async function updateAllMembers(groupId: number): Promise<number> {
  * A member is considered outdated 24 hours after their last update.
  */
 async function getOutdatedMembers(groupId: number): Promise<Pick<Player, 'username'>[]> {
-  const dayAgo = new Date(Date.now() - PeriodProps[Period.DAY].milliseconds);
+  const gracePeriod = 3_600_000; // 1 hour
+  const dayAgo = new Date(Date.now() - PeriodProps[Period.DAY].milliseconds + gracePeriod);
 
   const outdatedMembers = await prisma.membership.findMany({
     where: {


### PR DESCRIPTION
Fixes #1884.

As an aside, I wanted to add new players to the test data to add new test cases, but I was unable to locate the source data anywhere in the repo, at least by searching for player names used in existing test cases. I instead modified one of the existing test cases to get what I wanted, but this would be a good area of improvement for new contributors.