### PR TITLE
Allow negative gains for EHP, EHB, LMS, and PvP Arena

### DIFF
--- a/server/__tests__/suites/integration/deltas.test.ts
+++ b/server/__tests__/suites/integration/deltas.test.ts
@@ -218,7 +218,7 @@ describe('Deltas API', () => {
       expect(dayCachedDeltas.find(c => c.metric === Metric.TZKAL_ZUK)?.value).toBe(1);
       expect(dayCachedDeltas.find(c => c.metric === Metric.BOUNTY_HUNTER_HUNTER)?.value).toBe(5);
       expect(dayCachedDeltas.find(c => c.metric === Metric.SOUL_WARS_ZEAL)?.value).toBe(203);
-      expect(dayCachedDeltas.find(c => c.metric === Metric.LAST_MAN_STANDING)).toBe(undefined); // LMS went DOWN from 500 to 450, we shouldn't show negative gains
+      expect(dayCachedDeltas.find(c => c.metric === Metric.LAST_MAN_STANDING)?.value).toBe(-50); // LMS went DOWN from 500 to 450
 
       // gained less boss kc, expect ehb gains to be lesser
       expect(dayCachedDeltas.find(c => c.metric === Metric.EHB)?.value).toBeLessThan(

--- a/server/__tests__/suites/unit/calculateValueDiff.test.ts
+++ b/server/__tests__/suites/unit/calculateValueDiff.test.ts
@@ -125,6 +125,46 @@ describe('Util - Calculate Value Diff', () => {
     });
   });
 
+  it('should calculate a negative diff for LMS score', () => {
+    const startSnapshot = {
+      ...globalData.baseSnapshot,
+      last_man_standingScore: 500
+    };
+
+    const endSnapshot = {
+      ...globalData.baseSnapshot,
+      last_man_standingScore: 450
+    };
+
+    const diff = calculateValueDiff(Metric.LAST_MAN_STANDING, startSnapshot, endSnapshot);
+
+    expect(diff).toMatchObject({
+      start: 500,
+      end: 450,
+      gained: -50
+    });
+  });
+
+  it('should calculate a negative diff for PVP Arena score', () => {
+    const startSnapshot = {
+      ...globalData.baseSnapshot,
+      pvp_arenaScore: 1200
+    };
+
+    const endSnapshot = {
+      ...globalData.baseSnapshot,
+      pvp_arenaScore: 1150
+    };
+
+    const diff = calculateValueDiff(Metric.PVP_ARENA, startSnapshot, endSnapshot);
+
+    expect(diff).toMatchObject({
+      start: 1200,
+      end: 1150,
+      gained: -50
+    });
+  });
+
   it('should calculate the diff for unranked->ranked (with minimum kc, and start kc below min)', () => {
     const startSnapshot = {
       ...globalData.baseSnapshot,

--- a/server/src/api/modules/deltas/delta.utils.ts
+++ b/server/src/api/modules/deltas/delta.utils.ts
@@ -26,6 +26,14 @@ import {
 import { PlayerDeltasMapResponse } from '../../responses';
 import { getTotalLevel } from '../snapshots/snapshot.utils';
 
+// These metrics can legitimately decrease (see getNegativeGains in snapshot.utils.ts)
+const METRICS_ALLOWING_NEGATIVE_GAINS: Metric[] = [
+  Metric.EHP,
+  Metric.EHB,
+  Metric.LAST_MAN_STANDING,
+  Metric.PVP_ARENA
+];
+
 const EMPTY_PROGRESS = Object.freeze({ start: 0, end: 0, gained: 0 }) satisfies MetricDelta;
 
 /**
@@ -79,7 +87,8 @@ export function calculateValueDiff(metric: Metric, startSnapshot: Snapshot, endS
   const startValue = startSnapshot && startSnapshot[valueKey] ? startSnapshot[valueKey] : -1;
   const endValue = endSnapshot && endSnapshot[valueKey] ? endSnapshot[valueKey] : -1;
 
-  let gainedValue = roundNumber(Math.max(0, endValue - Math.max(startValue, 0)), 5);
+  const rawGain = roundNumber(endValue - Math.max(startValue, 0), 5);
+  let gainedValue = METRICS_ALLOWING_NEGATIVE_GAINS.includes(metric) ? rawGain : Math.max(0, rawGain);
 
   // Some players with low total level (but high exp) can sometimes fall off the hiscores
   // causing their starting exp to be -1, this would then cause the diff to think
@@ -122,7 +131,7 @@ function calculateEHPDiff(startSnapshot: Snapshot, endSnapshot: Snapshot, player
   const endEHP = endSnapshot ? getPlayerEHP(endSnapshot, player) : 0;
 
   return {
-    gained: Math.max(0, roundNumber(endEHP - startEHP, 5)),
+    gained: roundNumber(endEHP - startEHP, 5),
     start: startEHP,
     end: endEHP
   };
@@ -136,7 +145,7 @@ function calculateEHBDiff(startSnapshot: Snapshot, endSnapshot: Snapshot, player
   const endEHB = endSnapshot ? getPlayerEHB(endSnapshot, player) : 0;
 
   return {
-    gained: Math.max(0, roundNumber(endEHB - startEHB, 5)),
+    gained: roundNumber(endEHB - startEHB, 5),
     start: startEHB,
     end: endEHB
   };

--- a/server/src/api/modules/deltas/delta.utils.ts
+++ b/server/src/api/modules/deltas/delta.utils.ts
@@ -24,15 +24,7 @@ import {
   getPlayerEHP
 } from '../../modules/efficiency/efficiency.utils';
 import { PlayerDeltasMapResponse } from '../../responses';
-import { getTotalLevel } from '../snapshots/snapshot.utils';
-
-// These metrics can legitimately decrease (see getNegativeGains in snapshot.utils.ts)
-const METRICS_ALLOWING_NEGATIVE_GAINS: Metric[] = [
-  Metric.EHP,
-  Metric.EHB,
-  Metric.LAST_MAN_STANDING,
-  Metric.PVP_ARENA
-];
+import { getTotalLevel, METRICS_ALLOWING_NEGATIVE_GAINS } from '../snapshots/snapshot.utils';
 
 const EMPTY_PROGRESS = Object.freeze({ start: 0, end: 0, gained: 0 }) satisfies MetricDelta;
 

--- a/server/src/api/modules/snapshots/snapshot.utils.ts
+++ b/server/src/api/modules/snapshots/snapshot.utils.ts
@@ -64,9 +64,16 @@ function getExcessiveGains(before: Snapshot, after: Snapshot) {
   return { ehpDiff, ehbDiff, hoursDiff };
 }
 
+// These metrics can legitimately decrease
+export const METRICS_ALLOWING_NEGATIVE_GAINS: Metric[] = [
+  Metric.EHP,
+  Metric.EHB,
+  Metric.LAST_MAN_STANDING,
+  Metric.PVP_ARENA
+];
+
 function getNegativeGains(before: Snapshot, after: Snapshot) {
-  // LMS scores, PVP ARENA scores, EHP and EHB can fluctuate overtime
-  const metricsToIgnore: Metric[] = [Metric.EHP, Metric.EHB, Metric.LAST_MAN_STANDING, Metric.PVP_ARENA];
+  const metricsToIgnore = [...METRICS_ALLOWING_NEGATIVE_GAINS];
 
   // The Bounty Hunter game update on May 24th 2023 reset people's BH scores, so if this game update happened
   // in between the two snapshots, we should also ignore BH score negative gains.

--- a/server/src/jobs/handlers/sync-player-deltas.job.ts
+++ b/server/src/jobs/handlers/sync-player-deltas.job.ts
@@ -100,7 +100,7 @@ export const SyncPlayerDeltasJobHandler: JobHandler<Payload> = {
         value = periodDiffs.computed[metric].value.gained;
       }
 
-      if (value !== 0) {
+      if (value > 0) {
         newCachedDeltasMap.set(metric, {
           ...commonProps,
           metric,

--- a/server/src/jobs/handlers/sync-player-deltas.job.ts
+++ b/server/src/jobs/handlers/sync-player-deltas.job.ts
@@ -100,7 +100,7 @@ export const SyncPlayerDeltasJobHandler: JobHandler<Payload> = {
         value = periodDiffs.computed[metric].value.gained;
       }
 
-      if (value > 0) {
+      if (value !== 0) {
         newCachedDeltasMap.set(metric, {
           ...commonProps,
           metric,


### PR DESCRIPTION
Re: https://github.com/wise-old-man/wise-old-man/issues/936

LMS, PvP Arena, EHP, and EHB scores can decrease, but `calculateValueDiff`
clamps all gains to 0 with `Math.max(0, ...)`. The gains table shows 0
instead of the actual negative value. The graph is fine because it diffs
raw snapshots client-side.

## Changes

- `calculateValueDiff` - skip the `Math.max(0, ...)` clamp for LMS, PvP
  Arena, EHP, and EHB (same list as `getNegativeGains` in `snapshot.utils.ts`)
- `calculateEHPDiff` / `calculateEHBDiff` - remove `Math.max(0, ...)` clamp
- `sync-player-deltas.job.ts` - `value > 0` to `value !== 0` so negative
  gains get stored in cached deltas
- Unit tests for negative LMS and PvP Arena diffs
- Integration test expects `-50` for LMS instead of `undefined`

Competition deltas still clamp to 0 (`calculateCompetitionDelta`), per #386.

## Test plan

- [x] Unit tests pass (`calculateValueDiff`)
- [ ] Integration tests pass (`deltas`), needs Docker