### PR TITLE
[app] Fix timezone inconsistency on player gained time cards

### DIFF
--- a/app/src/app/players/[username]/layout.tsx
+++ b/app/src/app/players/[username]/layout.tsx
@@ -9,7 +9,8 @@ import {
   PlayerTypeProps,
   PlayerAnnotationType,
 } from "@wise-old-man/utils";
-import { formatDatetime, timeago } from "~/utils/dates";
+import { timeago } from "~/utils/dates";
+import { LocalDate } from "~/components/LocalDate";
 import { getPlayerDetails } from "~/services/wiseoldman";
 import { Button } from "~/components/Button";
 import { QueryLink } from "~/components/QueryLink";
@@ -319,7 +320,9 @@ function PlayerAttributes(props: PlayerDetailsResponse) {
         <TooltipTrigger asChild>
           <span>Last updated {timeago.format(latestSnapshot.createdAt)}</span>
         </TooltipTrigger>
-        <TooltipContent side="bottom">{formatDatetime(latestSnapshot.createdAt)}</TooltipContent>
+        <TooltipContent side="bottom">
+          <LocalDate mode="datetime" isoDate={latestSnapshot.createdAt.toISOString()} />
+        </TooltipContent>
       </Tooltip>,
     );
   }


### PR DESCRIPTION
Per #1742 there are some timezone inconsistencies on the player page. This is a quick fix to make those timezones concistent:

<img width="289" height="101" alt="Screenshot 2026-05-12 at 4 46 47 PM" src="https://github.com/user-attachments/assets/6e0b0495-cf73-45bd-adf1-ee9cfd433809" />
<img width="346" height="101" alt="Screenshot 2026-05-12 at 4 46 53 PM" src="https://github.com/user-attachments/assets/f93feb63-68b6-4570-9f98-f7934f0b68e1" />
