### PR TITLE
fix: exclude verified groups in protected player spam checks

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.8.44",
+  "version": "2.8.45",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/src/jobs/handlers/check-protected-players-spam.job.ts
+++ b/server/src/jobs/handlers/check-protected-players-spam.job.ts
@@ -23,6 +23,7 @@ export const CheckProtectedPlayersSpamJobHandler: JobHandler = {
         JOIN public.players p ON p."id" = m."playerId"
         WHERE p."username" IN (${PrismaTypes.join(protectedPlayers)})
         AND g."visible" = true
+        AND g."verified" = false
       `,
       prisma.$queryRaw<Array<Competition>>`
         SELECT DISTINCT c.*


### PR DESCRIPTION
Adds AND g."verified" = false to the groups query in the protected players spam check job. This prevents verified groups from being flagged and hidden when they contain protected players.

Closes #1958