### PR TITLE
feat(groups): adding Group Competition Code

### DIFF
--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "4.0.16",
+  "version": "4.1.0",
   "description": "A JavaScript/TypeScript client that interfaces and consumes the Wise Old Man API, an API that tracks and measures players' progress in Old School Runescape.",
   "keywords": [
     "wiseoldman",

--- a/client-js/src/clients/GroupsClient.ts
+++ b/client-js/src/clients/GroupsClient.ts
@@ -220,4 +220,28 @@ export default class GroupsClient extends BaseAPIClient {
   getMembersCSV(id: number) {
     return this.getText(`/groups/${id}/csv`);
   }
+
+  /**
+   * Generates or resets the competition code for a group.
+   * This code allows creating group competitions without full group admin access.
+   * Requires the main group verification code.
+   * @returns The newly generated competition code.
+   */
+  generateCompetitionCode(id: number, verificationCode: string) {
+    return this.putRequest<{ competitionCode: string }>(`/groups/${id}/competition-code`, {
+      verificationCode
+    });
+  }
+
+  /**
+   * Deletes the competition code for a group.
+   * After deletion, only the main verification code can be used to create group competitions.
+   * Requires the main group verification code.
+   * @returns A confirmation message.
+   */
+  deleteCompetitionCode(id: number, verificationCode: string) {
+    return this.deleteRequest<GenericMessageResponse>(`/groups/${id}/competition-code`, {
+      verificationCode
+    });
+  }
 }

--- a/docs/docs/api/competitions/competition-endpoints.mdx
+++ b/docs/docs/api/competitions/competition-endpoints.mdx
@@ -538,7 +538,7 @@ Creates a new competition. Returns the new [CompetitionWithParticipations](/api/
 | startsAt              | date                                                                  | `true`   | The competition's start date.                     |
 | endsAt                | date                                                                  | `true`   | The competition's end date.                       |
 | groupId               | integer?                                                              | `false`  | The competition's host group ID.                  |
-| groupVerificationCode | string?                                                               | `false`  | The competition's host group's verification code. |
+| groupVerificationCode | string?                                                               | `false`  | The group's verification code or competition code. |
 | participants          | string[]?                                                             | `false`  | The usernames of all the starting participants.   |
 | teams                 | [Team](/api/competitions/competition-type-definitions#object-team)[]? | `false`  | The competition's starting teams.                 |
 

--- a/docs/docs/api/groups/group-endpoints.mdx
+++ b/docs/docs/api/groups/group-endpoints.mdx
@@ -2010,3 +2010,131 @@ Alexsuperfly,short_green_guy,286211980,11-26-2023 07:40,11-27-2023 12:40
 ```
 
 ---
+
+## Generate Competition Code
+
+<Endpoint verb="PUT" path="/groups/:id/competition-code" />
+<br />
+
+Generates or resets a competition code for a group. This code allows trusted members to create group competitions without having full access to manage the group (edit, delete, add/remove members).
+
+Requires the group's main verification code.
+
+<br />
+
+**Request Params**
+
+| Field | Type    | Required | Description     |
+| ----- | ------- | -------- | --------------- |
+| id    | integer | `true`   | The group's ID. |
+
+<br />
+
+**Body Params**
+
+| Field            | Type   | Required | Description                    |
+| ---------------- | ------ | -------- | ------------------------------ |
+| verificationCode | string | `true`   | The group's verification code. |
+
+:::info
+If a competition code already exists, calling this endpoint will generate a new one and invalidate the previous code.
+:::
+
+<br />
+
+**Example Request**
+
+<TabbedCodeBlock>
+
+```curl
+curl -X PUT https://api.wiseoldman.net/v2/groups/123/competition-code \
+ -H "Content-type: application/json" \
+ -d '{
+	"verificationCode": "759-236-892"
+}'
+```
+
+```javascript
+const { WOMClient } = require('@wise-old-man/utils');
+
+const client = new WOMClient();
+
+const result = await client.groups.generateCompetitionCode(123, '759-236-892');
+// { competitionCode: "247-582-408" }
+```
+
+</TabbedCodeBlock>
+
+<br />
+
+**Example Response**
+
+```json
+{
+  "competitionCode": "247-582-408"
+}
+```
+
+---
+
+## Delete Competition Code
+
+<Endpoint verb="DELETE" path="/groups/:id/competition-code" />
+<br />
+
+Removes the competition code for a group. After deletion, only the main verification code can be used to create group competitions.
+
+Requires the group's main verification code.
+
+<br />
+
+**Request Params**
+
+| Field | Type    | Required | Description     |
+| ----- | ------- | -------- | --------------- |
+| id    | integer | `true`   | The group's ID. |
+
+<br />
+
+**Body Params**
+
+| Field            | Type   | Required | Description                    |
+| ---------------- | ------ | -------- | ------------------------------ |
+| verificationCode | string | `true`   | The group's verification code. |
+
+<br />
+
+**Example Request**
+
+<TabbedCodeBlock>
+
+```curl
+curl -X DELETE https://api.wiseoldman.net/v2/groups/123/competition-code \
+ -H "Content-type: application/json" \
+ -d '{
+	"verificationCode": "759-236-892"
+}'
+```
+
+```javascript
+const { WOMClient } = require('@wise-old-man/utils');
+
+const client = new WOMClient();
+
+const result = await client.groups.deleteCompetitionCode(123, '759-236-892');
+// { message: "Successfully deleted the competition code." }
+```
+
+</TabbedCodeBlock>
+
+<br />
+
+**Example Response**
+
+```json
+{
+  "message": "Successfully deleted the competition code."
+}
+```
+
+---

--- a/docs/docs/api/groups/group-type-definitions.md
+++ b/docs/docs/api/groups/group-type-definitions.md
@@ -52,6 +52,7 @@ sidebar_position: 1
 | createdAt    | date    | The group's creation date.                                |
 | updatedAt    | date    | The group's last modification date.                       |
 | memberCount  | integer | The group's total number of members.                      |
+| hasCompetitionCode | boolean | Whether the group has a competition code set.      |
 
 <br />
 

--- a/server/__tests__/suites/integration/groupCompetitionCode.test.ts
+++ b/server/__tests__/suites/integration/groupCompetitionCode.test.ts
@@ -1,0 +1,246 @@
+import supertest from 'supertest';
+import APIInstance from '../../../src/api';
+import { redisClient } from '../../../src/services/redis.service';
+import { resetDatabase } from '../../utils';
+
+const api = supertest(new APIInstance().init().express);
+
+const globalData = {
+  testGroup: {
+    id: -1,
+    verificationCode: ''
+  },
+  competitionCode: ''
+};
+
+beforeAll(async () => {
+  await resetDatabase();
+  await redisClient.flushall();
+
+  // Create a group to use in tests
+  const createGroupResponse = await api.post('/groups').send({
+    name: 'Competition Code Test Group',
+    members: [{ username: 'test_play_1' }, { username: 'test_play_2' }]
+  });
+
+  expect(createGroupResponse.status).toBe(201);
+
+  globalData.testGroup = {
+    id: createGroupResponse.body.group.id,
+    verificationCode: createGroupResponse.body.verificationCode
+  };
+});
+
+afterAll(async () => {
+  await redisClient.quit();
+});
+
+describe('Group Competition Code API', () => {
+  describe('1 - Generate Competition Code', () => {
+    it('should not generate (missing verification code)', async () => {
+      const response = await api.put(`/groups/${globalData.testGroup.id}/competition-code`).send({});
+
+      expect(response.status).toBe(400);
+      expect(response.body).toMatchObject({ code: 'MISSING_VERIFICATION_CODE' });
+    });
+
+    it('should not generate (incorrect verification code)', async () => {
+      const response = await api.put(`/groups/${globalData.testGroup.id}/competition-code`).send({
+        verificationCode: '000-000-000'
+      });
+
+      expect(response.status).toBe(403);
+      expect(response.body).toMatchObject({ code: 'INCORRECT_VERIFICATION_CODE' });
+    });
+
+    it('should not generate (group not found)', async () => {
+      const response = await api.put('/groups/999999/competition-code').send({
+        verificationCode: globalData.testGroup.verificationCode
+      });
+
+      expect(response.status).toBe(404);
+      expect(response.body).toMatchObject({ code: 'GROUP_NOT_FOUND' });
+    });
+
+    it('should generate a competition code', async () => {
+      const response = await api.put(`/groups/${globalData.testGroup.id}/competition-code`).send({
+        verificationCode: globalData.testGroup.verificationCode
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.body.competitionCode).toBeDefined();
+      expect(response.body.competitionCode).toMatch(/^\d{3}-\d{3}-\d{3}$/);
+
+      globalData.competitionCode = response.body.competitionCode;
+    });
+
+    it('should show hasCompetitionCode=true in group details', async () => {
+      const response = await api.get(`/groups/${globalData.testGroup.id}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.hasCompetitionCode).toBe(true);
+    });
+
+    it('should regenerate the competition code (overwrite old one)', async () => {
+      const response = await api.put(`/groups/${globalData.testGroup.id}/competition-code`).send({
+        verificationCode: globalData.testGroup.verificationCode
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.body.competitionCode).toBeDefined();
+      expect(response.body.competitionCode).toMatch(/^\d{3}-\d{3}-\d{3}$/);
+
+      // The new code should (almost certainly) be different from the old one
+      globalData.competitionCode = response.body.competitionCode;
+    });
+  });
+
+  describe('2 - Create Competition with Competition Code', () => {
+    it('should create a group competition using the main verification code', async () => {
+      const futureStart = new Date(Date.now() + 1000 * 60 * 60 * 24);
+      const futureEnd = new Date(Date.now() + 1000 * 60 * 60 * 48);
+
+      const response = await api.post('/competitions').send({
+        title: 'Test Comp Main Code',
+        metrics: ['woodcutting'],
+        startsAt: futureStart.toISOString(),
+        endsAt: futureEnd.toISOString(),
+        groupId: globalData.testGroup.id,
+        groupVerificationCode: globalData.testGroup.verificationCode
+      });
+
+      expect(response.status).toBe(201);
+      expect(response.body.competition.groupId).toBe(globalData.testGroup.id);
+    });
+
+    it('should create a group competition using the competition code', async () => {
+      const futureStart = new Date(Date.now() + 1000 * 60 * 60 * 24);
+      const futureEnd = new Date(Date.now() + 1000 * 60 * 60 * 48);
+
+      const response = await api.post('/competitions').send({
+        title: 'Test Comp Competition Code',
+        metrics: ['fishing'],
+        startsAt: futureStart.toISOString(),
+        endsAt: futureEnd.toISOString(),
+        groupId: globalData.testGroup.id,
+        groupVerificationCode: globalData.competitionCode
+      });
+
+      expect(response.status).toBe(201);
+      expect(response.body.competition.groupId).toBe(globalData.testGroup.id);
+    });
+
+    it('should not create a group competition with an invalid code', async () => {
+      const futureStart = new Date(Date.now() + 1000 * 60 * 60 * 24);
+      const futureEnd = new Date(Date.now() + 1000 * 60 * 60 * 48);
+
+      const response = await api.post('/competitions').send({
+        title: 'Test Comp Bad Code',
+        metrics: ['mining'],
+        startsAt: futureStart.toISOString(),
+        endsAt: futureEnd.toISOString(),
+        groupId: globalData.testGroup.id,
+        groupVerificationCode: '999-999-999'
+      });
+
+      expect(response.status).toBe(403);
+      expect(response.body).toMatchObject({ code: 'INCORRECT_GROUP_VERIFICATION_CODE' });
+    });
+
+    it('should not allow using competition code to edit the group', async () => {
+      const response = await api.put(`/groups/${globalData.testGroup.id}`).send({
+        verificationCode: globalData.competitionCode,
+        name: 'Hacked Group Name'
+      });
+
+      expect(response.status).toBe(403);
+      expect(response.body).toMatchObject({ code: 'INCORRECT_VERIFICATION_CODE' });
+    });
+
+    it('should not allow using competition code to delete the group', async () => {
+      const response = await api.delete(`/groups/${globalData.testGroup.id}`).send({
+        verificationCode: globalData.competitionCode
+      });
+
+      expect(response.status).toBe(403);
+      expect(response.body).toMatchObject({ code: 'INCORRECT_VERIFICATION_CODE' });
+    });
+  });
+
+  describe('3 - Delete Competition Code', () => {
+    it('should not delete (missing verification code)', async () => {
+      const response = await api.delete(`/groups/${globalData.testGroup.id}/competition-code`).send({});
+
+      expect(response.status).toBe(400);
+      expect(response.body).toMatchObject({ code: 'MISSING_VERIFICATION_CODE' });
+    });
+
+    it('should not delete (incorrect verification code)', async () => {
+      const response = await api.delete(`/groups/${globalData.testGroup.id}/competition-code`).send({
+        verificationCode: '000-000-000'
+      });
+
+      expect(response.status).toBe(403);
+      expect(response.body).toMatchObject({ code: 'INCORRECT_VERIFICATION_CODE' });
+    });
+
+    it('should not allow using competition code to delete itself', async () => {
+      const response = await api.delete(`/groups/${globalData.testGroup.id}/competition-code`).send({
+        verificationCode: globalData.competitionCode
+      });
+
+      expect(response.status).toBe(403);
+      expect(response.body).toMatchObject({ code: 'INCORRECT_VERIFICATION_CODE' });
+    });
+
+    it('should delete the competition code', async () => {
+      const response = await api.delete(`/groups/${globalData.testGroup.id}/competition-code`).send({
+        verificationCode: globalData.testGroup.verificationCode
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.body.message).toMatch(/successfully deleted/i);
+    });
+
+    it('should show hasCompetitionCode=false after deletion', async () => {
+      const response = await api.get(`/groups/${globalData.testGroup.id}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.hasCompetitionCode).toBe(false);
+    });
+
+    it('should not create a group competition with the old competition code after deletion', async () => {
+      const futureStart = new Date(Date.now() + 1000 * 60 * 60 * 24);
+      const futureEnd = new Date(Date.now() + 1000 * 60 * 60 * 48);
+
+      const response = await api.post('/competitions').send({
+        title: 'Test Comp After Delete',
+        metrics: ['attack'],
+        startsAt: futureStart.toISOString(),
+        endsAt: futureEnd.toISOString(),
+        groupId: globalData.testGroup.id,
+        groupVerificationCode: globalData.competitionCode
+      });
+
+      expect(response.status).toBe(403);
+      expect(response.body).toMatchObject({ code: 'INCORRECT_GROUP_VERIFICATION_CODE' });
+    });
+
+    it('should still create a group competition with the main code after competition code deletion', async () => {
+      const futureStart = new Date(Date.now() + 1000 * 60 * 60 * 24);
+      const futureEnd = new Date(Date.now() + 1000 * 60 * 60 * 48);
+
+      const response = await api.post('/competitions').send({
+        title: 'Test Comp Main After Delete',
+        metrics: ['strength'],
+        startsAt: futureStart.toISOString(),
+        endsAt: futureEnd.toISOString(),
+        groupId: globalData.testGroup.id,
+        groupVerificationCode: globalData.testGroup.verificationCode
+      });
+
+      expect(response.status).toBe(201);
+      expect(response.body.competition.groupId).toBe(globalData.testGroup.id);
+    });
+  });
+});

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-server",
-  "version": "2.8.45",
+  "version": "2.9.0",
   "description": "",
   "author": "Psikoi",
   "license": "ISC",

--- a/server/prisma/migrations/20260630000000_add_competition_verification_hash/migration.sql
+++ b/server/prisma/migrations/20260630000000_add_competition_verification_hash/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "groups" ADD COLUMN "competitionVerificationHash" VARCHAR(255);

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -142,8 +142,9 @@ model Group {
   profileImage     String?  @db.VarChar(255)
   bannerImage      String?  @db.VarChar(255)
   score            Int      @default(0)
-  verificationHash String   @db.VarChar(255)
-  createdAt        DateTime @default(now()) @db.Timestamptz(6)
+  verificationHash            String   @db.VarChar(255)
+  competitionVerificationHash String?  @db.VarChar(255)
+  createdAt                   DateTime @default(now()) @db.Timestamptz(6)
   updatedAt        DateTime @updatedAt @db.Timestamptz(6)
   creatorIpHash    String?  @db.VarChar(255)
 

--- a/server/src/api/modules/competitions/services/CreateCompetitionService.ts
+++ b/server/src/api/modules/competitions/services/CreateCompetitionService.ts
@@ -172,20 +172,33 @@ async function validateGroupVerification(
 
   const group = await prisma.group.findFirst({
     where: { id: groupId },
-    select: { verificationHash: true }
+    select: { verificationHash: true, competitionVerificationHash: true }
   });
 
   if (group === null) {
     return errored({ code: 'GROUP_NOT_FOUND' });
   }
 
-  const verificationResult = await cryptService.verifyCode(group.verificationHash, groupVerificationCode);
+  // Try the main group verification code first
+  const mainVerificationResult = await cryptService.verifyCode(group.verificationHash, groupVerificationCode);
 
-  if (isErrored(verificationResult)) {
-    return errored({ code: 'INCORRECT_GROUP_VERIFICATION_CODE' });
+  if (!isErrored(mainVerificationResult)) {
+    return complete(true);
   }
 
-  return complete(true);
+  // If the main code didn't match, try the competition-specific code
+  if (group.competitionVerificationHash) {
+    const competitionVerificationResult = await cryptService.verifyCode(
+      group.competitionVerificationHash,
+      groupVerificationCode
+    );
+
+    if (!isErrored(competitionVerificationResult)) {
+      return complete(true);
+    }
+  }
+
+  return errored({ code: 'INCORRECT_GROUP_VERIFICATION_CODE' });
 }
 
 async function getValidatedParticipations({

--- a/server/src/api/modules/groups/group.router.ts
+++ b/server/src/api/modules/groups/group.router.ts
@@ -44,6 +44,7 @@ import { fetchGroupStatistics } from './services/FetchGroupStatisticsService';
 import { fetchGroupMembersCSV } from './services/FetchMembersCSVService';
 import { removeMembers } from './services/RemoveMembersService';
 import { resetGroupCode } from './services/ResetGroupCodeService';
+import { generateCompetitionCode, deleteCompetitionCode } from './services/ManageCompetitionCodeService';
 import { searchGroups } from './services/SearchGroupsService';
 import { updateAllMembers } from './services/UpdateAllMembersService';
 import { verifyGroup } from './services/VerifyGroupService';
@@ -517,6 +518,38 @@ router.put(
     const response = formatGroupResponse(group, memberCount);
 
     res.status(200).json(response);
+  })
+);
+
+router.put(
+  '/groups/:id/competition-code',
+  checkGroupVerificationCode,
+  validateRequest({
+    params: z.object({
+      id: z.coerce.number().int().positive()
+    })
+  }),
+  executeRequest(async (req, res) => {
+    const { id } = req.params;
+
+    const result = await generateCompetitionCode(id);
+    res.status(200).json(result);
+  })
+);
+
+router.delete(
+  '/groups/:id/competition-code',
+  checkGroupVerificationCode,
+  validateRequest({
+    params: z.object({
+      id: z.coerce.number().int().positive()
+    })
+  }),
+  executeRequest(async (req, res) => {
+    const { id } = req.params;
+
+    const result = await deleteCompetitionCode(id);
+    res.status(200).json(result);
   })
 );
 

--- a/server/src/api/modules/groups/services/ManageCompetitionCodeService.ts
+++ b/server/src/api/modules/groups/services/ManageCompetitionCodeService.ts
@@ -1,0 +1,48 @@
+import { isErrored } from '@attio/fetchable';
+import prisma from '../../../../prisma';
+import * as cryptService from '../../../../services/crypt.service';
+import { NotFoundError } from '../../../errors';
+
+/**
+ * Generates or resets the competition verification code for a group.
+ * This code allows creating group competitions without having full group admin access.
+ */
+async function generateCompetitionCode(groupId: number): Promise<{ competitionCode: string }> {
+  const generateVerificationResult = await cryptService.generateVerification();
+
+  if (isErrored(generateVerificationResult)) {
+    throw generateVerificationResult.error.subError;
+  }
+
+  const { code, hash } = generateVerificationResult.value;
+
+  try {
+    await prisma.group.update({
+      where: { id: groupId },
+      data: { competitionVerificationHash: hash }
+    });
+
+    return { competitionCode: code };
+  } catch (_error) {
+    throw new NotFoundError('Group not found.');
+  }
+}
+
+/**
+ * Removes the competition verification code for a group.
+ * After this, only the main verification code can be used to create group competitions.
+ */
+async function deleteCompetitionCode(groupId: number): Promise<{ message: string }> {
+  try {
+    await prisma.group.update({
+      where: { id: groupId },
+      data: { competitionVerificationHash: null }
+    });
+
+    return { message: 'Successfully deleted the competition code.' };
+  } catch (_error) {
+    throw new NotFoundError('Group not found.');
+  }
+}
+
+export { generateCompetitionCode, deleteCompetitionCode };

--- a/server/src/api/responses/group.response.ts
+++ b/server/src/api/responses/group.response.ts
@@ -7,8 +7,10 @@
 import { Group } from '../../types';
 import { pick } from '../../utils/pick.util';
 
-export interface GroupResponse extends Omit<Group, 'verificationHash' | 'creatorIpHash'> {
+export interface GroupResponse
+  extends Omit<Group, 'verificationHash' | 'competitionVerificationHash' | 'creatorIpHash'> {
   memberCount: number;
+  hasCompetitionCode: boolean;
 }
 
 export function formatGroupResponse(group: Group, memberCount: number): GroupResponse {
@@ -29,6 +31,7 @@ export function formatGroupResponse(group: Group, memberCount: number): GroupRes
       'createdAt',
       'updatedAt'
     ),
-    memberCount
+    memberCount,
+    hasCompetitionCode: group.competitionVerificationHash !== null
   };
 }

--- a/server/src/types/group.type.ts
+++ b/server/src/types/group.type.ts
@@ -11,6 +11,7 @@ export interface Group {
   bannerImage: string | null;
   score: number;
   verificationHash: string;
+  competitionVerificationHash: string | null;
   createdAt: Date;
   updatedAt: Date;
   creatorIpHash: string | null;


### PR DESCRIPTION
 ## Rationale
Clan leaders currently have to share their main group verification code with anyone who needs to create competitions. This gives those members full admin access. This means they can edit, delete, or modify the group. There's no way to delegate competition creation without giving away the keys to everything, Which personally i feel is too risky as you want clan founders / admin to manage the group and then you can have event organisers / others to have the group competition code allowing to do as such without implicating the group control itself. 

 ## Feature
A secondary "competition code" that can only be used to create group competitions.
Group owners generate/reset/delete it via the group edit page or API, using their main verification code.

New endpoints:
- PUT /groups/:id/competition-code (generate/reset)
- DELETE /groups/:id/competition-code (revoke)

## Desired Outcomes
- Event managers can create group competitions without full group admin access
- Group owners retain full control, they can reset or revoke the competition code at any time
- The main verification code continues to work for everything, including creating competitions (Both codes can be used to make a competition to ensure less annoyance on the consumers end)
- Clear separation of concerns: competition code cannot edit, delete, or manage the group