### PR TITLE
feat(app): add competition code UI to group edit page

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -28,7 +28,7 @@
     "@tailwindcss/container-queries": "^0.1.1",
     "@tanstack/react-query": "^5.0.0-alpha.34",
     "@tanstack/react-table": "^8.9.1",
-    "@wise-old-man/utils": "^4.0.16",
+    "@wise-old-man/utils": "^4.1.0",
     "autoprefixer": "10.4.14",
     "class-variance-authority": "^0.5.2",
     "clsx": "^1.2.1",

--- a/app/src/components/competitions/CompetitionGroupForm.tsx
+++ b/app/src/components/competitions/CompetitionGroupForm.tsx
@@ -50,6 +50,13 @@ export function CompetitionGroupForm(props: CompetitionGroupFormProps) {
         // If it failed with 400 (Bad Request), that means it got through the code validation checks
         // and just failed due to an empty payload (as expected)
         if (error.statusCode === 400) return groupVerificationCode;
+
+        // If it failed with 403, it might be a competition code (which can't edit the group
+        // but can still create competitions). Accept it and let creation validate it.
+        // Note: this also passes through completely invalid codes, but those will fail
+        // with a clear error at the competition creation step.
+        if (error.statusCode === 403) return groupVerificationCode;
+
         throw error;
       }
     },
@@ -123,6 +130,9 @@ export function CompetitionGroupForm(props: CompetitionGroupFormProps) {
             value={groupVerificationCode}
             onChange={(e) => setGroupVerificationCode(e.target.value)}
           />
+          <p className="mt-2 text-xs text-gray-200">
+            You can use either the group&apos;s main verification code or a competition code.
+          </p>
         </div>
       </div>
 

--- a/app/src/components/groups/CompetitionCodeSection.tsx
+++ b/app/src/components/groups/CompetitionCodeSection.tsx
@@ -1,0 +1,257 @@
+"use client";
+
+import { useEffect, useRef, useState, useTransition } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { GroupDetailsResponse } from "@wise-old-man/utils";
+import { useRouter } from "next/navigation";
+import { useToast } from "~/hooks/useToast";
+import { useTicker } from "~/hooks/useTicker";
+import { useWOMClient } from "~/hooks/useWOMClient";
+import { Alert, AlertDescription } from "../Alert";
+import { Button } from "../Button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "../Dialog";
+import { Input } from "../Input";
+
+import ClipboardIcon from "~/assets/clipboard.svg";
+import LoadingIcon from "~/assets/loading.svg";
+import WarningIcon from "~/assets/warning.svg";
+
+const MIN_WAIT_PERIOD_SECONDS = 10;
+
+interface CompetitionCodeSectionProps {
+  group: GroupDetailsResponse;
+  verificationCode: string;
+}
+
+export function CompetitionCodeSection(props: CompetitionCodeSectionProps) {
+  const { group, verificationCode } = props;
+
+  const toast = useToast();
+  const router = useRouter();
+  const client = useWOMClient();
+
+  const [showCodeDialog, setShowCodeDialog] = useState(false);
+  const [generatedCode, setGeneratedCode] = useState("");
+  const [isTransitioning, startTransition] = useTransition();
+
+  const generateMutation = useMutation({
+    mutationFn: () => {
+      return client.groups.generateCompetitionCode(group.id, verificationCode);
+    },
+    onSuccess: (data) => {
+      setGeneratedCode(data.competitionCode);
+      setShowCodeDialog(true);
+    },
+    onError: (error) => {
+      if (error instanceof Error) {
+        toast.toast({ variant: "error", title: error.message });
+      }
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: () => {
+      return client.groups.deleteCompetitionCode(group.id, verificationCode);
+    },
+    onSuccess: () => {
+      startTransition(() => {
+        router.refresh();
+        toast.toast({ variant: "success", title: "Competition code deleted successfully." });
+      });
+    },
+    onError: (error) => {
+      if (error instanceof Error) {
+        toast.toast({ variant: "error", title: error.message });
+      }
+    },
+  });
+
+  const hasCompetitionCode = group.hasCompetitionCode;
+
+  return (
+    <div className="flex w-full flex-col gap-y-7">
+      <Alert>
+        <AlertDescription>
+          <p>
+            A competition code allows trusted members to create group competitions without having full
+            access to manage the group. Share this code with clan event managers or trusted members who
+            need to create competitions on behalf of your group.
+          </p>
+          <p className="mt-3 text-gray-100">
+            The competition code <span className="font-medium text-white">cannot</span> be used to edit,
+            delete, or manage the group itself.
+          </p>
+        </AlertDescription>
+      </Alert>
+
+      <div className="rounded-lg border border-gray-500 p-5">
+        <div className="flex items-center justify-between">
+          <div>
+            <h3 className="text-sm font-medium text-white">Competition Code</h3>
+            <p className="mt-1 text-xs text-gray-200">
+              {hasCompetitionCode
+                ? "A competition code has been generated for this group."
+                : "No competition code has been generated yet."}
+            </p>
+          </div>
+          <div className="flex items-center gap-x-1.5">
+            {hasCompetitionCode ? (
+              <span className="rounded-full bg-green-900/30 px-2 py-0.5 text-xs font-medium text-green-400">
+                Active
+              </span>
+            ) : (
+              <span className="rounded-full bg-gray-600 px-2 py-0.5 text-xs font-medium text-gray-200">
+                Not set
+              </span>
+            )}
+          </div>
+        </div>
+
+        <div className="mt-5 flex gap-x-3">
+          <Button
+            variant="blue"
+            onClick={() => generateMutation.mutate()}
+            disabled={generateMutation.isPending}
+          >
+            {generateMutation.isPending ? (
+              <>
+                <LoadingIcon className="-ml-1 h-4 w-4 animate-spin" />
+                Generating...
+              </>
+            ) : hasCompetitionCode ? (
+              "Reset Code"
+            ) : (
+              "Generate Code"
+            )}
+          </Button>
+          {hasCompetitionCode && (
+            <Button
+              variant="outline"
+              onClick={() => deleteMutation.mutate()}
+              disabled={deleteMutation.isPending || isTransitioning}
+            >
+              {deleteMutation.isPending || isTransitioning ? (
+                <>
+                  <LoadingIcon className="-ml-1 h-4 w-4 animate-spin" />
+                  Deleting...
+                </>
+              ) : (
+                "Delete Code"
+              )}
+            </Button>
+          )}
+        </div>
+
+        {hasCompetitionCode && (
+          <p className="mt-3 flex items-start gap-x-1.5 text-xs text-yellow-200">
+            <WarningIcon className="mt-0.5 h-3 w-3 shrink-0" />
+            Resetting will invalidate the previous code. Anyone using the old code will need the new one.
+          </p>
+        )}
+      </div>
+
+      <SaveCompetitionCodeDialog
+        isOpen={showCodeDialog}
+        competitionCode={generatedCode}
+        onClose={() => {
+          setShowCodeDialog(false);
+          startTransition(() => {
+            router.refresh();
+          });
+        }}
+      />
+    </div>
+  );
+}
+
+interface SaveCompetitionCodeDialogProps {
+  isOpen: boolean;
+  competitionCode: string;
+  onClose: () => void;
+}
+
+function SaveCompetitionCodeDialog(props: SaveCompetitionCodeDialogProps) {
+  const { isOpen, onClose, competitionCode } = props;
+
+  const toast = useToast();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const [isTransitioning, startTransition] = useTransition();
+  const [openedTimestamp, setOpenedTimestamp] = useState<number | null>(null);
+
+  useTicker(500, isOpen);
+
+  useEffect(() => {
+    if (isOpen) setOpenedTimestamp(Date.now());
+  }, [isOpen]);
+
+  const timeEllapsed = openedTimestamp ? Math.ceil((Date.now() - openedTimestamp) / 1000) : 0;
+  const hasWaited = timeEllapsed >= MIN_WAIT_PERIOD_SECONDS;
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(val) => {
+        if (!val && hasWaited) onClose();
+      }}
+    >
+      <DialogContent className="w-[22rem]" hideClose onPointerDownOutside={(e) => e.preventDefault()}>
+        <DialogHeader>
+          <DialogTitle className="text-center">Competition Code Generated!</DialogTitle>
+          <span className="text-center text-sm text-blue-400">
+            Your group&apos;s competition code is:
+          </span>
+        </DialogHeader>
+        <div className="relative flex items-center gap-x-2">
+          <Input
+            aria-label="Competition code"
+            ref={inputRef}
+            readOnly
+            autoFocus={false}
+            value={competitionCode}
+            containerClassName="grow"
+            className="h-[3.25rem] text-center font-mono text-xl"
+          />
+          <Button
+            autoFocus
+            variant="outline"
+            iconButton
+            className="absolute right-2 top-2 bg-white/5"
+            onClick={() => {
+              if (inputRef.current) inputRef.current.select();
+              navigator.clipboard.writeText(competitionCode);
+              toast.toast({ variant: "success", title: "Copied to the clipboard!" });
+            }}
+          >
+            <ClipboardIcon className="h-5 w-5 text-gray-200" />
+          </Button>
+        </div>
+        <p className="text-center text-body text-gray-200">
+          Save this code and share it with trusted members who need to create competitions for your
+          group. This code <span className="font-medium text-white">cannot</span> be used to manage the
+          group itself.
+        </p>
+        <Button
+          size="lg"
+          variant="blue"
+          className="mt-4 justify-center tabular-nums"
+          disabled={!hasWaited || isTransitioning}
+          onClick={() => {
+            startTransition(() => {
+              onClose();
+            });
+          }}
+        >
+          {isTransitioning ? (
+            "Closing..."
+          ) : (
+            <>
+              {hasWaited ? "Ok, I got it" : "Please read above"}{" "}
+              {!hasWaited && `(${MIN_WAIT_PERIOD_SECONDS - timeEllapsed}s)`}
+            </>
+          )}
+        </Button>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/src/components/groups/EditGroupForm.tsx
+++ b/app/src/components/groups/EditGroupForm.tsx
@@ -43,6 +43,7 @@ import { EmptyGroupDialog } from "./EmptyGroupDialog";
 import { Input } from "../Input";
 import { BannerImageUpload, ProfileImageUpload } from "../ImageUpload";
 import { GroupVerificationCodeCheckDialog } from "./GroupVerificationCodeCheckDialog";
+import { CompetitionCodeSection } from "./CompetitionCodeSection";
 
 import WebIcon from "~/assets/web.svg";
 import TwitchIcon from "~/assets/twitch.svg";
@@ -108,6 +109,13 @@ export function EditGroupForm(props: EditGroupFormProps) {
           {section === "links" && (
             <SocialLinksSection
               {...props}
+              key={group.updatedAt.toString()}
+              verificationCode={verificationCode || ""}
+            />
+          )}
+          {section === "competition-code" && (
+            <CompetitionCodeSection
+              group={group}
               key={group.updatedAt.toString()}
               verificationCode={verificationCode || ""}
             />
@@ -660,6 +668,7 @@ function SideNavigation(props: SideNavigationProps) {
     { name: "Members", value: "members" },
     { name: "Profile images", value: "images" },
     { name: "Social links", value: "links" },
+    { name: "Competition code", value: "competition-code" },
   ];
 
   return (


### PR DESCRIPTION
 ## Summary
Adds the frontend UI for the group competition code feature introduced in #1962.

## Changes
- New "Competition code" section in the group edit page sidebar
- Generate, reset, and delete competition code via the UI
- Code display dialog with clipboard copy and forced wait timer
- Updated CompetitionGroupForm to accept competition codes when creating group competitions
- Bumped @wise-old-man/utils to ^4.1.0

## Blocked by
This PR depends on #1962 being merged first (publishes @wise-old-man/utils@4.1.0 to npm).