### PR TITLE
fix(leaderboards): handle API errors in top leaderboard page gracefully

### DIFF
--- a/app/src/app/leaderboards/top/error.tsx
+++ b/app/src/app/leaderboards/top/error.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+export default function TopLeaderboardsError() {
+  return (
+    <div className="w-full rounded border border-gray-700 py-10 text-center text-sm text-gray-200">
+      Something went wrong while loading the leaderboards. Try adjusting your filters.
+    </div>
+  );
+}

--- a/app/src/app/leaderboards/top/page.tsx
+++ b/app/src/app/leaderboards/top/page.tsx
@@ -72,18 +72,29 @@ interface TopLeaderboardProps {
 async function TopLeaderboard(props: TopLeaderboardProps) {
   const { period, filters } = props;
 
-  const data = await getDeltaLeaderboard(
-    filters.metric,
-    period,
-    filters.country,
-    filters.playerType,
-    filters.playerBuild,
-  );
+  let data: Awaited<ReturnType<typeof getDeltaLeaderboard>> = [];
+  let fetchError = false;
+
+  try {
+    data = await getDeltaLeaderboard(
+      filters.metric,
+      period,
+      filters.country,
+      filters.playerType,
+      filters.playerBuild,
+    );
+  } catch {
+    fetchError = true;
+  }
 
   return (
     <div>
       <h3 className="pb-3 text-h3 font-bold">{PeriodProps[period].name}</h3>
-      {data.length === 0 ? (
+      {fetchError ? (
+        <div className="w-full rounded border border-gray-700 py-10 text-center text-sm text-gray-200">
+          Could not load leaderboard data for this filter.
+        </div>
+      ) : data.length === 0 ? (
         <div className="w-full rounded border border-gray-700 py-10 text-center text-sm text-gray-200">
           No results were found
         </div>


### PR DESCRIPTION
When a user selects the F2P (free-to-play) player build filter on the top leaderboards page, the underlying API call fails because that combination of filters returns an error response rather than an empty list. Since TopLeaderboard is an async server component and the error propagates uncaught, the entire page crashes with an unhandled exception.

This was reported in issue #1791.

The fix wraps each getDeltaLeaderboard call in a try-catch block, storing a fetchError flag when the call fails. Each panel then renders a graceful inline error message instead of crashing the page. The other panels, which may succeed with the same filters, continue to render normally.

A new error.tsx file was added as a Next.js App Router error boundary for the route segment. This catches any rendering errors that slip past the per-panel try-catch and shows a user-friendly fallback rather than the default error page.

Changes:

app/src/app/leaderboards/top/page.tsx: wrapped getDeltaLeaderboard call with try-catch, added fetchError state, added conditional rendering for the error case alongside the existing empty-state check.

app/src/app/leaderboards/top/error.tsx: new file, use client error boundary for the leaderboards top route segment.

Yokubjon Nurullaev identified the root cause by tracing the unhandled exception from the F2P filter through the async server component to the missing error boundary. He implemented the per-panel try-catch pattern in page.tsx, the fetchError state, and the conditional rendering logic.

IbrokhimN designed the error.tsx boundary component and reviewed the error state logic to ensure the three period panels remain independent, so a failure in one panel does not suppress results from the others.