### PR TITLE
feat: make default user agent for client-js a lazily evaluated function

### DIFF
--- a/client-js/package-lock.json
+++ b/client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "4.0.19",
+  "version": "4.0.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wise-old-man/utils",
-      "version": "4.0.19",
+      "version": "4.0.20",
       "license": "ISC",
       "devDependencies": {
         "@rollup/plugin-typescript": "^11.1.6",

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "4.0.19",
+  "version": "4.0.20",
   "description": "A JavaScript/TypeScript client that interfaces and consumes the Wise Old Man API, an API that tracks and measures players' progress in Old School Runescape.",
   "keywords": [
     "wiseoldman",

--- a/client-js/src/client.ts
+++ b/client-js/src/client.ts
@@ -26,7 +26,7 @@ export default class WOMClient extends BaseAPIClient {
   constructor(options?: WOMClientOptions) {
     const baseApiUrl = options?.baseAPIUrl || config.baseAPIUrl;
     const headers = {
-      'x-user-agent': options?.userAgent || config.defaultUserAgent
+      'x-user-agent': options?.userAgent || config.defaultUserAgent()
     };
 
     if (options?.apiKey) {

--- a/client-js/src/config.ts
+++ b/client-js/src/config.ts
@@ -1,4 +1,4 @@
 export default {
-  defaultUserAgent: `WiseOldMan JS Client v${process.env.npm_package_version}`,
+  defaultUserAgent: () => `WiseOldMan JS Client v${process.env.npm_package_version}`,
   baseAPIUrl: 'https://api.wiseoldman.net/v2'
 };


### PR DESCRIPTION
Removing direct access to `process` allows the client-js code to run in non-node environments. Note that this could, of course, still fail at runtime. But at least this allows people to specify their own `userAgent` on `WOMClientOptions`, so that `defaultUserAgent()` is never called.