### PR TITLE
[app] Move group and competition deletion into a Danger zone on the edit pages

### DIFF
--- a/app/src/app/competitions/[id]/(details)/layout.tsx
+++ b/app/src/app/competitions/[id]/(details)/layout.tsx
@@ -11,7 +11,6 @@ import { Alert, AlertDescription, AlertTitle } from "~/components/Alert";
 import { Button } from "~/components/Button";
 import { CompetitionDetailsNavigation } from "~/components/competitions/CompetitionDetailsNavigation";
 import { CompetitionPreviewWarning } from "~/components/competitions/CompetitionPreviewWarning";
-import { DeleteCompetitionDialog } from "~/components/competitions/DeleteCompetitionDialog";
 import { ExportCompetitionDialog } from "~/components/competitions/ExportCompetitionDialog";
 import { PreviewMetricDialog } from "~/components/competitions/PreviewMetricDialog";
 import { UpdateAllParticipantsDialog } from "~/components/competitions/UpdateAllParticipantsDialog";
@@ -79,7 +78,6 @@ export default async function CompetitionLayout(props: PropsWithChildren<PagePro
       {children}
 
       {/* Dialogs */}
-      <DeleteCompetitionDialog competitionId={id} />
       <ExportCompetitionDialog competitionId={id} />
       <UpdateAllParticipantsDialog competitionId={id} />
       {/* TODO: Fix this */}
@@ -149,9 +147,6 @@ function Header(props: CompetitionDetailsResponse) {
             <Link prefetch={false} href={`/competitions/${id}/edit`} rel="nofollow">
               <DropdownMenuItem>Edit</DropdownMenuItem>
             </Link>
-            <QueryLink query={{ dialog: "delete" }}>
-              <DropdownMenuItem>Delete</DropdownMenuItem>
-            </QueryLink>
             <QueryLink query={{ dialog: "preview" }}>
               <DropdownMenuItem>Preview as...</DropdownMenuItem>
             </QueryLink>

--- a/app/src/app/groups/[id]/(details)/layout.tsx
+++ b/app/src/app/groups/[id]/(details)/layout.tsx
@@ -8,7 +8,6 @@ import { Badge } from "~/components/Badge";
 import { Button } from "~/components/Button";
 import { QueryLink } from "~/components/QueryLink";
 import { Container } from "~/components/Container";
-import { DeleteGroupDialog } from "~/components/groups/DeleteGroupDialog";
 import { Tooltip, TooltipContent, TooltipTrigger } from "~/components/Tooltip";
 import { UpdateAllMembersDialog } from "~/components/groups/UpdateAllMembersDialog";
 import { GroupDetailsNavigation } from "~/components/groups/GroupDetailsNavigation";
@@ -114,7 +113,6 @@ export default async function GroupDetailsLayout(props: PropsWithChildren<PagePr
       </div>
       {children}
       {/* Dialogs */}
-      <DeleteGroupDialog groupId={id} />
       <UpdateAllMembersDialog groupId={id} />
       <ExportGroupMembersDialog groupId={id} />
     </Container>
@@ -171,9 +169,6 @@ function Header(props: GroupDetailsResponse) {
               <Link prefetch={false} href={`/groups/${id}/edit`} rel="nofollow">
                 <DropdownMenuItem>Edit</DropdownMenuItem>
               </Link>
-              <QueryLink query={{ dialog: "delete" }}>
-                <DropdownMenuItem>Delete</DropdownMenuItem>
-              </QueryLink>
               <Link prefetch={false} href={`/competitions/create?groupId=${id}`} rel="nofollow">
                 <DropdownMenuItem>Create group competition</DropdownMenuItem>
               </Link>

--- a/app/src/components/competitions/DeleteCompetitionDialog.tsx
+++ b/app/src/components/competitions/DeleteCompetitionDialog.tsx
@@ -15,6 +15,7 @@ import InfoIcon from "~/assets/info.svg";
 
 interface DeleteCompetitionDialogProps {
   competitionId: number;
+  competitionTitle: string;
 }
 
 export function DeleteCompetitionDialog(props: DeleteCompetitionDialogProps) {
@@ -49,6 +50,7 @@ export function DeleteCompetitionDialog(props: DeleteCompetitionDialogProps) {
         </DialogHeader>
         <DeleteCompetitionForm
           competitionId={props.competitionId}
+          competitionTitle={props.competitionTitle}
           onQuit={handleClose}
           onSubmitted={() => router.push("/competitions")}
         />
@@ -63,12 +65,15 @@ interface DeleteCompetitionFormProps extends DeleteCompetitionDialogProps {
 }
 
 function DeleteCompetitionForm(props: DeleteCompetitionFormProps) {
-  const { competitionId, onQuit, onSubmitted } = props;
+  const { competitionId, competitionTitle, onQuit, onSubmitted } = props;
 
   const toast = useToast();
   const client = useWOMClient();
 
   const [verificationCode, setVerificationCode] = useState("");
+  const [confirmedTitle, setConfirmedTitle] = useState("");
+
+  const hasConfirmedTitle = confirmedTitle.trim() === competitionTitle.trim();
 
   const deleteMutation = useMutation({
     mutationFn: () => {
@@ -87,12 +92,27 @@ function DeleteCompetitionForm(props: DeleteCompetitionFormProps) {
 
   return (
     <form
-      className="mt-2 flex flex-col gap-y-2"
+      className="mt-2 flex flex-col gap-y-5"
       onSubmit={(e) => {
         e.preventDefault();
+        if (!hasConfirmedTitle) return;
         deleteMutation.mutate();
       }}
     >
+      <div className="flex flex-col">
+        <Label className="mb-2 text-xs font-normal text-gray-200" htmlFor="confirmedTitle">
+          Type <span className="font-medium text-white">{competitionTitle}</span> to confirm
+        </Label>
+        <Input
+          id="confirmedTitle"
+          autoFocus
+          name="confirmedTitle"
+          autoComplete="off"
+          placeholder="Enter the competition title"
+          value={confirmedTitle}
+          onChange={(e) => setConfirmedTitle(e.target.value)}
+        />
+      </div>
       <div className="flex flex-col">
         <div className="mb-2 flex items-center">
           <Label className="text-xs font-normal text-gray-200" htmlFor="verificationCode">
@@ -119,7 +139,6 @@ function DeleteCompetitionForm(props: DeleteCompetitionFormProps) {
         </div>
         <Input
           id="verificationCode"
-          autoFocus
           type="password"
           name="verificationCode"
           autoComplete="verificationCode"
@@ -134,7 +153,7 @@ function DeleteCompetitionForm(props: DeleteCompetitionFormProps) {
           <Button
             variant="red"
             type="submit"
-            disabled={verificationCode.length === 0 || deleteMutation.isPending}
+            disabled={!hasConfirmedTitle || verificationCode.length === 0 || deleteMutation.isPending}
           >
             {deleteMutation.isPending ? "Deleting..." : "Delete"}
           </Button>

--- a/app/src/components/competitions/EditCompetitionForm.tsx
+++ b/app/src/components/competitions/EditCompetitionForm.tsx
@@ -18,13 +18,14 @@ import { cn } from "~/utils/styling";
 import { Button } from "../Button";
 import { Container } from "../Container";
 import { QueryLink } from "../QueryLink";
-import { Alert, AlertDescription } from "../Alert";
+import { Alert, AlertDescription, AlertTitle } from "../Alert";
 import { Tabs, TabsList, TabsTrigger } from "../Tabs";
 import { CompetitionInfoForm } from "./CompetitionInfoForm";
 import { CompetitionTeamsForm } from "./CompetitionTeamsForm";
 import { CompetitionParticipantsForm } from "./CompetitionParticipantsForm";
 import { GroupVerificationCodeCheckDialog } from "../groups/GroupVerificationCodeCheckDialog";
 import { CompetitionVerificationCodeCheckDialog } from "./CompetitionVerificationCodeCheckDialog";
+import { DeleteCompetitionDialog } from "./DeleteCompetitionDialog";
 
 import LoadingIcon from "~/assets/loading.svg";
 import WarningIcon from "~/assets/warning.svg";
@@ -62,14 +63,12 @@ export function EditCompetitionForm(props: EditCompetitionFormProps) {
         <div className="col-span-7 flex pt-7">
           {section === "teams" ? (
             <TeamsSection {...props} verificationCode={verificationCode ?? ""} />
+          ) : section === "participants" ? (
+            <ParticipantsSection {...props} verificationCode={verificationCode ?? ""} />
+          ) : section === "danger" ? (
+            <DangerZoneSection {...props} />
           ) : (
-            <>
-              {section === "participants" ? (
-                <ParticipantsSection {...props} verificationCode={verificationCode ?? ""} />
-              ) : (
-                <GeneralSection {...props} verificationCode={verificationCode ?? ""} />
-              )}
-            </>
+            <GeneralSection {...props} verificationCode={verificationCode ?? ""} />
           )}
         </div>
       </div>
@@ -114,6 +113,11 @@ function SideNavigation(props: { type: CompetitionType }) {
                 <TabsTrigger value="teams">Teams</TabsTrigger>
               </QueryLink>
             )}
+            <QueryLink query={{ section: "danger" }}>
+              <TabsTrigger value="danger" className="text-red-500 data-[state=active]:text-red-500">
+                Danger zone
+              </TabsTrigger>
+            </QueryLink>
           </TabsList>
         </Tabs>
       </div>
@@ -160,6 +164,17 @@ function SideNavigation(props: { type: CompetitionType }) {
             </li>
           </QueryLink>
         )}
+        <QueryLink query={{ section: "danger" }}>
+          <li
+            className={cn(
+              "relative overflow-hidden rounded px-4 py-3 text-sm text-red-500 hover:bg-gray-800 active:bg-gray-600",
+              section === "danger" && "bg-gray-700",
+            )}
+          >
+            {section === "danger" && <div className="absolute bottom-0 left-0 top-0 w-0.5 bg-red-500" />}
+            Danger zone
+          </li>
+        </QueryLink>
       </ul>
     </>
   );
@@ -233,6 +248,32 @@ function GeneralSection(props: EditCompetitionFormProps & { verificationCode: st
           </div>
         )}
       />
+    </div>
+  );
+}
+
+function DangerZoneSection(props: EditCompetitionFormProps) {
+  const { competition } = props;
+
+  return (
+    <div className="flex w-full flex-col">
+      <Alert variant="error">
+        <AlertTitle>Delete competition</AlertTitle>
+        <AlertDescription className="mt-3">
+          <p>
+            This action cannot be undone. This will permanently delete this competition and all its data.
+          </p>
+
+          <div className="mt-5">
+            <QueryLink query={{ dialog: "delete" }}>
+              <Button variant="red">Delete competition</Button>
+            </QueryLink>
+          </div>
+        </AlertDescription>
+      </Alert>
+
+      {/* Dialogs */}
+      <DeleteCompetitionDialog competitionId={competition.id} />
     </div>
   );
 }

--- a/app/src/components/competitions/EditCompetitionForm.tsx
+++ b/app/src/components/competitions/EditCompetitionForm.tsx
@@ -273,7 +273,7 @@ function DangerZoneSection(props: EditCompetitionFormProps) {
       </Alert>
 
       {/* Dialogs */}
-      <DeleteCompetitionDialog competitionId={competition.id} />
+      <DeleteCompetitionDialog competitionId={competition.id} competitionTitle={competition.title} />
     </div>
   );
 }

--- a/app/src/components/groups/DeleteGroupDialog.tsx
+++ b/app/src/components/groups/DeleteGroupDialog.tsx
@@ -15,6 +15,7 @@ import InfoIcon from "~/assets/info.svg";
 
 interface DeleteGroupDialogProps {
   groupId: number;
+  groupName: string;
 }
 
 export function DeleteGroupDialog(props: DeleteGroupDialogProps) {
@@ -47,6 +48,7 @@ export function DeleteGroupDialog(props: DeleteGroupDialogProps) {
         </DialogHeader>
         <DeleteGroupForm
           groupId={props.groupId}
+          groupName={props.groupName}
           onQuit={() => handleClose()}
           onSubmitted={() => router.push("/groups")}
         />
@@ -61,12 +63,15 @@ interface DeleteGroupFormProps extends DeleteGroupDialogProps {
 }
 
 function DeleteGroupForm(props: DeleteGroupFormProps) {
-  const { groupId, onQuit, onSubmitted } = props;
+  const { groupId, groupName, onQuit, onSubmitted } = props;
 
   const toast = useToast();
   const client = useWOMClient();
 
   const [verificationCode, setVerificationCode] = useState("");
+  const [confirmedName, setConfirmedName] = useState("");
+
+  const hasConfirmedName = confirmedName.trim() === groupName.trim();
 
   const deleteMutation = useMutation({
     mutationFn: () => {
@@ -85,12 +90,27 @@ function DeleteGroupForm(props: DeleteGroupFormProps) {
 
   return (
     <form
-      className="mt-2 flex flex-col gap-y-2"
+      className="mt-2 flex flex-col gap-y-5"
       onSubmit={(e) => {
         e.preventDefault();
+        if (!hasConfirmedName) return;
         deleteMutation.mutate();
       }}
     >
+      <div className="flex flex-col">
+        <Label className="mb-2 text-xs font-normal text-gray-200" htmlFor="confirmedName">
+          Type <span className="font-medium text-white">{groupName}</span> to confirm
+        </Label>
+        <Input
+          id="confirmedName"
+          autoFocus
+          name="confirmedName"
+          autoComplete="off"
+          placeholder="Enter the group name"
+          value={confirmedName}
+          onChange={(e) => setConfirmedName(e.target.value)}
+        />
+      </div>
       <div className="flex flex-col">
         <div className="mb-2 flex items-center">
           <Label className="text-xs font-normal text-gray-200" htmlFor="verificationCode">
@@ -117,7 +137,6 @@ function DeleteGroupForm(props: DeleteGroupFormProps) {
         </div>
         <Input
           id="verificationCode"
-          autoFocus
           type="password"
           name="verificationCode"
           autoComplete="verificationCode"
@@ -132,7 +151,7 @@ function DeleteGroupForm(props: DeleteGroupFormProps) {
           <Button
             variant="red"
             type="submit"
-            disabled={verificationCode.length === 0 || deleteMutation.isPending}
+            disabled={!hasConfirmedName || verificationCode.length === 0 || deleteMutation.isPending}
           >
             {deleteMutation.isPending ? "Deleting..." : "Delete"}
           </Button>

--- a/app/src/components/groups/EditGroupForm.tsx
+++ b/app/src/components/groups/EditGroupForm.tsx
@@ -657,9 +657,7 @@ function DangerZoneSection(props: EditGroupFormProps) {
       <Alert variant="error">
         <AlertTitle>Delete group</AlertTitle>
         <AlertDescription className="mt-3">
-          <p>
-            This action cannot be undone. This will permanently delete this group and all its data.
-          </p>
+          <p>This action cannot be undone. This will permanently delete this group and all its data.</p>
 
           <div className="mt-5">
             <QueryLink query={{ dialog: "delete" }}>

--- a/app/src/components/groups/EditGroupForm.tsx
+++ b/app/src/components/groups/EditGroupForm.tsx
@@ -668,7 +668,7 @@ function DangerZoneSection(props: EditGroupFormProps) {
       </Alert>
 
       {/* Dialogs */}
-      <DeleteGroupDialog groupId={group.id} />
+      <DeleteGroupDialog groupId={group.id} groupName={group.name} />
     </div>
   );
 }

--- a/app/src/components/groups/EditGroupForm.tsx
+++ b/app/src/components/groups/EditGroupForm.tsx
@@ -43,6 +43,7 @@ import { EmptyGroupDialog } from "./EmptyGroupDialog";
 import { Input } from "../Input";
 import { BannerImageUpload, ProfileImageUpload } from "../ImageUpload";
 import { GroupVerificationCodeCheckDialog } from "./GroupVerificationCodeCheckDialog";
+import { DeleteGroupDialog } from "./DeleteGroupDialog";
 
 import WebIcon from "~/assets/web.svg";
 import TwitchIcon from "~/assets/twitch.svg";
@@ -112,6 +113,7 @@ export function EditGroupForm(props: EditGroupFormProps) {
               verificationCode={verificationCode || ""}
             />
           )}
+          {section === "danger" && <DangerZoneSection {...props} key={group.updatedAt.toString()} />}
         </div>
       </div>
 
@@ -647,6 +649,32 @@ function GeneralSection(props: EditGroupFormProps & { verificationCode: string }
   );
 }
 
+function DangerZoneSection(props: EditGroupFormProps) {
+  const { group } = props;
+
+  return (
+    <div className="flex w-full flex-col">
+      <Alert variant="error">
+        <AlertTitle>Delete group</AlertTitle>
+        <AlertDescription className="mt-3">
+          <p>
+            This action cannot be undone. This will permanently delete this group and all its data.
+          </p>
+
+          <div className="mt-5">
+            <QueryLink query={{ dialog: "delete" }}>
+              <Button variant="red">Delete group</Button>
+            </QueryLink>
+          </div>
+        </AlertDescription>
+      </Alert>
+
+      {/* Dialogs */}
+      <DeleteGroupDialog groupId={group.id} />
+    </div>
+  );
+}
+
 interface SideNavigationProps {
   isPatron: boolean;
 }
@@ -660,6 +688,7 @@ function SideNavigation(props: SideNavigationProps) {
     { name: "Members", value: "members" },
     { name: "Profile images", value: "images" },
     { name: "Social links", value: "links" },
+    { name: "Danger zone", value: "danger" },
   ];
 
   return (
@@ -669,7 +698,10 @@ function SideNavigation(props: SideNavigationProps) {
           <TabsList>
             {sections.map((s) => (
               <QueryLink key={s.value} query={{ section: s.value }}>
-                <TabsTrigger value={s.value}>
+                <TabsTrigger
+                  value={s.value}
+                  className={cn(s.value === "danger" && "text-red-500 data-[state=active]:text-red-500")}
+                >
                   {s.name}
                   {!props.isPatron && (s.value === "images" || s.value === "links") && (
                     <div className="ml-2 h-1.5 w-1.5 rounded-full bg-yellow-400" />
@@ -689,10 +721,19 @@ function SideNavigation(props: SideNavigationProps) {
               <li
                 className={cn(
                   "relative flex items-center justify-between overflow-hidden rounded px-4 py-3 text-sm text-gray-200 hover:bg-gray-800 active:bg-gray-600",
+                  s.value === "danger" && "text-red-500",
                   isSelected && "bg-gray-700 text-white",
+                  isSelected && s.value === "danger" && "text-red-500",
                 )}
               >
-                {isSelected && <div className="absolute bottom-0 left-0 top-0 w-0.5 bg-blue-500" />}
+                {isSelected && (
+                  <div
+                    className={cn(
+                      "absolute bottom-0 left-0 top-0 w-0.5 bg-blue-500",
+                      s.value === "danger" && "bg-red-500",
+                    )}
+                  />
+                )}
                 {s.name}
                 {!props.isPatron && (s.value === "images" || s.value === "links") && (
                   <div className="h-1.5 w-1.5 rounded-full bg-yellow-400" />


### PR DESCRIPTION
Closes #1837.

## Summary

Moves the "delete" action for both **groups** and **competitions** out of the details actions dropdown (where it was easy to trigger accidentally) and into a new **Danger zone** section on the respective **edit** page, behind the existing verification-code gate.

### Groups

- Removed the **Delete** item from the group details `...` actions menu.
- Added a **Danger zone** entry to the edit page side navigation, styled in red (`text-red-500`, matching the active accent bar).
- The Danger zone is presented as a card (reusing the existing `Alert` `error` variant) with the deletion warning and a red **Delete group** button.
- The delete flow itself is unchanged — the existing `DeleteGroupDialog` still requires re-entering the verification code before anything is deleted.

### Competitions

- Removed the **Delete** item from the competition details `...` actions menu.
- Added a matching **Danger zone** entry to the competition edit page side navigation (both the desktop list and the mobile tabs), styled in red.
- The Danger zone reuses the same `Alert` `error` card with a red **Delete competition** button.
- The delete flow is unchanged — the existing `DeleteCompetitionDialog` still requires re-entering the verification code before anything is deleted.

Because both edit pages are already gated by a verification-code check, the delete entry points are only reachable after owner verification.

## Screenshots

**Group edit page – General section (note the red "Danger zone" nav item):**

<img width="996" height="508" alt="image" src="https://github.com/user-attachments/assets/18846b93-a14c-49a7-81a1-98ed58ceebaa" />

**Group edit page – Danger zone section:**

<img width="983" height="406" alt="image" src="https://github.com/user-attachments/assets/1f0a57e1-521b-42b1-add0-82d186cc2567" />

**Group details actions menu – "Delete" removed (only Edit / Create group competition remain):**

<img width="1230" height="183" alt="image" src="https://github.com/user-attachments/assets/23e8f42c-17cd-4a46-8e6b-9a0429ce9f78" />
