### PR TITLE
Add multi-metric competition support (frontend + client-js)

### DIFF
--- a/app/src/components/competitions/CompetitionInfoForm.tsx
+++ b/app/src/components/competitions/CompetitionInfoForm.tsx
@@ -5,6 +5,7 @@ import {
   ACTIVITIES,
   BOSSES,
   COMPUTED_METRICS,
+  CreateCompetitionPayload,
   Metric,
   MetricProps,
   MetricType,
@@ -47,12 +48,10 @@ const METRIC_GROUPS: Array<{ type: MetricType; label: string; metrics: Metric[] 
 ];
 
 type TimezoneOption = "utc" | "local";
-type Payload = {
-  title: string;
-  metrics: Metric[];
-  startsAt: Date;
-  endsAt: Date;
-};
+// `metrics` is optional on CreateCompetitionPayload (the deprecated `metric` alias is kept for
+// backwards compatibility), but the form always works with a concrete list, so require it here.
+type Payload = Pick<CreateCompetitionPayload, "title" | "startsAt" | "endsAt"> &
+  Required<Pick<CreateCompetitionPayload, "metrics">>;
 
 interface CompetitionInfoFormProps {
   mode: "create" | "edit";

--- a/app/src/components/competitions/CompetitionInfoForm.tsx
+++ b/app/src/components/competitions/CompetitionInfoForm.tsx
@@ -5,13 +5,13 @@ import {
   ACTIVITIES,
   BOSSES,
   COMPUTED_METRICS,
-  CreateCompetitionPayload,
   Metric,
   MetricProps,
+  MetricType,
   SKILLS,
   isMetric,
 } from "@wise-old-man/utils";
-import { useMemo, useState } from "react";
+import { Fragment, useMemo, useState } from "react";
 import { DateValue, TimeValue } from "react-aria";
 import { useHasMounted } from "~/hooks/useHasMounted";
 import {
@@ -31,14 +31,28 @@ import { MetricIconSmall } from "../Icon";
 import { Input } from "../Input";
 import { Label } from "../Label";
 import { Alert, AlertDescription } from "../Alert";
+import { Badge } from "../Badge";
 
 import LoadingIcon from "~/assets/loading.svg";
 import ChevronDownIcon from "~/assets/chevron_down.svg";
+import CloseIcon from "~/assets/close.svg";
 
 const MAX_NAME_LENGTH = 50;
 
+const METRIC_GROUPS: Array<{ type: MetricType; label: string; metrics: Metric[] }> = [
+  { type: MetricType.SKILL, label: "Skills", metrics: SKILLS },
+  { type: MetricType.BOSS, label: "Bosses", metrics: BOSSES },
+  { type: MetricType.ACTIVITY, label: "Activities", metrics: ACTIVITIES },
+  { type: MetricType.COMPUTED, label: "Computed", metrics: COMPUTED_METRICS },
+];
+
 type TimezoneOption = "utc" | "local";
-type Payload = Pick<CreateCompetitionPayload, "title" | "metric" | "startsAt" | "endsAt">;
+type Payload = {
+  title: string;
+  metrics: Metric[];
+  startsAt: Date;
+  endsAt: Date;
+};
 
 interface CompetitionInfoFormProps {
   mode: "create" | "edit";
@@ -58,7 +72,7 @@ export function CompetitionInfoForm(props: CompetitionInfoFormProps) {
   const hasMounted = useHasMounted();
 
   const [title, setTitle] = useState(competition.title);
-  const [metric, setMetric] = useState(competition.metric);
+  const [metrics, setMetrics] = useState(competition.metrics);
 
   const timezoneOffset = useMemo(() => {
     return timezone === "utc" ? new Date().getTimezoneOffset() * 60_000 : 0;
@@ -81,7 +95,7 @@ export function CompetitionInfoForm(props: CompetitionInfoFormProps) {
 
   const hasUnsavedChanges = checkUnsavedChanges(
     competition,
-    { title, metric, startsAt: toDate(startDate, startTime), endsAt: toDate(endDate, endTime) },
+    { title, metrics, startsAt: toDate(startDate, startTime), endsAt: toDate(endDate, endTime) },
     timezone,
   );
 
@@ -95,7 +109,7 @@ export function CompetitionInfoForm(props: CompetitionInfoFormProps) {
     const startsAt = new Date(toDate(startDate, startTime).getTime() + timezoneOffset);
     const endsAt = new Date(toDate(endDate, endTime).getTime() + timezoneOffset);
 
-    onCompetitionChanged({ ...competition, title, metric, startsAt, endsAt });
+    onCompetitionChanged({ ...competition, title, metrics, startsAt, endsAt });
   }
 
   if (!hasMounted) {
@@ -134,9 +148,13 @@ export function CompetitionInfoForm(props: CompetitionInfoFormProps) {
       </div>
       <div>
         <Label htmlFor="title" className="mb-2 block text-xs text-gray-200">
-          Metric
+          Metrics
         </Label>
-        <MetricSelect metric={metric} onMetricSelected={setMetric} />
+        <MetricSelect metrics={metrics} onMetricsChanged={setMetrics} />
+        <p className="mt-2 text-xs text-gray-200">
+          All metrics in a competition must be of the same type. To switch to a different type, remove
+          your currently selected metrics first.
+        </p>
       </div>
       <div className="overflow-hidden rounded-md border border-gray-500 bg-gray-800">
         <div className="border-b border-gray-500 p-4">
@@ -193,6 +211,7 @@ export function CompetitionInfoForm(props: CompetitionInfoFormProps) {
       {/* Allow the parent pages to render what they need on the actions slot (Previous/Next or Save) */}
       {props.formActions(
         title.length === 0 ||
+          metrics.length === 0 ||
           !isEndDateAfterStartDate ||
           (mode === "create" && (hasPastStartDate || hasPastEndDate)),
         hasUnsavedChanges,
@@ -235,73 +254,100 @@ function TimezoneSelector(props: TimezoneSelectorProps) {
 }
 
 interface MetricSelectProps {
-  metric: Metric;
-  onMetricSelected: (metric: Metric) => void;
+  metrics: Metric[];
+  onMetricsChanged: (metrics: Metric[]) => void;
 }
 
 function MetricSelect(props: MetricSelectProps) {
-  const { metric, onMetricSelected } = props;
+  const { metrics, onMetricsChanged } = props;
+
+  const selectedType = metrics.length > 0 ? MetricProps[metrics[0]].type : undefined;
+  const selectedSet = new Set(metrics);
+
+  // Once a metric is selected, only metrics of that same type can be added. To switch to a
+  // different type, the user must first remove all of their currently selected metrics.
+  const availableGroups =
+    selectedType === undefined
+      ? METRIC_GROUPS
+      : METRIC_GROUPS.filter((group) => group.type === selectedType);
+
+  function handleSelect(metric: Metric) {
+    if (selectedSet.has(metric)) {
+      handleRemove(metric);
+    } else {
+      onMetricsChanged([...metrics, metric]);
+    }
+  }
+
+  function handleRemove(metric: Metric) {
+    onMetricsChanged(metrics.filter((m) => m !== metric));
+  }
 
   return (
-    <>
+    <div className="flex flex-col gap-y-3">
       <Combobox
-        value={metric}
+        value={undefined}
         onValueChanged={(val) => {
-          if (val === undefined) {
-            onMetricSelected(Metric.OVERALL);
-          } else if (isMetric(val)) {
-            onMetricSelected(val);
+          if (val !== undefined && isMetric(val)) {
+            handleSelect(val);
           }
         }}
       >
         <ComboboxButton className="w-full bg-gray-800 hover:bg-gray-700">
-          <div className="flex items-center gap-x-2">
-            <MetricIconSmall metric={metric} />
-            <span className="line-clamp-1 text-left">{MetricProps[metric].name} </span>
-          </div>
+          <span className="line-clamp-1 text-left text-gray-100">
+            {metrics.length === 0 ? "Select a metric..." : "Add another metric..."}
+          </span>
         </ComboboxButton>
-        <ComboboxContent className="max-h-64">
+        <ComboboxContent>
           <ComboboxInput placeholder="Search metrics..." />
           <ComboboxEmpty>No results were found</ComboboxEmpty>
           <ComboboxItemsContainer>
-            <ComboboxItemGroup label="Skills">
-              {SKILLS.map((skill) => (
-                <ComboboxItem key={skill} value={skill}>
-                  <MetricIconSmall metric={skill} />
-                  {MetricProps[skill].name}
-                </ComboboxItem>
-              ))}
-            </ComboboxItemGroup>
-            <ComboboxSeparator />
-            <ComboboxItemGroup label="Bosses">
-              {BOSSES.map((boss) => (
-                <ComboboxItem key={boss} value={boss}>
-                  <MetricIconSmall metric={boss} />
-                  {MetricProps[boss].name}
-                </ComboboxItem>
-              ))}
-            </ComboboxItemGroup>
-            <ComboboxSeparator />
-            <ComboboxItemGroup label="Activities">
-              {ACTIVITIES.map((activity) => (
-                <ComboboxItem key={activity} value={activity}>
-                  <MetricIconSmall metric={activity} />
-                  {MetricProps[activity].name}
-                </ComboboxItem>
-              ))}
-            </ComboboxItemGroup>
-            <ComboboxItemGroup label="Computed">
-              {COMPUTED_METRICS.map((computed) => (
-                <ComboboxItem key={computed} value={computed}>
-                  <MetricIconSmall metric={computed} />
-                  {MetricProps[computed].name}
-                </ComboboxItem>
-              ))}
-            </ComboboxItemGroup>
+            {availableGroups.map((group, index) => {
+              const options = group.metrics.filter((metric) => !selectedSet.has(metric));
+
+              if (options.length === 0) return null;
+
+              return (
+                <Fragment key={group.type}>
+                  {index > 0 && <ComboboxSeparator />}
+                  <ComboboxItemGroup label={group.label}>
+                    {options.map((metric) => (
+                      <ComboboxItem key={metric} value={metric}>
+                        <MetricIconSmall metric={metric} />
+                        {MetricProps[metric].name}
+                      </ComboboxItem>
+                    ))}
+                  </ComboboxItemGroup>
+                </Fragment>
+              );
+            })}
           </ComboboxItemsContainer>
         </ComboboxContent>
       </Combobox>
-    </>
+
+      {metrics.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {metrics.map((metric) => (
+            <Badge
+              key={metric}
+              variant="outline"
+              className="flex items-center gap-x-1.5 py-1 pl-1.5 pr-1"
+            >
+              <MetricIconSmall metric={metric} />
+              <span className="text-xs font-medium text-white">{MetricProps[metric].name}</span>
+              <button
+                type="button"
+                aria-label={`Remove ${MetricProps[metric].name}`}
+                onClick={() => handleRemove(metric)}
+                className="rounded-full p-0.5 text-gray-200 transition-colors hover:bg-gray-500 hover:text-white"
+              >
+                <CloseIcon className="h-3 w-3" />
+              </button>
+            </Badge>
+          ))}
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -327,8 +373,15 @@ function checkUnsavedChanges(previous: Payload, next: Payload, timezone: Timezon
 
   return (
     previous.title !== next.title ||
-    previous.metric !== next.metric ||
+    !haveSameMetrics(previous.metrics, next.metrics) ||
     previous.startsAt.getTime() !== startsAt.getTime() ||
     previous.endsAt.getTime() !== endsAt.getTime()
   );
+}
+
+function haveSameMetrics(previous: Metric[], next: Metric[]) {
+  if (previous.length !== next.length) return false;
+
+  const nextSet = new Set(next);
+  return previous.every((metric) => nextSet.has(metric));
 }

--- a/app/src/components/competitions/CreateCompetitionForm.tsx
+++ b/app/src/components/competitions/CreateCompetitionForm.tsx
@@ -8,7 +8,6 @@ import {
   CreateCompetitionPayload,
   GroupDetailsResponse,
   GroupResponse,
-  Metric,
 } from "@wise-old-man/utils";
 import { cn } from "~/utils/styling";
 import { useToast } from "~/hooks/useToast";
@@ -48,7 +47,7 @@ export function CreateCompetitionForm(props: CreateCompetitionFormProps) {
 
   const [competition, setCompetition] = useState<CreateCompetitionPayload>({
     title: "",
-    metric: Metric.OVERALL,
+    metrics: [],
     startsAt: getDefaultStartDate(),
     endsAt: getDefaultEndDate(),
     participants: [],
@@ -115,7 +114,12 @@ export function CreateCompetitionForm(props: CreateCompetitionFormProps) {
           <CompetitionInfoForm
             mode="create"
             timezone={timezone}
-            competition={competition}
+            competition={{
+              title: competition.title,
+              metrics: competition.metrics ?? [],
+              startsAt: competition.startsAt,
+              endsAt: competition.endsAt,
+            }}
             onTimezoneChanged={(tz) => {
               setTimezone(tz);
             }}

--- a/app/src/components/competitions/EditCompetitionForm.tsx
+++ b/app/src/components/competitions/EditCompetitionForm.tsx
@@ -178,7 +178,7 @@ function GeneralSection(props: EditCompetitionFormProps & { verificationCode: st
   const [timezone, setTimezone] = useState<TimezoneOption>("local");
 
   const editGeneralMutation = useMutation({
-    mutationFn: (payload: { title: string; metric: Metric; startsAt: Date; endsAt: Date }) => {
+    mutationFn: (payload: { title: string; metrics: Metric[]; startsAt: Date; endsAt: Date }) => {
       return client.competitions.editCompetition(competition.id, payload, verificationCode);
     },
     onSuccess: () => {
@@ -199,13 +199,18 @@ function GeneralSection(props: EditCompetitionFormProps & { verificationCode: st
       <CompetitionInfoForm
         mode="edit"
         timezone={timezone}
-        competition={competition}
+        competition={{
+          title: competition.title,
+          metrics: competition.metrics.map((m) => m.metric),
+          startsAt: competition.startsAt,
+          endsAt: competition.endsAt,
+        }}
         onTimezoneChanged={(tz) => {
           setTimezone(tz);
         }}
         onCompetitionChanged={(payload) => {
-          const { title, metric, startsAt, endsAt } = payload;
-          editGeneralMutation.mutate({ title, metric, startsAt, endsAt });
+          const { title, metrics, startsAt, endsAt } = payload;
+          editGeneralMutation.mutate({ title, metrics, startsAt, endsAt });
         }}
         formActions={(disabled, hasUnsavedChanges) => (
           <div className={cn("flex", hasUnsavedChanges ? "justify-between" : "justify-end")}>

--- a/client-js/package-lock.json
+++ b/client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "4.0.22",
+  "version": "4.0.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wise-old-man/utils",
-      "version": "4.0.22",
+      "version": "4.0.23",
       "license": "ISC",
       "devDependencies": {
         "@rollup/plugin-typescript": "^11.1.6",

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wise-old-man/utils",
-  "version": "4.0.22",
+  "version": "4.0.23",
   "description": "A JavaScript/TypeScript client that interfaces and consumes the Wise Old Man API, an API that tracks and measures players' progress in Old School Runescape.",
   "keywords": [
     "wiseoldman",

--- a/client-js/src/api-types.ts
+++ b/client-js/src/api-types.ts
@@ -70,7 +70,12 @@ export type EditGroupPayload = Partial<CreateGroupPayload> & {
 
 export type CreateCompetitionPayload = {
   title: string;
-  metric: Metric;
+  /**
+   * @deprecated Use `metrics` instead. Kept for backwards compatibility and will be removed in a
+   * future version. When both are provided, `metrics` takes precedence. Equivalent to `metrics[0]`.
+   */
+  metric?: Metric;
+  metrics?: Metric[];
   startsAt: Date;
   endsAt: Date;
   groupId?: number;
@@ -86,7 +91,12 @@ export type CreateCompetitionPayload = {
 
 export type EditCompetitionPayload = {
   title?: string;
+  /**
+   * @deprecated Use `metrics` instead. Kept for backwards compatibility and will be removed in a
+   * future version. When both are provided, `metrics` takes precedence. Equivalent to `metrics[0]`.
+   */
   metric?: Metric;
+  metrics?: Metric[];
   startsAt?: Date;
   endsAt?: Date;
   participants?: string[];


### PR DESCRIPTION
Implements the frontend + client-js write path for competitions that track multiple metrics (#817).

## Context

The backend already supports multi-metric competitions (a `competitionMetrics` join table, per-metric plus aggregated `total` deltas, scoring, and integration coverage), gated behind the `SERVER_API_FEATURE_FLAG_MULTI_METRIC_COMPETITIONS` flag. This PR adds the missing write path so multi-metric competitions can actually be created/edited from the app.

## Changes

**app**
- `CompetitionInfoForm`: the single-metric picker is now a same-type-constrained multi-select — an "add" combobox plus removable chips. Once a metric is selected, only metrics of that same type are offered; to switch types you remove the current selection first. At least one metric is required before proceeding.
- `CreateCompetitionForm` / `EditCompetitionForm`: build and submit `metrics[]`. The create form starts with no metric pre-selected; the edit form seeds from the competition's existing metrics.

**client-js** (bumped to `4.0.23`)
- `CreateCompetitionPayload` / `EditCompetitionPayload` gain a `metrics: Metric[]` field. The single `metric` field is kept as a **deprecated alias** for backwards compatibility (the API already normalizes `metric` → `metrics`).

## Notes

- **No backend changes** — multi-metric creation stays gated behind `SERVER_API_FEATURE_FLAG_MULTI_METRIC_COMPETITIONS` until it's enabled.
- **Release ordering:** the app consumes `@wise-old-man/utils` from npm, so client-js `4.0.23` should be published before the app build picks up the new payload types.

## Testing

- `tsc` + ESLint clean for both `app` and `client-js`.
- Verified the picker in the running app: multi-select, type-switching, chip removal, and search filtering.
- Ran the competitions integration suite locally — passing.
