### PR TITLE
[server] Skip persisting 5min and yearly cached deltas 

### DIFF
--- a/server/__tests__/suites/integration/deltas.test.ts
+++ b/server/__tests__/suites/integration/deltas.test.ts
@@ -174,17 +174,19 @@ describe('Deltas API', () => {
         where: { playerId: firstTrackResponse.body.id }
       });
 
-      expect(secondCachedDeltas.length).toBe(12);
-      expect(secondCachedDeltas.filter(c => c.metric === Metric.EHP && c.value > 0.1).length).toBe(3);
-      expect(secondCachedDeltas.filter(c => c.metric === Metric.EHB && c.value > 0.1).length).toBe(3);
-      expect(secondCachedDeltas.filter(c => c.metric === Metric.NEX && c.value === 53).length).toBe(3);
+      /**
+       * Note, although 3 periods were synced, only 2 (week & day) were persisted into CacheDeltas
+       */
+      expect(secondCachedDeltas.length).toBe(8);
+      expect(secondCachedDeltas.filter(c => c.metric === Metric.EHP && c.value > 0.1).length).toBe(2);
+      expect(secondCachedDeltas.filter(c => c.metric === Metric.EHB && c.value > 0.1).length).toBe(2);
+      expect(secondCachedDeltas.filter(c => c.metric === Metric.NEX && c.value === 53).length).toBe(2);
 
       const smithingCachedDeltas = secondCachedDeltas.filter(c => c.metric === Metric.SMITHING);
-      expect(smithingCachedDeltas.length).toBe(3);
-      expect(smithingCachedDeltas.filter(c => c.value === 50_000).length).toBe(3);
+      expect(smithingCachedDeltas.length).toBe(2);
+      expect(smithingCachedDeltas.filter(c => c.value === 50_000).length).toBe(2);
       expect(smithingCachedDeltas.map(c => c.period)).toContain('week');
       expect(smithingCachedDeltas.map(c => c.period)).toContain('month');
-      expect(smithingCachedDeltas.map(c => c.period)).toContain('year');
 
       // All deltas' end snapshot is the latest one
       expect(secondCachedDeltas.filter(d => Date.now() - d.endedAt.getTime() > 10_000).length).toBe(0);

--- a/server/src/jobs/handlers/sync-player-deltas.job.ts
+++ b/server/src/jobs/handlers/sync-player-deltas.job.ts
@@ -97,8 +97,10 @@ export const SyncPlayerDeltasJobHandler: JobHandler<Payload> = {
       }
     }
 
+    const shouldPersist = SUPPORTED_CACHED_DELTA_PERIODS.includes(period);
+
     if (newDeltaValueMap.size === 0) {
-      if (!SUPPORTED_CACHED_DELTA_PERIODS.includes(period)) {
+      if (!shouldPersist) {
         return;
       }
 
@@ -113,8 +115,8 @@ export const SyncPlayerDeltasJobHandler: JobHandler<Payload> = {
       return;
     }
 
-    if (SUPPORTED_CACHED_DELTA_PERIODS.includes(period)) {
-      const newCachedDeltas = Array.from(newDeltaValueMap.entries()).map(([metric, value]) => ({
+    if (shouldPersist) {
+      const newCachedDeltas = Array.from(newDeltaValueMap, ([metric, value]) => ({
         playerId: player.id,
         period,
         startedAt: startSnapshot.createdAt,
@@ -157,7 +159,7 @@ export const SyncPlayerDeltasJobHandler: JobHandler<Payload> = {
         username,
         period,
         startSnapshotDate: startSnapshot.createdAt,
-        deltas: Array.from(newDeltaValueMap.entries().map(([metric, value]) => ({ metric, value })))
+        deltas: Array.from(newDeltaValueMap, ([metric, value]) => ({ metric, value }))
       });
     }
   }

--- a/server/src/jobs/handlers/sync-player-deltas.job.ts
+++ b/server/src/jobs/handlers/sync-player-deltas.job.ts
@@ -1,12 +1,18 @@
 import { calculatePlayerDeltas } from '../../api/modules/deltas/delta.utils';
 import prisma from '../../prisma';
-import { CachedDelta, Metric, METRICS, Period } from '../../types';
+import { Metric, METRICS, Period } from '../../types';
 import { selectRequiredSnapshotFields } from '../../utils/get-required-snapshot-fields.util';
-import { pick } from '../../utils/pick.util';
 import { prepareDecimalValue } from '../../utils/prepare-decimal-value.util';
 import { isActivity, isBoss, isComputedMetric, isSkill, PeriodProps } from '../../utils/shared';
 import { JobHandler, JobHandlerContext } from '../types/job-handler.type';
 import { JobType } from '../types/job-type.enum';
+
+/**
+ * Previously, we were persiting deltas for all periods, but we actually only showed 3 of them on the website.
+ * Considering yearly cached deltas accounted for 63% of disk usage and Postgres churn, it's best to
+ * only persist the deltas that are actually used on the website.
+ */
+const SUPPORTED_CACHED_DELTA_PERIODS = [Period.DAY, Period.WEEK, Period.MONTH];
 
 interface Payload {
   username: string;
@@ -42,6 +48,10 @@ export const SyncPlayerDeltasJobHandler: JobHandler<Payload> = {
 
     const [previousDeltas, startSnapshot] = await Promise.all([
       prisma.cachedDelta.findMany({
+        select: {
+          metric: true,
+          value: true
+        },
         where: {
           playerId: player.id,
           period
@@ -64,21 +74,10 @@ export const SyncPlayerDeltasJobHandler: JobHandler<Payload> = {
       return;
     }
 
-    const previousCachedDeltasMap = new Map<Metric, CachedDelta>(
-      previousDeltas.map(cachedDelta => [cachedDelta.metric, cachedDelta])
-    );
-
-    const newCachedDeltasMap = new Map<Metric, CachedDelta>();
+    const previousDeltaValueMap = new Map(previousDeltas.map(c => [c.metric, c.value]));
+    const newDeltaValueMap = new Map<Metric, number>();
 
     const periodDiffs = calculatePlayerDeltas(startSnapshot, latestSnapshot, player);
-
-    const commonProps = {
-      playerId: player.id,
-      period,
-      startedAt: startSnapshot.createdAt,
-      endedAt: latestSnapshot.createdAt,
-      updatedAt: new Date()
-    };
 
     for (const metric of METRICS) {
       let value = 0;
@@ -94,16 +93,16 @@ export const SyncPlayerDeltasJobHandler: JobHandler<Payload> = {
       }
 
       if (value > 0) {
-        newCachedDeltasMap.set(metric, {
-          ...commonProps,
-          metric,
-          value
-        });
+        newDeltaValueMap.set(metric, value);
       }
     }
 
-    // If has no gains in any metric, clear all deltas for this period and return early
-    if (newCachedDeltasMap.size === 0) {
+    if (newDeltaValueMap.size === 0) {
+      if (!SUPPORTED_CACHED_DELTA_PERIODS.includes(period)) {
+        return;
+      }
+
+      // If has no gains in any metric, clear all deltas for this period and return early
       await prisma.cachedDelta.deleteMany({
         where: {
           playerId: player.id,
@@ -114,13 +113,37 @@ export const SyncPlayerDeltasJobHandler: JobHandler<Payload> = {
       return;
     }
 
-    // if any metric has improved since the last delta sync, it is a potential record
+    if (SUPPORTED_CACHED_DELTA_PERIODS.includes(period)) {
+      const newCachedDeltas = Array.from(newDeltaValueMap.entries()).map(([metric, value]) => ({
+        playerId: player.id,
+        period,
+        startedAt: startSnapshot.createdAt,
+        endedAt: latestSnapshot.createdAt,
+        updatedAt: new Date(),
+        metric,
+        value: prepareDecimalValue(metric, Math.min(value, 2147483647))
+      }));
+
+      await prisma.$transaction([
+        prisma.cachedDelta.deleteMany({
+          where: {
+            playerId: player.id,
+            period
+          }
+        }),
+        prisma.cachedDelta.createMany({
+          data: newCachedDeltas
+        })
+      ]);
+    }
+
+    // If any metric has improved since the last delta sync, it is a potential record
     // and we should also check for new records in this period
     const hasImprovements =
       previousDeltas.length !== 0 &&
       METRICS.some(metric => {
-        const previousValue = previousCachedDeltasMap.get(metric)?.value;
-        const newValue = newCachedDeltasMap.get(metric)?.value;
+        const previousValue = previousDeltaValueMap.get(metric);
+        const newValue = newDeltaValueMap.get(metric);
 
         if (newValue === undefined) {
           return false;
@@ -129,29 +152,12 @@ export const SyncPlayerDeltasJobHandler: JobHandler<Payload> = {
         return previousValue === undefined || newValue > previousValue;
       });
 
-    const newCachedDeltas = Array.from(newCachedDeltasMap.values());
-
-    await prisma.$transaction([
-      prisma.cachedDelta.deleteMany({
-        where: {
-          playerId: player.id,
-          period
-        }
-      }),
-      prisma.cachedDelta.createMany({
-        data: Array.from(newCachedDeltasMap.values()).map(c => ({
-          ...c,
-          value: prepareDecimalValue(c.metric, Math.min(c.value, 2147483647))
-        }))
-      })
-    ]);
-
     if (previousDeltas.length === 0 || hasImprovements) {
       context.jobManager.add(JobType.SYNC_PLAYER_RECORDS, {
         username,
         period,
         startSnapshotDate: startSnapshot.createdAt,
-        deltas: newCachedDeltas.map(c => pick(c, 'metric', 'value'))
+        deltas: Array.from(newDeltaValueMap.entries().map(([metric, value]) => ({ metric, value })))
       });
     }
   }

--- a/server/src/jobs/handlers/sync-player-records.job.ts
+++ b/server/src/jobs/handlers/sync-player-records.job.ts
@@ -10,10 +10,9 @@ interface Payload {
   username: string;
   period: Period;
 
-  // TODO: make required soon!
-  startSnapshotDate?: Date;
+  startSnapshotDate: Date;
 
-  deltas?: Array<{
+  deltas: Array<{
     metric: Metric;
     value: number;
   }>;
@@ -29,33 +28,31 @@ export const SyncPlayerRecordsJobHandler: JobHandler<Payload> = {
   },
 
   async execute(payload: Payload) {
-    const currentDeltas = await prisma.cachedDelta.findMany({
-      where: {
-        player: {
-          username: payload.username
-        },
-        period: payload.period
-      }
+    const player = await prisma.player.findFirst({
+      where: { username: payload.username },
+      select: { id: true }
     });
 
-    if (currentDeltas.length === 0) {
+    if (player === null) {
       return;
     }
 
-    const playerId = currentDeltas[0].playerId;
-
     const [currentRecords, previousSnapshot] = await Promise.all([
       prisma.record.findMany({
+        select: {
+          metric: true,
+          value: true
+        },
         where: {
-          playerId,
+          playerId: player.id,
           period: payload.period
         }
       }),
       prisma.snapshot.findFirst({
         select: selectRequiredSnapshotFields(METRICS), // Only select value fields, not ranks
         where: {
-          playerId,
-          createdAt: currentDeltas[0].startedAt
+          playerId: player.id,
+          createdAt: payload.startSnapshotDate
         }
       })
     ]);
@@ -64,7 +61,7 @@ export const SyncPlayerRecordsJobHandler: JobHandler<Payload> = {
       return;
     }
 
-    const currentDeltasMap = new Map(currentDeltas.map(d => [d.metric, d]));
+    const currentDeltasMap = new Map(payload.deltas.map(d => [d.metric, d]));
     const currentRecordsMap = new Map(currentRecords.map(r => [r.metric, r]));
 
     const toUpsert: { metric: Metric; value: number }[] = [];
@@ -106,7 +103,7 @@ export const SyncPlayerRecordsJobHandler: JobHandler<Payload> = {
 
     await prisma.$executeRaw`
       INSERT INTO public.records ("playerId", "period", "metric", "value", "updatedAt")
-      SELECT ${playerId}, ${payload.period}::period, r.metric, r.value, NOW()
+      SELECT ${player.id}, ${payload.period}::period, r.metric, r.value, NOW()
       FROM UNNEST(
         ${toUpsert.map(u => u.metric)}::metric[],
         ${toUpsert.map(u => u.value)}::bigint[]


### PR DESCRIPTION
Yearly cached deltas account for 63% of all storage and (most importantly) writes on the `CachedDelta` table, but because we don't expose leaderboards for year and 5min periods on the website, all those rows are pretty much never read.

This PR skips persisting those rows - we might want to revert this in the future if we do decide to add those periods to the website leaderboards, but if that does happen, we need to figure out a way to reduce Postgres churn, ideally it would all be HOT updates.