### PR TITLE
Updated EHP rates to match Hallowed Sepulchre changes

### DIFF
--- a/server/src/api/modules/efficiency/configs/ehp/main.ehp.ts
+++ b/server/src/api/modules/efficiency/configs/ehp/main.ehp.ts
@@ -579,12 +579,12 @@ export default [
         description: 'Hallowed Sepulchre'
       },
       {
-        startExp: 2_421_087,
+        startExp: 1_475_581,
         rate: 79_700,
         description: 'Hallowed Sepulchre'
       },
       {
-        startExp: 6_517_253,
+        startExp: 3_972_294,
         rate: 102_000,
         description: 'Hallowed Sepulchre with ancient & forgotten brews'
       }


### PR DESCRIPTION
Hallowed Sepulchre changed their requirements for floor 4 and 5. I'd assume that would lower the requirements for the EHP calculations. If I'm wrong or am using the wrong XP lemme know.

Floor 4 reqs changed to level 77
Floor 5 reqs changed to level 87